### PR TITLE
Re-cut release 2026-07-24 to include domain-hierarchy bridges

### DIFF
--- a/molsim-full.json
+++ b/molsim-full.json
@@ -48308,6 +48308,10 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
       "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000006"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
+      "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0001236"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
@@ -48333,6 +48337,10 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0000839",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0001411"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002090"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
       "pred" : "is_a",

--- a/molsim-full.obo
+++ b/molsim-full.obo
@@ -17347,6 +17347,7 @@ comment: Modified base:<modified_base>.
 subset: SOFA
 synonym: "INSDC_feature:modified_base" EXACT []
 synonym: "modified base site" EXACT []
+is_a: MOLSIM:000006 ! model
 is_a: SO:0001236 ! base
 is_a: SO:0001720 ! epigenetically_modified_region
 
@@ -17413,6 +17414,7 @@ comment: Range.
 subset: biosapiens
 synonym: "polypeptide structural region" EXACT []
 synonym: "structural_region" RELATED []
+is_a: MOLSIM:002090 ! molecular entity
 is_a: SO:0000839 ! polypeptide_region
 
 [Term]

--- a/molsim-full.owl
+++ b/molsim-full.owl
@@ -37448,6 +37448,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/SO_0000305 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001236"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001720"/>
         <obo:IAO_0000115>A modified nucleotide, i.e. a nucleotide other than A, T, C. G.</obo:IAO_0000115>
@@ -37600,6 +37601,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/SO_0001070 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001070">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002090"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000839"/>
         <obo:IAO_0000115>Region of polypeptide with a given structural property.</obo:IAO_0000115>
         <oboInOwl:hasAlternativeId>BS:00337</oboInOwl:hasAlternativeId>

--- a/molsim.json
+++ b/molsim.json
@@ -48308,6 +48308,10 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
       "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000006"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
+      "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0001236"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0000305",
@@ -48333,6 +48337,10 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0000839",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0001411"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002090"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
       "pred" : "is_a",

--- a/molsim.obo
+++ b/molsim.obo
@@ -17347,6 +17347,7 @@ comment: Modified base:<modified_base>.
 subset: SOFA
 synonym: "INSDC_feature:modified_base" EXACT []
 synonym: "modified base site" EXACT []
+is_a: MOLSIM:000006 ! model
 is_a: SO:0001236 ! base
 is_a: SO:0001720 ! epigenetically_modified_region
 
@@ -17413,6 +17414,7 @@ comment: Range.
 subset: biosapiens
 synonym: "polypeptide structural region" EXACT []
 synonym: "structural_region" RELATED []
+is_a: MOLSIM:002090 ! molecular entity
 is_a: SO:0000839 ! polypeptide_region
 
 [Term]

--- a/molsim.owl
+++ b/molsim.owl
@@ -37448,6 +37448,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/SO_0000305 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001236"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001720"/>
         <obo:IAO_0000115>A modified nucleotide, i.e. a nucleotide other than A, T, C. G.</obo:IAO_0000115>
@@ -37600,6 +37601,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/SO_0001070 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001070">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002090"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000839"/>
         <obo:IAO_0000115>Region of polypeptide with a given structural property.</obo:IAO_0000115>
         <oboInOwl:hasAlternativeId>BS:00337</oboInOwl:hasAlternativeId>


### PR DESCRIPTION
Regenerate release artifacts from main (4cfd8d0) so the SO/GO bridge axioms from PR #59 are included; the previous release predated them. molsim-base.* unchanged (external axioms are stripped from the base variant by design).
