### PR TITLE
Add MDDB Group A1 + B + C terms

### DIFF
--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -16901,4 +16901,230 @@ SubClassOf(obo:MOLSIM_002205 obo:MOLSIM_002203)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:SO_0100003 "intrinsically disordered region"@en)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:SO_0100003 "IDR"@en)
 
+# Class: obo:MOLSIM_002206 (protein functional class label)
+
+Declaration(Class(obo:MOLSIM_002206))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002206 "protein functional class label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002206 "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002206 obo:MOLSIM_002162)
+
+# Class: obo:MOLSIM_002207 (enzyme classification label)
+
+Declaration(Class(obo:MOLSIM_002207))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002207 "enzyme classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002207 "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002207 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002208 (transport protein classification label)
+
+Declaration(Class(obo:MOLSIM_002208))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002208 "transport protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002208 "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002208 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002209 (structural protein classification label)
+
+Declaration(Class(obo:MOLSIM_002209))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002209 "structural protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002209 "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002209 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002210 (regulatory protein classification label)
+
+Declaration(Class(obo:MOLSIM_002210))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002210 "regulatory protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002210 "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002210 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002211 (signaling protein classification label)
+
+Declaration(Class(obo:MOLSIM_002211))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002211 "signaling protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002211 "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002211 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002212 (motor protein classification label)
+
+Declaration(Class(obo:MOLSIM_002212))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002212 "motor protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002212 "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002212 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002213 (immune protein classification label)
+
+Declaration(Class(obo:MOLSIM_002213))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002213 "immune protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002213 "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002213 obo:MOLSIM_002206)
+
+# Class: obo:MOLSIM_002214 (storage protein classification label)
+
+Declaration(Class(obo:MOLSIM_002214))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002214 "storage protein classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002214 "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002214 obo:MOLSIM_002206)
+
+# Data Property: obo:MOLSIM_002215 (protein atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002215))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002215 "protein atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002215 "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002215 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002215 xsd:integer)
+
+# Data Property: obo:MOLSIM_002216 (nucleic acid atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002216))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002216 "nucleic acid atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002216 "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002216 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002216 xsd:integer)
+
+# Data Property: obo:MOLSIM_002217 (lipid atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002217))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002217 "lipid atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002217 "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002217 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002217 xsd:integer)
+
+# Data Property: obo:MOLSIM_002218 (ion atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002218))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002218 "ion atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002218 "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002218 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002218 xsd:integer)
+
+# Data Property: obo:MOLSIM_002219 (solvent atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002219))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002219 "solvent atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002219 "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002219 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002219 xsd:integer)
+
+# Data Property: obo:MOLSIM_002220 (other atom count)
+
+Declaration(DataProperty(obo:MOLSIM_002220))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002220 "other atom count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002220 "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002220 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002220 xsd:integer)
+
+# Data Property: obo:MOLSIM_002221 (protein residue count)
+
+Declaration(DataProperty(obo:MOLSIM_002221))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002221 "protein residue count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002221 "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002221 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002221 xsd:integer)
+
+# Data Property: obo:MOLSIM_002222 (nucleic acid residue count)
+
+Declaration(DataProperty(obo:MOLSIM_002222))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002222 "nucleic acid residue count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002222 "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002222 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002222 xsd:integer)
+
+# Data Property: obo:MOLSIM_002223 (lipid residue count)
+
+Declaration(DataProperty(obo:MOLSIM_002223))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002223 "lipid residue count"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002223 "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002223 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002223 xsd:integer)
+
+# Data Property: obo:MOLSIM_002224 (number of nucleosomes)
+
+Declaration(DataProperty(obo:MOLSIM_002224))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002224 "number of nucleosomes"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002224 "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002224 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002224 xsd:integer)
+
+# Data Property: obo:MOLSIM_002225 (number of nucleotides per DNA strand)
+
+Declaration(DataProperty(obo:MOLSIM_002225))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002225 "number of nucleotides per DNA strand"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002225 "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002225 obo:MOLSIM_001121)
+DataPropertyRange(obo:MOLSIM_002225 xsd:integer)
+
+# Class: obo:MOLSIM_002226 (periodic box angles)
+
+Declaration(Class(obo:MOLSIM_002226))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002226 "periodic box angles"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002226 "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002226 obo:MOLSIM_001210)
+
+# Data Property: obo:MOLSIM_002227 (box angles array)
+
+Declaration(DataProperty(obo:MOLSIM_002227))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002227 "box angles array"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002227 "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002227 obo:MOLSIM_002140)
+DataPropertyRange(obo:MOLSIM_002227 xsd:string)
+
+# Data Property: obo:MOLSIM_002228 (has positions flag)
+
+Declaration(DataProperty(obo:MOLSIM_002228))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002228 "has positions flag"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002228 "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002228 obo:MOLSIM_001156)
+DataPropertyRange(obo:MOLSIM_002228 xsd:boolean)
+
+# Data Property: obo:MOLSIM_002229 (has forces flag)
+
+Declaration(DataProperty(obo:MOLSIM_002229))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002229 "has forces flag"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002229 "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002229 obo:MOLSIM_001156)
+DataPropertyRange(obo:MOLSIM_002229 xsd:boolean)
+
+# Class: obo:MOLSIM_002230 (SMILES code)
+
+Declaration(Class(obo:MOLSIM_002230))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002230 "SMILES code"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002230 "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002230 obo:MOLSIM_000447)
+
+# Data Property: obo:MOLSIM_002231 (software version)
+
+Declaration(DataProperty(obo:MOLSIM_002231))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002231 "software version"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002231 "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubDataPropertyOf(obo:MOLSIM_002231 owl:topDataProperty)
+DataPropertyDomain(obo:MOLSIM_002231 obo:MOLSIM_000001)
+DataPropertyRange(obo:MOLSIM_002231 xsd:string)
+
+# Class: obo:MOLSIM_002232 (compiler)
+
+Declaration(Class(obo:MOLSIM_002232))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002232 "compiler"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002232 "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002232 obo:MOLSIM_000171)
+
+# Class: obo:MOLSIM_002233 (atom index group)
+
+Declaration(Class(obo:MOLSIM_002233))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002233 "atom index group"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002233 "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002233 obo:MOLSIM_000310)
+
+# Class: obo:MOLSIM_002234 (classical molecular dynamics)
+
+Declaration(Class(obo:MOLSIM_002234))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002234 "classical molecular dynamics"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002234 "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002234 obo:MOLSIM_000843)
+
+# Class: obo:MOLSIM_002235 (source structure residue mapping)
+
+Declaration(Class(obo:MOLSIM_002235))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002235 "source structure residue mapping"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002235 "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002235 obo:MOLSIM_001072)
+
 )


### PR DESCRIPTION
Added new classes and definitions:

A1: 9 protein functional-class labels; 
B: 11 per-species composition-count data properties; 
C: 10 technical fields. 

All (NEWLY_ADDED)(UNVERIFIED), QC green.
