### PR TITLE
Add MDDB strain/histone variant labels

### DIFF
--- a/src/ontology/mappings/molsim.sssom.tsv
+++ b/src/ontology/mappings/molsim.sssom.tsv
@@ -1,0 +1,12 @@
+# curie_map:
+#   MOLSIM: http://purl.obolibrary.org/obo/MOLSIM_
+#   EDAM: http://edamontology.org/
+#   skos: http://www.w3.org/2004/02/skos/core#
+#   semapv: https://w3id.org/semapv/vocab/
+#   orcid: https://orcid.org/
+# mapping_set_id: http://purl.obolibrary.org/obo/molsim/mappings/molsim.sssom.tsv
+# mapping_set_title: MOLSIM cross-ontology mappings
+# mapping_provider: https://github.com/CPCLab/molsim-ontology
+# license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	confidence	creator_id	comment
+MOLSIM:002230	SMILES code	skos:closeMatch	EDAM:format_1196	SMILES	semapv:ManualMappingCuration	0.9	orcid:0000-0003-4846-8051	MOLSIM 'SMILES code' (an identifier that encodes a molecular structure) corresponds to the EDAM 'SMILES' format concept; closeMatch rather than exactMatch because MOLSIM models it as an identifier and EDAM as a data format.

--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -17211,4 +17211,18 @@ AnnotationAssertion(rdfs:label obo:MOLSIM_002246 "spike opening conformational s
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002246 "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)"@en)
 SubClassOf(obo:MOLSIM_002246 obo:MOLSIM_000105)
 
+# Class: obo:MOLSIM_002247 (biological strain classification label)
+
+Declaration(Class(obo:MOLSIM_002247))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002247 "biological strain classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002247 "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002247 obo:MOLSIM_002162)
+
+# Class: obo:MOLSIM_002248 (histone variant classification label)
+
+Declaration(Class(obo:MOLSIM_002248))
+AnnotationAssertion(rdfs:label obo:MOLSIM_002248 "histone variant classification label"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002248 "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)"@en)
+SubClassOf(obo:MOLSIM_002248 obo:MOLSIM_002162)
+
 )


### PR DESCRIPTION
Add MDDB strain + histone-variant labels (002247–002248); SMILES→EDAM SSSOM 

mapping biological strain classification label + histone variant classification label under system classification label; first curated SSSOM mapping (SMILES code → EDAM:format_1196).