### PR TITLE
Align molsim-odk.yaml description with README + ontology header

### DIFF
--- a/src/ontology/molsim-odk.yaml
+++ b/src/ontology/molsim-odk.yaml
@@ -1,6 +1,6 @@
 id: molsim
 title: "Molecular Simulation Ontology"
-description: "Molsim is an interoperable domain ontology designed to semantically represent platform-agnostic molecular simulations as FAIR (Findable, Accessible, Interoperable, and Reusable) datasets. This ontology aims to standardize the representation of molecular simulation data, processes, and methodologies across different platforms and tools."
+description: "MOLSIM is a domain (application) ontology designed to semantically represent platform-agnostic biomolecular simulations (all-atom and coarse-grained) as FAIR (Findable, Accessible, Interoperable, and Reusable) datasets. As an application ontology, it reuses terms from established OBO ontologies where they fit and defines its own where they do not, aiming to standardize the representation of biomolecular simulation data, processes, and methodologies across platforms and tools."
 contact:  f.musyaffa [at] fz-juelich [.] de
 creators:
   - IBG-4, Forschungszentrum Jülich, Germany & Heinrich Heine University Dusseldorf, Germany


### PR DESCRIPTION
Update the ODK config description to the same wording: domain (application) ontology, biomolecular (all-atom and coarse-grained), reuse-and-map stance. Keeps the project description consistent across README, the dcterms:description header, and the config.