### PR TITLE
Fix CI: guard custom uo/chebi import rules with IMP=true

### DIFF
--- a/src/ontology/molsim.Makefile
+++ b/src/ontology/molsim.Makefile
@@ -3,6 +3,12 @@
 ## If you need to customize your Makefile, make
 ## changes here rather than in the main Makefile
 
+# Custom import modules. Guarded by IMP=true (like the standard rules in the main
+# Makefile) so that when imports are NOT being rebuilt (IMP=false, e.g. in CI/QC),
+# the committed imports/*_import.owl are treated as static files and do not require
+# the mirror/*.owl sources to be present. Only an actual import refresh (IMP=true,
+# MIR=true) needs the mirrors.
+ifeq ($(IMP),true)
 $(IMPORTDIR)/uo_import.owl: $(MIRRORDIR)/uo.owl
 	$(ROBOT) extract --input $< \
 		--method MIREOT \
@@ -14,6 +20,7 @@ $(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl
 		--method MIREOT \
 		--lower-terms $(IMPORTDIR)/chebi_terms.txt \
 		--output $@
+endif
 
 $(COMPONENTSDIR)/molsim_units_component.owl: $(SRC) templates/molsim_units_component.tsv
 	$(ROBOT) template --template templates/molsim_units_component.tsv \


### PR DESCRIPTION
## Fix
Restores green QC after PR #47 stopped tracking the `mirror/` build artifacts.

**Root cause:** the custom `uo_import.owl` and `chebi_import.owl` rules in `molsim.Makefile` declared `mirror/*.owl` as prerequisites but were **not** wrapped in `ifeq ($(IMP),true)`, unlike the standard import rules in the main Makefile. With the mirrors no longer committed, `make test IMP=false MIR=false` still evaluated those rules and failed:

```
make: *** No rule to make target 'mirror/uo.owl', needed by 'imports/uo_import.owl'.  Stop.
```

(`MIR=false` disables the rule that would fetch the mirror, so make has no way to produce it.)

**Fix:** wrap both custom rules in `ifeq ($(IMP),true) ... endif`. When imports are not being rebuilt (`IMP=false`, as in CI/QC), the committed `imports/*_import.owl` are now treated as static files — exactly how `ro`/`omo`/`iao` already behave. Mirrors are only needed for an actual import refresh (`IMP=true MIR=true`).

## Verification
With **all** `mirror/*.owl` removed to reproduce a fresh CI checkout:

```
make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=false MIR=false
...
Finished running all tests successfully.
```

Exit 0; ROBOT report ERROR 0; DL profile validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)