### PR TITLE
Definition repairs and OBO-compliant term deprecation

### DIFF
--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -7266,7 +7266,6 @@ SubClassOf(obo:MOLSIM_000678 obo:MOLSIM_000328)
 AnnotationAssertion(owl:deprecated obo:MOLSIM_000679 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000679 "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000679 "obsolete image bond fixing analysis"@en)
-SubClassOf(obo:MOLSIM_000679 obo:MOLSIM_000659)
 
 # Class: obo:MOLSIM_000680 (atom selection analysis)
 
@@ -8627,7 +8626,6 @@ SubClassOf(obo:MOLSIM_000904 obo:MOLSIM_001073)
 AnnotationAssertion(owl:deprecated obo:MOLSIM_000905 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000905 "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000905 "obsolete small molecule structure"@en)
-SubClassOf(obo:MOLSIM_000905 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_000906 (mol2 format)
 
@@ -9504,7 +9502,6 @@ SubClassOf(obo:MOLSIM_001086 obo:MOLSIM_001091)
 AnnotationAssertion(owl:deprecated obo:MOLSIM_001087 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001087 "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001087 "obsolete macromolecular structure format"@en)
-SubClassOf(obo:MOLSIM_001087 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_001088 (molecular structure format)
 
@@ -9518,7 +9515,6 @@ SubClassOf(obo:MOLSIM_001088 obo:MOLSIM_001085)
 AnnotationAssertion(owl:deprecated obo:MOLSIM_001089 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001089 "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001089 "obsolete software-specific coordinate format"@en)
-SubClassOf(obo:MOLSIM_001089 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_001090 (molecular trajectory format)
 
@@ -13383,7 +13379,6 @@ AnnotationAssertion(owl:deprecated obo:MOLSIM_001747 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001747 "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations."@en)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001747 "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21")
 AnnotationAssertion(rdfs:label obo:MOLSIM_001747 "obsolete trajectory analysis algorithm"@en)
-SubClassOf(obo:MOLSIM_001747 obo:MOLSIM_000037)
 
 # Class: obo:MOLSIM_001748 (toroidal-view-preserving algorithm)
 
@@ -13459,7 +13454,6 @@ AnnotationAssertion(owl:deprecated obo:MOLSIM_001759 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001759 "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model."@en)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001759 "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001759 "obsolete Miller indices"@en)
-SubClassOf(obo:MOLSIM_001759 obo:MOLSIM_000447)
 
 # Class: obo:MOLSIM_001760 (residue type)
 
@@ -16738,7 +16732,7 @@ DisjointClasses(obo:MOLSIM_000866 obo:MOLSIM_000868 obo:MOLSIM_000869 obo:MOLSIM
 # simulation log format (MOLSIM_000439) — 17 children
 DisjointClasses(obo:MOLSIM_000470 obo:MOLSIM_000593 obo:MOLSIM_000599 obo:MOLSIM_000600 obo:MOLSIM_000601 obo:MOLSIM_000879 obo:MOLSIM_000881 obo:MOLSIM_000882 obo:MOLSIM_000883 obo:MOLSIM_000884 obo:MOLSIM_000885 obo:MOLSIM_000886 obo:MOLSIM_000887 obo:MOLSIM_000888 obo:MOLSIM_000889 obo:MOLSIM_001118 obo:MOLSIM_002036)
 # molecular structure format (MOLSIM_001088) — 27 children
-DisjointClasses(obo:MOLSIM_000025 obo:MOLSIM_000319 obo:MOLSIM_000445 obo:MOLSIM_000446 obo:MOLSIM_000473 obo:MOLSIM_000872 obo:MOLSIM_000874 obo:MOLSIM_000875 obo:MOLSIM_000895 obo:MOLSIM_000896 obo:MOLSIM_000897 obo:MOLSIM_000905 obo:MOLSIM_000906 obo:MOLSIM_000907 obo:MOLSIM_000921 obo:MOLSIM_001037 obo:MOLSIM_001044 obo:MOLSIM_001059 obo:MOLSIM_001062 obo:MOLSIM_001087 obo:MOLSIM_001089 obo:MOLSIM_001094 obo:MOLSIM_001095 obo:MOLSIM_001096 obo:MOLSIM_001105 obo:MOLSIM_002058 obo:MOLSIM_002062)
+DisjointClasses(obo:MOLSIM_000025 obo:MOLSIM_000319 obo:MOLSIM_000445 obo:MOLSIM_000446 obo:MOLSIM_000473 obo:MOLSIM_000872 obo:MOLSIM_000874 obo:MOLSIM_000875 obo:MOLSIM_000895 obo:MOLSIM_000896 obo:MOLSIM_000897 obo:MOLSIM_000906 obo:MOLSIM_000907 obo:MOLSIM_000921 obo:MOLSIM_001037 obo:MOLSIM_001044 obo:MOLSIM_001059 obo:MOLSIM_001062 obo:MOLSIM_001094 obo:MOLSIM_001095 obo:MOLSIM_001096 obo:MOLSIM_001105 obo:MOLSIM_002058 obo:MOLSIM_002062)
 # molecular dynamics engine (MOLSIM_000160) — 14 children
 DisjointClasses(obo:MOLSIM_000777 obo:MOLSIM_000784 obo:MOLSIM_000786 obo:MOLSIM_000790 obo:MOLSIM_001568 obo:MOLSIM_001599 obo:MOLSIM_001669 obo:MOLSIM_001670 obo:MOLSIM_001675 obo:MOLSIM_001683 obo:MOLSIM_001929 obo:MOLSIM_001935 obo:MOLSIM_002043 obo:MOLSIM_002064)
 # quantum chemistry engine (MOLSIM_000161) — 28 children
@@ -16812,7 +16806,7 @@ DisjointClasses(obo:MOLSIM_000812 obo:MOLSIM_000813 obo:MOLSIM_000814)
 # ==== disjointness batch 3 (algorithms / hardware / models) ====
 # --- algorithms ---
 # algorithm (MOLSIM_000037) — 14 children
-DisjointClasses(obo:MOLSIM_000049 obo:MOLSIM_000074 obo:MOLSIM_000087 obo:MOLSIM_000253 obo:MOLSIM_000382 obo:MOLSIM_000407 obo:MOLSIM_001688 obo:MOLSIM_001694 obo:MOLSIM_001696 obo:MOLSIM_001700 obo:MOLSIM_001728 obo:MOLSIM_001740 obo:MOLSIM_001747 obo:MOLSIM_001986)
+DisjointClasses(obo:MOLSIM_000049 obo:MOLSIM_000074 obo:MOLSIM_000087 obo:MOLSIM_000253 obo:MOLSIM_000382 obo:MOLSIM_000407 obo:MOLSIM_001688 obo:MOLSIM_001694 obo:MOLSIM_001696 obo:MOLSIM_001700 obo:MOLSIM_001728 obo:MOLSIM_001740 obo:MOLSIM_001986)
 # electrostatic interaction algorithm (MOLSIM_000053) — 6 children
 DisjointClasses(obo:MOLSIM_000055 obo:MOLSIM_000056 obo:MOLSIM_000390 obo:MOLSIM_000392 obo:MOLSIM_000428 obo:MOLSIM_000429)
 # similarity calculation algorithm (MOLSIM_000074) — 7 children

--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -4835,7 +4835,7 @@ SubClassOf(obo:MOLSIM_000293 obo:MOLSIM_000286)
 
 # Class: obo:MOLSIM_000294 (conveyor belt thermodynamic integration)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000294 "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000294 "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)"@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000294 "CBTI"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000294 "conveyor belt thermodynamic integration"@en)
 SubClassOf(obo:MOLSIM_000294 obo:MOLSIM_000286)
@@ -4861,7 +4861,7 @@ SubClassOf(obo:MOLSIM_000298 obo:MOLSIM_000355)
 
 # Class: obo:MOLSIM_000299 (thermodynamic integration with linear extrapolation)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000299 "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (...) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000299 "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000299 "thermodynamic integration with linear extrapolation"@en)
 SubClassOf(obo:MOLSIM_000299 obo:MOLSIM_000298)
 DisjointClasses(obo:MOLSIM_000299 obo:MOLSIM_000356)
@@ -6230,7 +6230,7 @@ SubClassOf(obo:MOLSIM_000513 obo:MOLSIM_000485)
 
 # Class: obo:MOLSIM_000514 (LANL2-[6s4p4d2f])
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000514 "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (...) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000514 "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000514 "LANL2-[6s4p4d2f]"@en)
 SubClassOf(obo:MOLSIM_000514 obo:MOLSIM_000485)
 
@@ -6248,7 +6248,7 @@ SubClassOf(obo:MOLSIM_000516 obo:MOLSIM_000485)
 
 # Class: obo:MOLSIM_000517 (LANL2DZ+2s2p2d2f)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000517 "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes.(...) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000517 "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000517 "LANL2DZ+2s2p2d2f"@en)
 SubClassOf(obo:MOLSIM_000517 obo:MOLSIM_000485)
 
@@ -6608,7 +6608,7 @@ SubClassOf(obo:MOLSIM_000576 obo:MOLSIM_000485)
 
 # Class: obo:MOLSIM_000577 (Ahlrichs pvDZ)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000577 "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (...) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000577 "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000577 "Ahlrichs pvDZ"@en)
 SubClassOf(obo:MOLSIM_000577 obo:MOLSIM_000485)
 
@@ -7263,8 +7263,9 @@ SubClassOf(obo:MOLSIM_000678 obo:MOLSIM_000328)
 
 # Class: obo:MOLSIM_000679 (image bond fixing analysis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000679 "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (DEPRECATED) (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_000679 "image bond fixing analysis"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_000679 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000679 "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_000679 "obsolete image bond fixing analysis"@en)
 SubClassOf(obo:MOLSIM_000679 obo:MOLSIM_000659)
 
 # Class: obo:MOLSIM_000680 (atom selection analysis)
@@ -8623,8 +8624,9 @@ SubClassOf(obo:MOLSIM_000904 obo:MOLSIM_001073)
 
 # Class: obo:MOLSIM_000905 (small molecule structure (deprecated))
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000905 "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_000905 "small molecule structure (deprecated)"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_000905 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000905 "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_000905 "obsolete small molecule structure"@en)
 SubClassOf(obo:MOLSIM_000905 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_000906 (mol2 format)
@@ -9499,8 +9501,9 @@ SubClassOf(obo:MOLSIM_001086 obo:MOLSIM_001091)
 
 # Class: obo:MOLSIM_001087 (macromolecular structure format (deprecated))
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001087 "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_001087 "macromolecular structure format (deprecated)"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_001087 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001087 "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_001087 "obsolete macromolecular structure format"@en)
 SubClassOf(obo:MOLSIM_001087 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_001088 (molecular structure format)
@@ -9512,8 +9515,9 @@ SubClassOf(obo:MOLSIM_001088 obo:MOLSIM_001085)
 
 # Class: obo:MOLSIM_001089 (software-specific coordinate format (deprecated))
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001089 "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_001089 "software-specific coordinate format (deprecated)"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_001089 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001089 "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_001089 "obsolete software-specific coordinate format"@en)
 SubClassOf(obo:MOLSIM_001089 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_001090 (molecular trajectory format)
@@ -12873,7 +12877,7 @@ SubClassOf(obo:MOLSIM_001665 obo:MOLSIM_001664)
 
 # Class: obo:MOLSIM_001666 (metatwist)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001666 "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001666 "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001666 "metatwist"@en)
 SubClassOf(obo:MOLSIM_001666 obo:MOLSIM_001960)
 
@@ -13375,9 +13379,10 @@ SubClassOf(obo:MOLSIM_001746 obo:MOLSIM_001745)
 
 # Class: obo:MOLSIM_001747 (trajectory analysis algorithm (deprecated))
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001747 "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_001747 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001747 "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations."@en)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001747 "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21")
-AnnotationAssertion(rdfs:label obo:MOLSIM_001747 "trajectory analysis algorithm (deprecated)"@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_001747 "obsolete trajectory analysis algorithm"@en)
 SubClassOf(obo:MOLSIM_001747 obo:MOLSIM_000037)
 
 # Class: obo:MOLSIM_001748 (toroidal-view-preserving algorithm)
@@ -13450,9 +13455,10 @@ SubClassOf(obo:MOLSIM_001758 obo:MOLSIM_001711)
 
 # Class: obo:MOLSIM_001759 (Miller indices (deprecated))
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001759 "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)"@en)
+AnnotationAssertion(owl:deprecated obo:MOLSIM_001759 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001759 "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model."@en)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001759 "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_001759 "Miller indices (deprecated)"@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_001759 "obsolete Miller indices"@en)
 SubClassOf(obo:MOLSIM_001759 obo:MOLSIM_000447)
 
 # Class: obo:MOLSIM_001760 (residue type)

--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -2223,6 +2223,7 @@ Declaration(AnnotationProperty(<http://protege.stanford.edu/plugins/owl/protege#
 Declaration(AnnotationProperty(obo:IAO_0000115))
 Declaration(AnnotationProperty(obo:IAO_0000117))
 Declaration(AnnotationProperty(obo:IAO_0000119))
+Declaration(AnnotationProperty(obo:IAO_0100001))
 Declaration(AnnotationProperty(dcterms:BibliographicResource))
 Declaration(AnnotationProperty(dcterms:contributor))
 Declaration(AnnotationProperty(dcterms:creator))
@@ -3893,7 +3894,7 @@ SubClassOf(obo:MOLSIM_000147 obo:MOLSIM_000143)
 
 # Class: obo:MOLSIM_000148 (experimental data availability)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000148 "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000148 "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000148 "experimental data availability"@en)
 AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000148 orcid:0000-0002-2294-5393)
 SubClassOf(obo:MOLSIM_000148 obo:MOLSIM_000143)
@@ -6754,7 +6755,7 @@ SubClassOf(obo:MOLSIM_000599 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_000600 (AMBER eigenvector format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000600 "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000600 "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)"@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000600 "evecs.dat"@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000600 "evecs.out"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000600 "AMBER eigenvector format"@en)
@@ -15969,7 +15970,7 @@ ClassAssertion(obo:MOLSIM_000696 obo:MOLSIM_000920)
 
 # Individual: obo:MOLSIM_000922 (NCBI RefSeq Nucleotide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000922 "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000922 "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000922 "NCBI RefSeq Nucleotide"@en)
 ClassAssertion(obo:MOLSIM_000697 obo:MOLSIM_000922)
 
@@ -16271,6 +16272,8 @@ ClassAssertion(obo:MOLSIM_001522 obo:MOLSIM_001532)
 # Individual: obo:MOLSIM_001945 (obsolete Omni-Path)
 
 AnnotationAssertion(owl:deprecated obo:MOLSIM_001945 "true"^^xsd:boolean)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001945 "OBSOLETE. A redundant untyped individual that duplicated the class 'omni-path' (MOLSIM:001949). It should not be used; use that class instead."@en)
+AnnotationAssertion(obo:IAO_0100001 obo:MOLSIM_001945 obo:MOLSIM_001949)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001945 "Obsoleted: redundant untyped individual duplicating the class 'omni-path' (MOLSIM_001949), which is the concept to use instead."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001945 "obsolete Omni-Path"@en)
 


### PR DESCRIPTION
14fe3cd — truncated + missing definitions (ontology now has 100% definition coverage)
d78b458 — deprecation normalised across 7 terms
14c7784 — obsolete terms detached from the hierarchy