### PR TITLE
Reuse SO nucleic-acid modification terms (A5) via SO import

### DIFF
--- a/src/ontology/imports/so_import.owl
+++ b/src/ontology/imports/so_import.owl
@@ -33,6 +33,22 @@
     
 
 
+    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by">
+        <rdfs:label>created by</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#creation_date -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date">
+        <rdfs:label>creation date</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId">
@@ -178,6 +194,99 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/SO_0000114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000306"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001963"/>
+        <obo:IAO_0000115>A methylated deoxy-cytosine.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>methylated C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated cytosine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated cytosine base</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated cytosine residue</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated_C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0000114</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:label>methylated_cytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000114"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A methylated deoxy-cytosine.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000161 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000306"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001962"/>
+        <obo:IAO_0000115>A modified base in which adenine has been methylated.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>methylated A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated adenine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated adenine base</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated adenine residue</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>methylated_A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0000161</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:label>methylated_adenine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000161"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified base in which adenine has been methylated.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001236"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001720"/>
+        <obo:IAO_0000115>A modified nucleotide, i.e. a nucleotide other than A, T, C. G.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>INSDC_feature:modified_base</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>modified base site</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0000305</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:comment>Modified base:&lt;modified_base&gt;.</rdfs:comment>
+        <rdfs:label>modified_DNA_base</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000305"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified nucleotide, i.e. a nucleotide other than A, T, C. G.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>http://www.insdc.org/files/feature_table.html</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000306 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000306">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000305"/>
+        <obo:IAO_0000115>A nucleotide modified by methylation.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>methylated base feature</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0000306</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:label>methylated_DNA_base_feature</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000306"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A nucleotide modified by methylation.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/SO_0000417 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000417">
@@ -199,6 +308,12 @@
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget>polypeptide_structural_domain</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>A structurally or functionally defined protein region. In proteins with multiple domains, the combination of the domains determines the function of the protein. A region which has been shown to recur throughout evolution.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
@@ -216,11 +331,26 @@
         <owl:annotatedTarget>structural domain</owl:annotatedTarget>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
     </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0000831 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000831">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
+        <obo:IAO_0000115>A region of a gene.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>gene member region</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0000831</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:comment>A manufactured term used to allow the parts of a gene to have an is_a path to the root.</rdfs:comment>
+        <rdfs:label>gene_member_region</rdfs:label>
+    </owl:Class>
     <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
-        <owl:annotatedTarget>polypeptide_structural_domain</owl:annotatedTarget>
-        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0000831"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A region of a gene.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -290,6 +420,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/SO_0001236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
+        <obo:IAO_0000115>A base is a sequence feature that corresponds to a single unit of a nucleotide polymer.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Nucleobase</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001236</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:label>base</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001236"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A base is a sequence feature that corresponds to a single unit of a nucleotide polymer.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001236"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Nucleobase</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/SO_0001411 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001411">
@@ -308,6 +464,222 @@
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>A region defined by its disposition to be involved in a biological process.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>SO:cb</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001720 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001720">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0005836"/>
+        <obo:IAO_0000115>A biological DNA region implicated in epigenomic changes caused by mechanisms other than changes in the underlying DNA sequence. This includes, nucleosomal histone post-translational modifications, nucleosome depletion to render DNA accessible and post-replicational base modifications such as cytosine modification.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2010-03-27T12:02:29Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>epigenetically modified region</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001720</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:comment>Moved from is_a biological_region (SO:0001411) to is_a regulatory_region (SO:0005836) on 11 Feb 2021. GREEKC members pointed out that this would be a more appropriate location. See GitHub Issue #530. 11 Feb 2021 updated definition along with addition of epigenomically_modified_region (SO:0002332). Epigenetically modified region is now not inherited while epigenomically modified region is not annotated as inherited. See GitHub Issue #532 and issue #534.</rdfs:comment>
+        <rdfs:label>epigenetically_modified_region</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001720"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A biological DNA region implicated in epigenomic changes caused by mechanisms other than changes in the underlying DNA sequence. This includes, nucleosomal histone post-translational modifications, nucleosome depletion to render DNA accessible and post-replicational base modifications such as cytosine modification.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Epigenetics</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001918 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001918">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000114"/>
+        <obo:IAO_0000115>A cytosine methylated at the 5 carbon.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2012-10-17T12:46:10Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref>http://www.insdc.org/files/feature_table.html#7.4.2</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>http:http://www.pacificbiosciences.com/pdf/WP_Detecting_DNA_Base_Modifications_Using_SMRT_Sequencing.pdf</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>5 methylcytosine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>5-mC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>m-5C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>m5c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001918</oboInOwl:id>
+        <rdfs:label>5_methylcytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001918"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A cytosine methylated at the 5 carbon.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:rtapella</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001920 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001920">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000161"/>
+        <obo:IAO_0000115>An adenine methylated at the 6 nitrogen.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2012-10-17T12:54:23Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref>http:http://www.pacificbiosciences.com/pdf/WP_Detecting_DNA_Base_Modifications_Using_SMRT_Sequencing.pdf</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>6-mA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>6-methyladenine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>6mA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>N6-methyladenine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>m-6A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>m6a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001920</oboInOwl:id>
+        <rdfs:label>N6_methyladenine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001920"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>An adenine methylated at the 6 nitrogen.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:rtapella</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001960 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001960">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000114"/>
+        <obo:IAO_0000115>A modified DNA cytosine base feature, modified by a hydroxymethyl group at the 5 carbon.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2013-05-17T05:05:31Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref>http:http://www.pacificbiosciences.com/pdf/WP_Detecting_DNA_Base_Modifications_Using_SMRT_Sequencing.pdf</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>5-hmC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>5-hydroxymethylcytosine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001960</oboInOwl:id>
+        <rdfs:label>5_hydroxymethylcytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001960"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified DNA cytosine base feature, modified by a hydroxymethyl group at the 5 carbon.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001961 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001961">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001963"/>
+        <obo:IAO_0000115>A modified DNA cytosine base feature, modified by a formyl group at the 5 carbon.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2013-05-17T05:06:13Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref>http:http://www.pacificbiosciences.com/pdf/WP_Detecting_DNA_Base_Modifications_Using_SMRT_Sequencing.pdf</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>5-fC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>5-formylcytosine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001961</oboInOwl:id>
+        <rdfs:label>5_formylcytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001961"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified DNA cytosine base feature, modified by a formyl group at the 5 carbon.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001962 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001962">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000305"/>
+        <obo:IAO_0000115>A modified adenine DNA base feature.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2013-05-20T01:22:30Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001962</oboInOwl:id>
+        <rdfs:label>modified_adenine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001962"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified adenine DNA base feature.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001963 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001963">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000305"/>
+        <obo:IAO_0000115>A modified cytosine DNA base feature.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2013-05-20T01:23:47Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001963</oboInOwl:id>
+        <rdfs:label>modified_cytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001963"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified cytosine DNA base feature.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001966 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001966">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001963"/>
+        <obo:IAO_0000115>A modified DNA cytosine base feature, modified by a carboxy group at the 5 carbon.</obo:IAO_0000115>
+        <oboInOwl:created_by>kareneilbeck</oboInOwl:created_by>
+        <oboInOwl:creation_date>2013-05-20T01:30:01Z</oboInOwl:creation_date>
+        <oboInOwl:hasDbXref>http:http://www.pacificbiosciences.com/pdf/WP_Detecting_DNA_Base_Modifications_Using_SMRT_Sequencing.pdf</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>5-caC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>5-carboxycytosine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001966</oboInOwl:id>
+        <rdfs:label>5_carboxylcytosine</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001966"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A modified DNA cytosine base feature, modified by a carboxy group at the 5 carbon.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0005836 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0005836">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000831"/>
+        <obo:IAO_0000115>A region of sequence that is involved in the control of a biological process.</obo:IAO_0000115>
+        <oboInOwl:hasBroadSynonym>INSDC_feature:regulatory</oboInOwl:hasBroadSynonym>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Regulatory_region</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>INSDC_qualifier:other</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>regulatory region</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0005836</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#SOFA"/>
+        <rdfs:label>regulatory_region</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0005836"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A region of sequence that is involved in the control of a biological process.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>SO:ke</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0005836"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Regulatory_region</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
     </owl:Axiom>
     
 

--- a/src/ontology/imports/so_terms.txt
+++ b/src/ontology/imports/so_terms.txt
@@ -1,2 +1,8 @@
 SO:0000417 # polypeptide_domain (parent of MOLSIM:002203 protein domain)
 SO:0100003 # intrinsically_unstructured_polypeptide_region (reused as intrinsically disordered region)
+SO:0000305 # modified_DNA_base (umbrella for MDDB nucleic-acid modifications)
+SO:0001918 # 5_methylcytosine (MDDB 5-mC)
+SO:0001960 # 5_hydroxymethylcytosine (MDDB 5-hmC)
+SO:0001961 # 5_formylcytosine (MDDB 5-fC)
+SO:0001966 # 5_carboxylcytosine (MDDB 5-caC)
+SO:0001920 # N6_methyladenine (MDDB 6-mA)


### PR DESCRIPTION
Add SO:0000305 modified_DNA_base + 5mC/5hmC/5fC/5caC/6mA (SO:0001918/0001960/0001961/0001966/0001920) to so_terms.txt; rebuild so_import.owl. No minting.
