### PR TITLE
Re-cut alpha release 2026-07-29

### DIFF
--- a/molsim-base.json
+++ b/molsim-base.json
@@ -36,13 +36,19 @@
         "pred" : "http://www.geneontology.org/formats/oboInOwl#default-namespace",
         "val" : "molsim"
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification."
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-24"
+        "val" : "2026-07-29"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim-base.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-base.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000000",
@@ -105,7 +111,8 @@
       "meta" : {
         "definition" : {
           "val" : "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000007",
@@ -443,7 +450,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis."
+          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -452,7 +459,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)"
         }
       }
     }, {
@@ -461,7 +468,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -470,7 +477,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)."
+          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)"
         }
       }
     }, {
@@ -479,7 +486,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)."
+          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)"
         }
       }
     }, {
@@ -488,7 +495,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)."
+          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -497,7 +504,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)."
+          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)"
         }
       }
     }, {
@@ -506,7 +513,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)."
+          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -528,7 +535,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)."
+          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -537,7 +544,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)."
+          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -546,7 +553,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)."
+          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -559,7 +566,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -568,7 +575,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)."
+          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)"
         }
       }
     }, {
@@ -577,7 +584,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)."
+          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)"
         }
       }
     }, {
@@ -586,7 +593,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)."
+          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -602,7 +609,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)."
+          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)"
         }
       }
     }, {
@@ -611,7 +618,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)."
+          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -624,7 +631,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)."
+          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -637,7 +644,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)."
+          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -814,7 +821,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)."
+          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -823,7 +830,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)."
+          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -832,7 +839,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules."
+          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -841,7 +848,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)."
+          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)"
         }
       }
     }, {
@@ -850,7 +857,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)."
+          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)"
         }
       }
     }, {
@@ -877,7 +884,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)."
+          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)"
         }
       }
     }, {
@@ -886,7 +893,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)."
+          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)"
         }
       }
     }, {
@@ -895,7 +902,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)."
+          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)"
         }
       }
     }, {
@@ -904,7 +911,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities."
+          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)"
         }
       }
     }, {
@@ -913,7 +920,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule."
+          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)"
         }
       }
     }, {
@@ -922,7 +929,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)."
+          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)"
         }
       }
     }, {
@@ -931,7 +938,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)."
+          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)"
         }
       }
     }, {
@@ -940,7 +947,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)."
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
         }
       }
     }, {
@@ -949,7 +956,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)."
+          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)"
         }
       }
     }, {
@@ -958,7 +965,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)."
+          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)"
         }
       }
     }, {
@@ -967,7 +974,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)."
+          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -980,7 +987,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)."
+          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)"
         }
       }
     }, {
@@ -989,7 +996,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)."
+          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)"
         }
       }
     }, {
@@ -998,7 +1005,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)"
         }
       }
     }, {
@@ -1007,7 +1014,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)"
         }
       }
     }, {
@@ -1016,7 +1023,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)."
+          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)"
         }
       }
     }, {
@@ -1191,21 +1198,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "lbl" : "correlation coefficient",
+      "lbl" : "obsolete correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000142"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "lbl" : "Pearson's correlation coefficient",
+      "lbl" : "obsolete Pearson's correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
@@ -1352,7 +1371,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  "
+          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)"
         }
       }
     }, {
@@ -1583,7 +1602,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable"
+          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -1828,7 +1847,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)."
+          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -1859,7 +1878,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)"
+          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)"
         }
       }
     }, {
@@ -2687,7 +2706,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)."
+          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -2696,7 +2715,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)."
+          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -3130,7 +3149,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)"
+          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3174,7 +3193,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)"
+          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)"
         }
       }
     }, {
@@ -3218,7 +3237,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)."
+          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -3561,7 +3580,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows."
+          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)"
         }
       }
     }, {
@@ -3610,7 +3629,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)."
+          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)"
         }
       }
     }, {
@@ -3619,7 +3638,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)."
+          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)"
         }
       }
     }, {
@@ -3743,7 +3762,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD."
+          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -3759,17 +3778,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)."
+          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)"
         }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "lbl" : "p-value",
+      "lbl" : "obsolete p-value",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000700"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
@@ -4614,7 +4639,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)."
+          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)"
         }
       }
     }, {
@@ -4957,7 +4982,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching."
+          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)"
         }
       }
     }, {
@@ -5351,7 +5376,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)."
+          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)"
         }
       }
     }, {
@@ -5360,7 +5385,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)."
+          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)"
         }
       }
     }, {
@@ -5436,7 +5461,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)"
+          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)"
         }
       }
     }, {
@@ -5463,7 +5488,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)"
+          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)"
         }
       }
     }, {
@@ -6003,7 +6028,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)"
+          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)"
         }
       }
     }, {
@@ -6030,7 +6055,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)."
+          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -6039,7 +6064,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)."
+          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)"
         }
       }
     }, {
@@ -6226,7 +6251,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process."
+          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -6242,7 +6267,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),"
+          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -6258,7 +6283,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations."
+          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -6407,7 +6432,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)"
+          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)"
         },
         "comments" : [ "AMBER lib format" ],
         "synonyms" : [ {
@@ -7070,12 +7095,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "lbl" : "image bond fixing analysis",
+      "lbl" : "obsolete image bond fixing analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)"
-        }
+          "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
@@ -7169,7 +7195,7 @@
         "definition" : {
           "val" : "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)"
         },
-        "comments" : [ "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
+        "comments" : [ "How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.", "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
@@ -7919,7 +7945,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
+          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -8094,7 +8120,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)."
+          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)"
         }
       }
     }, {
@@ -8103,7 +8129,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)."
+          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)"
         }
       }
     }, {
@@ -8112,7 +8138,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)."
+          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -8121,7 +8147,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)."
+          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)"
         }
       }
     }, {
@@ -8130,7 +8156,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)."
+          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)"
         }
       }
     }, {
@@ -8148,7 +8174,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)."
+          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)"
         }
       }
     }, {
@@ -8157,7 +8183,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)."
+          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)"
         }
       }
     }, {
@@ -8166,7 +8192,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)."
+          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)"
         }
       }
     }, {
@@ -8175,7 +8201,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)."
+          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -8184,7 +8210,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -8193,7 +8219,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)."
+          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)"
         }
       }
     }, {
@@ -8202,7 +8228,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)"
         }
       }
     }, {
@@ -8211,7 +8237,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)."
+          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)"
         }
       }
     }, {
@@ -8220,7 +8246,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)."
+          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)"
         }
       }
     }, {
@@ -8229,7 +8255,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)."
+          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)"
         }
       }
     }, {
@@ -8238,7 +8264,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)."
+          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8251,7 +8277,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8264,7 +8290,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)."
+          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8277,7 +8303,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8290,7 +8316,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)."
+          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)"
         }
       }
     }, {
@@ -8299,7 +8325,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)."
+          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)"
         }
       }
     }, {
@@ -8308,7 +8334,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)."
+          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -8317,7 +8343,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)."
+          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -8326,7 +8352,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)."
+          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)"
         }
       }
     }, {
@@ -8335,7 +8361,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)."
+          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)"
         }
       }
     }, {
@@ -8344,7 +8370,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)."
+          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)"
         }
       }
     }, {
@@ -8353,7 +8379,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)."
+          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)"
         }
       }
     }, {
@@ -8362,7 +8388,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)."
+          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -8371,7 +8397,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)."
+          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)"
         }
       }
     }, {
@@ -8380,7 +8406,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)."
+          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)"
         }
       }
     }, {
@@ -8389,7 +8415,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)."
+          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)"
         }
       }
     }, {
@@ -8454,7 +8480,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)."
+          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)"
         }
       }
     }, {
@@ -8463,7 +8489,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)."
+          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8476,7 +8502,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)."
+          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8489,7 +8515,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)."
+          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8502,7 +8528,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)."
+          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8515,7 +8541,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)."
+          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -8528,7 +8554,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)."
+          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)"
         }
       }
     }, {
@@ -8537,7 +8563,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)"
         }
       }
     }, {
@@ -8546,7 +8572,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -9266,12 +9292,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "lbl" : "small molecule structure (deprecated)",
+      "lbl" : "obsolete small molecule structure",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
@@ -9756,7 +9783,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)."
+          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)"
         }
       }
     }, {
@@ -9765,7 +9792,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)."
+          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)"
         }
       }
     }, {
@@ -9831,7 +9858,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)."
+          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -10703,12 +10730,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "lbl" : "macromolecular structure format (deprecated)",
+      "lbl" : "obsolete macromolecular structure format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
@@ -10725,12 +10753,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "lbl" : "software-specific coordinate format (deprecated)",
+      "lbl" : "obsolete software-specific coordinate format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
@@ -11783,7 +11812,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D."
+          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -12159,7 +12188,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e"
+          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)"
         }
       }
     }, {
@@ -12373,7 +12402,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)"
+          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)"
         }
       }
     }, {
@@ -13641,21 +13670,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "lbl" : "Pearson product-moment correlation coefficient",
+      "lbl" : "obsolete Pearson product-moment correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "lbl" : "Spearman rank correlation coefficient",
+      "lbl" : "obsolete Spearman rank correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000201"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
@@ -13686,21 +13727,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "lbl" : "standard error of the mean (SEM)",
+      "lbl" : "obsolete standard error of the mean (SEM)",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000037"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
-      "lbl" : "coefficient of determination",
+      "lbl" : "obsolete coefficient of determination",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000564"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001411",
@@ -13735,12 +13788,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
-      "lbl" : "standard deviation",
+      "lbl" : "obsolete standard deviation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000237"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001415",
@@ -14417,12 +14476,17 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001484",
-      "lbl" : "statistical model",
+      "lbl" : "statistical mechanics model",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)"
-        }
+          "val" : "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)"
+        },
+        "comments" : [ "Not to be confused with STATO:0000107 \"statistical model\", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; \"statistical model\" is retained as an exact synonym." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "statistical model"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001485",
@@ -14430,7 +14494,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
+          "val" : "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
         }
       }
     }, {
@@ -14439,7 +14503,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
+          "val" : "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -16134,7 +16198,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)"
+          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)"
         }
       }
     }, {
@@ -16916,13 +16980,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "lbl" : "trajectory analysis algorithm (deprecated)",
+      "lbl" : "obsolete trajectory analysis algorithm",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)"
+          "val" : "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations."
         },
-        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ]
+        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
@@ -17033,13 +17098,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "lbl" : "Miller indices (deprecated)",
+      "lbl" : "obsolete Miller indices",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)"
+          "val" : "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model."
         },
-        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ]
+        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
@@ -19319,7 +19385,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)"
+          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)"
         }
       }
     }, {
@@ -19590,7 +19656,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
+          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
         }
       }
     }, {
@@ -20066,7 +20132,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)"
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -20075,7 +20141,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -20088,7 +20154,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -20187,7 +20253,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)"
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
         }
       }
     }, {
@@ -21240,7 +21306,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second."
+          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21253,7 +21319,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth."
+          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21266,7 +21332,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes."
+          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21279,7 +21345,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities."
+          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21292,7 +21358,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights."
+          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21305,7 +21371,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs."
+          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21318,7 +21384,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density."
+          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)"
         }
       }
     }, {
@@ -21327,7 +21393,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)."
+          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21340,7 +21406,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity."
+          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -21349,7 +21415,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters."
+          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21362,7 +21428,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector."
+          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)"
         }
       }
     }, {
@@ -21371,7 +21437,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein."
+          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)"
         }
       }
     }, {
@@ -21389,7 +21455,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods."
+          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -21398,7 +21464,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy."
+          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21407,7 +21473,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces."
+          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)"
         }
       }
     }, {
@@ -21530,6 +21596,9 @@
       "id" : "http://purl.obolibrary.org/obo/SO_0000417",
       "type" : "CLASS"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000142",
+      "type" : "CLASS"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/UO_0000000",
       "type" : "CLASS"
     }, {
@@ -21591,7 +21660,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
+          "val" : "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
         }
       }
     }, {
@@ -22203,7 +22272,8 @@
       "meta" : {
         "definition" : {
           "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002125",
@@ -23016,7 +23086,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation"
+          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)"
         }
       }
     }, {
@@ -23088,7 +23158,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry."
+          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)"
         }
       }
     }, {
@@ -23169,7 +23239,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
+          "val" : "Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -23214,7 +23284,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis."
+          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -23332,7 +23402,12 @@
       "meta" : {
         "definition" : {
           "val" : "A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from the class 'model' (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym 'MoDEL database' when matching." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "MoDEL database"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001002",
@@ -23466,7 +23541,14 @@
       "lbl" : "obsolete Omni-Path",
       "type" : "INDIVIDUAL",
       "meta" : {
+        "definition" : {
+          "val" : "OBSOLETE. A redundant untyped individual that duplicated the class 'omni-path' (MOLSIM:001949). It should not be used; use that class instead."
+        },
         "comments" : [ "Obsoleted: redundant untyped individual duplicating the class 'omni-path' (MOLSIM_001949), which is the concept to use instead." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001949"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -23524,6 +23606,10 @@
       "propertyType" : "ANNOTATION"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000117",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -24007,14 +24093,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000110",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001691"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
       "pred" : "is_a",
@@ -24991,10 +25069,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000353",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000400"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
       "pred" : "is_a",
@@ -26284,10 +26358,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
@@ -27136,10 +27206,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001073"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -27652,17 +27718,9 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001091"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001085"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
       "pred" : "is_a",
@@ -28744,31 +28802,15 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001292"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001407",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001408",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -28781,10 +28823,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001411"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001413",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -30120,10 +30158,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001745"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000037"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001696"
@@ -30167,10 +30201,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001758",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001711"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
       "pred" : "is_a",
@@ -30374,7 +30404,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001810",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001811",
       "pred" : "is_a",

--- a/molsim-base.obo
+++ b/molsim-base.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: molsim/releases/2026-07-24/molsim-base.owl
+data-version: molsim/releases/2026-07-29/molsim-base.owl
 default-namespace: molsim
 idspace: dce http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
@@ -7,6 +7,8 @@ idspace: foaf http://xmlns.com/foaf/0.1/
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 idspace: orcid https://orcid.org/ 
 idspace: protege http://protege.stanford.edu/plugins/owl/protege# 
+remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
+remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
 ontology: molsim/molsim-base
 property_value: dce:type IAO:8000001
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
@@ -18,7 +20,7 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-24" xsd:string
+property_value: owl:versionInfo "2026-07-29" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
@@ -60,6 +62,7 @@ disjoint_from: MOLSIM:000208 ! thermalization
 id: MOLSIM:000006
 name: model
 def: "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)" []
+comment: Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.
 
 [Term]
 id: MOLSIM:000007
@@ -270,12 +273,12 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000037
 name: algorithm
-def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis." []
+def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:000038
 name: thermostat algorithm
-def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
@@ -283,38 +286,38 @@ disjoint_from: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000039
 name: barostat algorithm
-def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 
 [Term]
 id: MOLSIM:000040
 name: Berendsen barostat
-def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)." []
+def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000041 ! Monte Carlo barostat
 
 [Term]
 id: MOLSIM:000041
 name: Monte Carlo barostat
-def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)." []
+def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000042
 name: Andersen barostat
-def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)." []
+def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000043
 name: Parrinello-Rahman barostat
-def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)." []
+def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000044
 name: Langevin-piston barostat
-def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)." []
+def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
@@ -329,46 +332,46 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000046
 name: Berendsen thermostat
-def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)." []
+def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000047
 name: Andersen thermostat
-def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)." []
+def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000048
 name: Nosé-Hoover thermostat
-def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)." []
+def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)" []
 synonym: "Nose-Hoover" EXACT []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000049
 name: constraint algorithm
-def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 disjoint_from: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000050
 name: SHAKE algorithm
-def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)." []
+def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 disjoint_from: MOLSIM:000051 ! RATTLE algorithm
 
 [Term]
 id: MOLSIM:000051
 name: RATTLE algorithm
-def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)." []
+def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000052
 name: LINCS algorithm
-def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)." []
+def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)" []
 synonym: "LINCS" EXACT []
 synonym: "linear constraint solver algorithm" EXACT []
 is_a: MOLSIM:000049 ! constraint algorithm
@@ -376,21 +379,21 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000053
 name: electrostatic interaction algorithm
-def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)." []
+def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)" []
 is_a: MOLSIM:000384 ! force calculation algorithm
 disjoint_from: MOLSIM:001724 ! Treecode algorithm
 
 [Term]
 id: MOLSIM:000054
 name: particle mesh Ewald
-def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)." []
+def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)" []
 synonym: "PME" EXACT []
 is_a: MOLSIM:000428 ! Ewald summation
 
 [Term]
 id: MOLSIM:000055
 name: reaction field
-def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)." []
+def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)" []
 synonym: "RF" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
 disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
@@ -398,7 +401,7 @@ disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
 [Term]
 id: MOLSIM:000056
 name: particle-particle particle-mesh
-def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)." []
+def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)" []
 synonym: "P3M" EXACT []
 synonym: "PPPM" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
@@ -514,32 +517,32 @@ disjoint_from: MOLSIM:000270 ! Poisson-Boltzmann surface area
 [Term]
 id: MOLSIM:000074
 name: similarity calculation algorithm
-def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)." []
+def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000075
 name: Tanimoto similarity algorithm
-def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)." []
+def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 disjoint_from: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000076
 name: Tversky index algorithm
-def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules." []
+def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000077
 name: Dice coefficient algorithm
-def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)." []
+def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000078
 name: Euclidean distance
-def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)." []
+def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)" []
 is_a: MOLSIM:001403 ! statistical property
 
 [Term]
@@ -557,100 +560,100 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:000081
 name: Hamming distance algorithm
-def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)." []
+def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000082
 name: Jaccard index algorithm
-def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)." []
+def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000083
 name: overlap coefficient algorithm
-def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)." []
+def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000084
 name: fit Tversky combo
-def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities." []
+def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 disjoint_from: MOLSIM:000085 ! ref Tversky
 
 [Term]
 id: MOLSIM:000085
 name: ref Tversky
-def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule." []
+def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000086
 name: combo score algorithm
-def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)." []
+def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000087
 name: optimal transformation path algorithm
-def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)." []
+def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)." []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
 
 [Term]
 id: MOLSIM:000089
 name: Prim's algorithm
-def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)." []
+def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000090
 name: Dijkstra's algorithm
-def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)." []
+def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000091
 name: A* search algorithm
-def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)." []
+def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)" []
 synonym: "A-star search algorithm" EXACT []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000092
 name: nearest neighbor algorithm
-def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)." []
+def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000093
 name: genetic algorithm
-def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)." []
+def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000094
 name: simulated annealing algorithm
-def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000095
 name: ant colony optimization algorithm
-def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000096
 name: network flow algorithm
-def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)." []
+def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
@@ -754,15 +757,19 @@ disjoint_from: MOLSIM:001692 ! Beeman integrator
 
 [Term]
 id: MOLSIM:000111
-name: correlation coefficient
-def: "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete correlation coefficient
+def: "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.
+is_obsolete: true
+replaced_by: STATO:0000142
 
 [Term]
 id: MOLSIM:000112
-name: Pearson's correlation coefficient
-def: "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson's correlation coefficient
+def: "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:000113
@@ -847,7 +854,7 @@ is_a: MOLSIM:000348 ! hypothesis testing analysis
 [Term]
 id: MOLSIM:000125
 name: Kolmogorov-Smirnov test analysis
-def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  " []
+def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)" []
 is_a: MOLSIM:000124 ! statistical test analysis
 
 [Term]
@@ -993,7 +1000,7 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000148
 name: experimental data availability
-def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable" []
+def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable." []
 is_a: MOLSIM:000143 ! ligand pairs selection criteria
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -1150,7 +1157,7 @@ is_a: MOLSIM:001850 ! modeling and setup tool
 [Term]
 id: MOLSIM:000173
 name: quantum mechanics
-def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)." []
+def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)" []
 synonym: "QM" EXACT []
 is_a: MOLSIM:000141 ! theoretical approach
 
@@ -1173,7 +1180,7 @@ disjoint_from: MOLSIM:000179 ! Q-Chem
 [Term]
 id: MOLSIM:000176
 name: GAMESS
-def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)" []
+def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -1680,13 +1687,13 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000253
 name: clustering algorithm
-def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)." []
+def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000254
 name: hierarchical agglomerative bottom-up algorithm
-def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)." []
+def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000253 ! clustering algorithm
 disjoint_from: MOLSIM:001707 ! DBSCAN clustering algorithm
 
@@ -1952,7 +1959,7 @@ is_a: MOLSIM:000286 ! thermodynamic integration approach
 [Term]
 id: MOLSIM:000294
 name: conveyor belt thermodynamic integration
-def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)" []
+def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)" []
 synonym: "CBTI" EXACT []
 is_a: MOLSIM:000286 ! thermodynamic integration approach
 
@@ -1978,7 +1985,7 @@ is_a: MOLSIM:000355 ! thermodynamic integration analysis
 [Term]
 id: MOLSIM:000299
 name: thermodynamic integration with linear extrapolation
-def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)" []
+def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)" []
 is_a: MOLSIM:000298 ! thermodynamic integration extrapolation approach
 disjoint_from: MOLSIM:000356 ! thermodynamic integration without linear extrapolation
 
@@ -2006,7 +2013,7 @@ is_a: MOLSIM:000300 ! free energy and molecular dynamics analysis
 [Term]
 id: MOLSIM:000303
 name: linear dependence evaluation analysis
-def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)." []
+def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -2214,7 +2221,7 @@ is_a: MOLSIM:000332 ! SCF convergence algorithm
 [Term]
 id: MOLSIM:000334
 name: fit color Tversky
-def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows." []
+def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -2245,13 +2252,13 @@ is_a: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000339
 name: numerical integration
-def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)." []
+def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)" []
 is_a: MOLSIM:000340 ! integration analysis
 
 [Term]
 id: MOLSIM:000340
 name: integration analysis
-def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)." []
+def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -2328,7 +2335,7 @@ is_a: MOLSIM:000400 ! statistical analysis
 [Term]
 id: MOLSIM:000352
 name: binpos format
-def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD." []
+def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)" []
 synonym: ".binpos" EXACT []
 synonym: "Scripps binpos format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
@@ -2336,14 +2343,16 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000353
 name: validation analysis
-def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)." []
+def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000354
-name: p-value
-def: "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete p-value
+def: "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000700
 
 [Term]
 id: MOLSIM:000355
@@ -2847,7 +2856,7 @@ is_a: MOLSIM:000331 ! force field component
 [Term]
 id: MOLSIM:000432
 name: quantum mechanics basis set
-def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)." []
+def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 disjoint_from: MOLSIM:000827 ! Moeller-Plesset
 
@@ -3056,7 +3065,7 @@ is_a: MOLSIM:000257 ! endpoint free energy tool
 [Term]
 id: MOLSIM:000463
 name: ref Tversky combo
-def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching." []
+def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -3310,13 +3319,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000502
 name: linear correlation significance determination analysis
-def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)." []
+def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000503
 name: determination by p-value analysis
-def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)." []
+def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
@@ -3365,7 +3374,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000514
 name: LANL2-[6s4p4d2f]
-def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)" []
+def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -3383,7 +3392,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000517
 name: LANL2DZ+2s2p2d2f
-def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)" []
+def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -3743,7 +3752,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000577
 name: Ahlrichs pvDZ
-def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)" []
+def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -3761,13 +3770,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000580
 name: plane-wave
-def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)." []
+def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
 id: MOLSIM:000581
 name: real-space
-def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)." []
+def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
@@ -3883,7 +3892,7 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000599
 name: AMBER REM log format
-def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process." []
+def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)" []
 synonym: "Amber Replica Exchange Log" EXACT []
 synonym: "rem.log" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -3891,7 +3900,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000600
 name: AMBER eigenvector format
-def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj)," []
+def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)" []
 synonym: "evecs.dat" EXACT []
 synonym: "evecs.out" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -3899,7 +3908,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000601
 name: cpout format
-def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations." []
+def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)" []
 synonym: ".cpout" EXACT []
 synonym: "AMBER cpout format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -3987,7 +3996,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000614
 name: off format
-def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)" []
+def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)" []
 comment: AMBER lib format
 synonym: ".off" EXACT []
 synonym: "AMBER Object File Format" EXACT []
@@ -4401,9 +4410,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 
 [Term]
 id: MOLSIM:000679
-name: image bond fixing analysis
-def: "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)" []
-is_a: MOLSIM:000659 ! periodic boundary imaging
+name: obsolete image bond fixing analysis
+def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000680
@@ -4460,7 +4469,7 @@ is_a: MOLSIM:000448 ! protein database ID
 id: MOLSIM:000688
 name: data source
 def: "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)" []
-comment: TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import
+comment: How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.
 
 [Term]
 id: MOLSIM:000689
@@ -4941,7 +4950,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:000775
 name: CP2K
-def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
+def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -5057,31 +5066,31 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000794
 name: Hoover barostat
-def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)." []
+def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000795
 name: M-SHAKE algorithm
-def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)." []
+def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000796
 name: P-SHAKE algorithm
-def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)." []
+def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000797
 name: SETTLE algorithm
-def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)." []
+def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000798
 name: SHAPE algorithm
-def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)." []
+def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
@@ -5093,76 +5102,76 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000800
 name: Nose thermostat
-def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)." []
+def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000801
 name: Nose-Poincare thermostat
-def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)." []
+def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000802
 name: V-rescale thermostat
-def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)." []
+def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000803
 name: semi-empirical method
-def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)." []
+def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000804
 name: all-valence-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 disjoint_from: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000805
 name: PPP
-def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)." []
+def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)" []
 is_a: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000806
 name: pi-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 
 [Term]
 id: MOLSIM:000807
 name: AM1
-def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)." []
+def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 disjoint_from: MOLSIM:000808 ! CNDO/2
 
 [Term]
 id: MOLSIM:000808
 name: CNDO/2
-def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)." []
+def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000809
 name: INDO
-def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)." []
+def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000810
 name: Hartree-Fock
-def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)." []
+def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)" []
 synonym: "HF" EXACT []
 is_a: MOLSIM:000685 ! ab-initio method
 
 [Term]
 id: MOLSIM:000812
 name: restricted open-shell Hartree-Fock
-def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "ROHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 disjoint_from: MOLSIM:000813 ! self-consistent field
@@ -5170,88 +5179,88 @@ disjoint_from: MOLSIM:000813 ! self-consistent field
 [Term]
 id: MOLSIM:000813
 name: self-consistent field
-def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)." []
+def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)" []
 synonym: "SCF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000814
 name: Unrestricted Hartree-Fock
-def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "UHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000815
 name: MINDO
-def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)." []
+def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)" []
 is_a: MOLSIM:000809 ! INDO
 
 [Term]
 id: MOLSIM:000816
 name: MNDO
-def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)." []
+def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000817
 name: NDDO
-def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)." []
+def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 disjoint_from: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000818
 name: PDDG
-def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)." []
+def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000819
 name: PM3
-def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)." []
+def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000820
 name: PM3MM
-def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)." []
+def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000821
 name: PM6
-def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)." []
+def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000822
 name: RM1
-def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)." []
+def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000823
 name: SAM1
-def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)." []
+def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000824
 name: SINDO
-def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)." []
+def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000825
 name: Sparkle/AM1
-def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)." []
+def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)" []
 is_a: MOLSIM:000807 ! AM1
 
 [Term]
 id: MOLSIM:000826
 name: ZANDO
-def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)." []
+def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
@@ -5293,13 +5302,13 @@ is_a: MOLSIM:000827 ! Moeller-Plesset
 [Term]
 id: MOLSIM:000832
 name: multi-reference
-def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)." []
+def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000833
 name: complete active space self-consistent field
-def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)." []
+def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)" []
 synonym: "CASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
@@ -5307,48 +5316,48 @@ disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
 [Term]
 id: MOLSIM:000834
 name: multi-configurational self-consistent field
-def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)." []
+def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)" []
 synonym: "MC-SCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000835
 name: multi-reference coupled cluster with single and double excitations
-def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)." []
+def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)" []
 synonym: "MR-CCSD" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000836
 name: multi-reference configuration interaction with single and double excitations
-def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)." []
+def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)" []
 synonym: "MR-CI(SD)" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000837
 name: restricted active space self-consistent field
-def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)." []
+def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)" []
 synonym: "RASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000838
 name: quadratic configuration interaction
-def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)." []
+def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000839
 name: QCISD(T)
-def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 disjoint_from: MOLSIM:000840 ! QCISD
 
 [Term]
 id: MOLSIM:000840
 name: QCISD
-def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 
 [Term]
@@ -5775,9 +5784,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:000905
-name: small molecule structure (deprecated)
-def: "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete small molecule structure
+def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000906
@@ -6080,14 +6089,14 @@ is_a: MOLSIM:000984 ! distribution analysis
 [Term]
 id: MOLSIM:000978
 name: conformation validation analysis
-def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)." []
+def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 disjoint_from: MOLSIM:000981 ! secondary structure assignment analysis
 
 [Term]
 id: MOLSIM:000979
 name: ramachandran analysis
-def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)." []
+def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)" []
 is_a: MOLSIM:000917 ! structural analysis
 disjoint_from: MOLSIM:000980 ! structural check analysis
 
@@ -6127,7 +6136,7 @@ is_a: MOLSIM:000974 ! solvent analysis
 [Term]
 id: MOLSIM:000985
 name: matrix diagonalization analysis
-def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)." []
+def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -6640,9 +6649,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 
 [Term]
 id: MOLSIM:001087
-name: macromolecular structure format (deprecated)
-def: "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete macromolecular structure format
+def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001088
@@ -6653,9 +6662,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001089
-name: software-specific coordinate format (deprecated)
-def: "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete software-specific coordinate format
+def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001090
@@ -7305,7 +7314,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001234
 name: GaMD potential boost stddev limit
-def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D." []
+def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D." []
 is_a: MOLSIM:001233 ! Gaussian accelerated MD parameter
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -7534,7 +7543,7 @@ is_a: MOLSIM:001268 ! volumetric analysis parameter
 [Term]
 id: MOLSIM:001270
 name: grid function
-def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e" []
+def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)" []
 is_a: MOLSIM:001268 ! volumetric analysis parameter
 
 [Term]
@@ -7670,7 +7679,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001292
 name: computed observable
-def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)" []
+def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:001293
@@ -8411,21 +8420,25 @@ is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:001404
-name: Pearson product-moment correlation coefficient
-def: "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson product-moment correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages." []
+comment: Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:001405
-name: Spearman rank correlation coefficient
-def: "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Spearman rank correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.
+is_obsolete: true
+replaced_by: STATO:0000201
 
 [Term]
 id: MOLSIM:001406
 name: Kendall tau correlation coefficient
 def: "A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall's tau. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142
 
 [Term]
 id: MOLSIM:001407
@@ -8441,15 +8454,19 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001409
-name: standard error of the mean (SEM)
-def: "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard error of the mean (SEM)
+def: "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation.
+is_obsolete: true
+replaced_by: STATO:0000037
 
 [Term]
 id: MOLSIM:001410
-name: coefficient of determination
-def: "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete coefficient of determination
+def: "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000564
 
 [Term]
 id: MOLSIM:001411
@@ -8472,9 +8489,11 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001414
-name: standard deviation
-def: "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard deviation
+def: "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000237
 
 [Term]
 id: MOLSIM:001415
@@ -8908,21 +8927,23 @@ is_a: MOLSIM:000007 ! force field
 
 [Term]
 id: MOLSIM:001484
-name: statistical model
-def: "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)" []
+name: statistical mechanics model
+def: "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)" []
+comment: Not to be confused with STATO:0000107 "statistical model", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; "statistical model" is retained as an exact synonym.
+synonym: "statistical model" EXACT []
 is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:001485
 name: Maxwell-Boltzmann distribution
-def: "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
-is_a: MOLSIM:001484 ! statistical model
+def: "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
+is_a: MOLSIM:001484 ! statistical mechanics model
 
 [Term]
 id: MOLSIM:001486
 name: two-state transition model
-def: "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
-is_a: MOLSIM:001484 ! statistical model
+def: "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
+is_a: MOLSIM:001484 ! statistical mechanics model
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -10022,7 +10043,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:001666
 name: metatwist
-def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)" []
+def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)" []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
@@ -10533,10 +10554,10 @@ disjoint_from: MOLSIM:010012 ! STRIDE algorithm
 
 [Term]
 id: MOLSIM:001747
-name: trajectory analysis algorithm (deprecated)
-def: "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)" []
+name: obsolete trajectory analysis algorithm
+def: "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations." []
 comment: candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21
-is_a: MOLSIM:000037 ! algorithm
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001748
@@ -10609,10 +10630,10 @@ is_a: MOLSIM:001711 ! residue library
 
 [Term]
 id: MOLSIM:001759
-name: Miller indices (deprecated)
-def: "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)" []
+name: obsolete Miller indices
+def: "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model." []
 comment: Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26
-is_a: MOLSIM:000447 ! identifier
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001760
@@ -10930,7 +10951,7 @@ is_a: MOLSIM:001403 ! statistical property
 id: MOLSIM:001810
 name: RMS average correlation
 def: "The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system's dynamics, with a higher value indicating that the molecule's motions are more concerted. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142
 
 [Term]
 id: MOLSIM:001811
@@ -11993,7 +12014,7 @@ is_a: MOLSIM:000172 ! topology and parameterization tool
 [Term]
 id: MOLSIM:001973
 name: AMBERGS
-def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)" []
+def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)" []
 is_a: MOLSIM:000009 ! protein force field
 
 [Term]
@@ -12169,7 +12190,7 @@ is_a: MOLSIM:001515 ! Lennard-Jones parameters
 [Term]
 id: MOLSIM:002001
 name: repulsion interaction parameter
-def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
+def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
 is_a: MOLSIM:001515 ! Lennard-Jones parameters
 
 [Term]
@@ -12469,20 +12490,20 @@ is_a: MOLSIM:001566 ! library
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
@@ -12533,7 +12554,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
@@ -13204,81 +13225,81 @@ is_a: MOLSIM:002162 ! system classification label
 [Term]
 id: MOLSIM:010001
 name: femtosecond
-def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second." []
+def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)" []
 synonym: "fs" EXACT []
 is_a: UO:1000010
 
 [Term]
 id: MOLSIM:010002
 name: atmosphere
-def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth." []
+def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)" []
 synonym: "atm" EXACT []
 is_a: UO:0000109
 
 [Term]
 id: MOLSIM:010003
 name: angstrom per nanosecond
-def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes." []
+def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)" []
 synonym: "Å/ns|angstrom/nanosecond" EXACT []
 is_a: UO:0000060
 
 [Term]
 id: MOLSIM:010004
 name: kilocalorie per mole
-def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities." []
+def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)" []
 synonym: "kcal/mol|kilocalorie/mole" EXACT []
 is_a: UO:0000111
 
 [Term]
 id: MOLSIM:010005
 name: kilocalorie per mole per square angstrom
-def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights." []
+def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)" []
 synonym: "kcal/mol/Å^2|kilocalorie/mole/angstrom^2" EXACT []
 is_a: UO:0000111
 
 [Term]
 id: MOLSIM:010006
 name: elementary charge
-def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs." []
+def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)" []
 synonym: "e" EXACT []
 is_a: UO:0000219
 
 [Term]
 id: MOLSIM:010007
 name: kinematic viscosity unit
-def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density." []
+def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)" []
 is_a: UO:0000000
 
 [Term]
 id: MOLSIM:010008
 name: square centimeter per second
-def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)." []
+def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)" []
 synonym: "cm^2/s|stokes|St" EXACT []
 is_a: MOLSIM:010007 ! kinematic viscosity unit
 
 [Term]
 id: MOLSIM:010009
 name: electric dipole moment unit
-def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity." []
+def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)" []
 is_a: UO:0000000
 
 [Term]
 id: MOLSIM:010010
 name: debye
-def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters." []
+def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)" []
 synonym: "D" EXACT []
 is_a: MOLSIM:010009 ! electric dipole moment unit
 
 [Term]
 id: MOLSIM:010011
 name: Kabsch RMSD algorithm
-def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector." []
+def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)" []
 is_a: MOLSIM:001717 ! RMSD calculation algorithm
 
 [Term]
 id: MOLSIM:010012
 name: STRIDE algorithm
-def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein." []
+def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)" []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 
 [Term]
@@ -13290,19 +13311,19 @@ is_a: MOLSIM:001751 ! statistical algorithm
 [Term]
 id: MOLSIM:010014
 name: parametric distribution fitting algorithm
-def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods." []
+def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010015
 name: spline-based estimation algorithm
-def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy." []
+def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010016
 name: Shrake-Rupley algorithm
-def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces." []
+def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)" []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
 
 [Term]
@@ -13404,7 +13425,7 @@ range: MOLSIM:000001 ! software
 [Typedef]
 id: MOLSIM:000508
 name: protein structure source
-def: "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
+def: "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
 domain: MOLSIM:000904 ! molecular structure
 range: MOLSIM:000688 ! data source
 

--- a/molsim-base.owl
+++ b/molsim-base.owl
@@ -14,7 +14,7 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim/molsim-base.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim-base.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-base.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <dce:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
@@ -26,7 +26,9 @@
         <dcterms:subject xml:lang="en">biomolecular simulation</dcterms:subject>
         <dcterms:title>Molecular Simulation Ontology</dcterms:title>
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
-        <owl:versionInfo>2026-07-24</owl:versionInfo>
+        <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
+        <owl:versionInfo>2026-07-29</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -58,6 +60,12 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
     
 
 
@@ -192,7 +200,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000904"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000688"/>
-        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein structure source</rdfs:label>
     </owl:ObjectProperty>
     
@@ -890,7 +898,9 @@
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1708,6 +1718,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000006">
         <obo:IAO_0000115 xml:lang="en">A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system&apos;s behavior. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Distinct from &apos;MoDEL&apos; (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.</rdfs:comment>
         <rdfs:label xml:lang="en">model</rdfs:label>
     </owl:Class>
     
@@ -2032,7 +2043,7 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000037">
-        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">algorithm</rdfs:label>
     </owl:Class>
     
@@ -2042,7 +2053,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000038">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -2052,7 +2063,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">barostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -2062,7 +2073,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen barostat</rdfs:label>
     </owl:Class>
     
@@ -2072,7 +2083,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Monte Carlo barostat</rdfs:label>
     </owl:Class>
     
@@ -2082,7 +2093,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen barostat</rdfs:label>
     </owl:Class>
     
@@ -2092,7 +2103,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Parrinello-Rahman barostat</rdfs:label>
     </owl:Class>
     
@@ -2102,7 +2113,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000044">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Langevin-piston barostat</rdfs:label>
     </owl:Class>
     
@@ -2123,7 +2134,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000046">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen thermostat</rdfs:label>
     </owl:Class>
     
@@ -2133,7 +2144,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000047">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen thermostat</rdfs:label>
     </owl:Class>
     
@@ -2143,7 +2154,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000048">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Nose-Hoover</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Nosé-Hoover thermostat</rdfs:label>
     </owl:Class>
@@ -2154,7 +2165,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">constraint algorithm</rdfs:label>
     </owl:Class>
     
@@ -2164,7 +2175,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -2174,7 +2185,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RATTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -2184,7 +2195,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000052">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">LINCS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">linear constraint solver algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">LINCS algorithm</rdfs:label>
@@ -2197,7 +2208,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000053">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000384"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001724"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">electrostatic interaction algorithm</rdfs:label>
     </owl:Class>
     
@@ -2207,7 +2218,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000054">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000428"/>
-        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">PME</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle mesh Ewald</rdfs:label>
     </owl:Class>
@@ -2218,7 +2229,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000055">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">reaction field</rdfs:label>
     </owl:Class>
@@ -2229,7 +2240,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000056">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">P3M</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">PPPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle-particle particle-mesh</rdfs:label>
@@ -2413,7 +2424,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000074">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">similarity calculation algorithm</rdfs:label>
     </owl:Class>
     
@@ -2423,7 +2434,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000075">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tanimoto similarity algorithm</rdfs:label>
     </owl:Class>
     
@@ -2433,7 +2444,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -2443,7 +2454,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000077">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dice coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -2453,7 +2464,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000078">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Euclidean distance</rdfs:label>
     </owl:Class>
     
@@ -2483,7 +2494,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000081">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hamming distance algorithm</rdfs:label>
     </owl:Class>
     
@@ -2493,7 +2504,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000082">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Jaccard index algorithm</rdfs:label>
     </owl:Class>
     
@@ -2503,7 +2514,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000083">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">overlap coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -2513,7 +2524,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000084">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -2523,7 +2534,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000085">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky</rdfs:label>
     </owl:Class>
     
@@ -2533,7 +2544,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000086">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">combo score algorithm</rdfs:label>
     </owl:Class>
     
@@ -2543,7 +2554,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000087">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">optimal transformation path algorithm</rdfs:label>
     </owl:Class>
     
@@ -2553,7 +2564,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -2563,7 +2574,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000089">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Prim&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -2573,7 +2584,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000090">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dijkstra&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -2583,7 +2594,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000091">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">A-star search algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">A* search algorithm</rdfs:label>
     </owl:Class>
@@ -2594,7 +2605,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000092">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nearest neighbor algorithm</rdfs:label>
     </owl:Class>
     
@@ -2604,7 +2615,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">genetic algorithm</rdfs:label>
     </owl:Class>
     
@@ -2614,7 +2625,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000094">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulated annealing algorithm</rdfs:label>
     </owl:Class>
     
@@ -2624,7 +2635,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000095">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ant colony optimization algorithm</rdfs:label>
     </owl:Class>
     
@@ -2634,7 +2645,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000096">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">network flow algorithm</rdfs:label>
     </owl:Class>
     
@@ -2795,9 +2806,11 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000111 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000111">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2805,9 +2818,11 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000112 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000112">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson&apos;s correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson&apos;s correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -2944,7 +2959,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000125">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000124"/>
-        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  </obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kolmogorov-Smirnov test analysis</rdfs:label>
     </owl:Class>
     
@@ -3180,7 +3195,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000148">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000143"/>
-        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">experimental data availability</rdfs:label>
     </owl:Class>
@@ -3435,7 +3450,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000173">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000141"/>
-        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">QM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">quantum mechanics</rdfs:label>
     </owl:Class>
@@ -3466,7 +3481,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000176">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">GAMESS</rdfs:label>
     </owl:Class>
     
@@ -4274,7 +4289,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000253">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">clustering algorithm</rdfs:label>
     </owl:Class>
     
@@ -4284,7 +4299,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000254">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000253"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hierarchical agglomerative bottom-up algorithm</rdfs:label>
     </owl:Class>
     
@@ -4705,7 +4720,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000294">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000286"/>
-        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CBTI</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">conveyor belt thermodynamic integration</rdfs:label>
     </owl:Class>
@@ -4748,7 +4763,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000299">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000298"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000356"/>
-        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermodynamic integration with linear extrapolation</rdfs:label>
     </owl:Class>
     
@@ -4791,7 +4806,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000303">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear dependence evaluation analysis</rdfs:label>
     </owl:Class>
     
@@ -5120,7 +5135,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit color Tversky</rdfs:label>
     </owl:Class>
     
@@ -5171,7 +5186,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000340"/>
-        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">numerical integration</rdfs:label>
     </owl:Class>
     
@@ -5181,7 +5196,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">integration analysis</rdfs:label>
     </owl:Class>
     
@@ -5306,7 +5321,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.binpos</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">Scripps binpos format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">binpos format</rdfs:label>
@@ -5318,7 +5333,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">validation analysis</rdfs:label>
     </owl:Class>
     
@@ -5327,9 +5342,11 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000354 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000354">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">p-value</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000700"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete p-value</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6144,7 +6161,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quantum mechanics basis set</rdfs:label>
     </owl:Class>
     
@@ -6470,7 +6487,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -6873,7 +6890,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear correlation significance determination analysis</rdfs:label>
     </owl:Class>
     
@@ -6883,7 +6900,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">determination by p-value analysis</rdfs:label>
     </owl:Class>
     
@@ -6964,7 +6981,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2-[6s4p4d2f]</rdfs:label>
     </owl:Class>
     
@@ -6994,7 +7011,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2DZ+2s2p2d2f</rdfs:label>
     </owl:Class>
     
@@ -7594,7 +7611,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000577">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Ahlrichs pvDZ</rdfs:label>
     </owl:Class>
     
@@ -7624,7 +7641,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000580">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">plane-wave</rdfs:label>
     </owl:Class>
     
@@ -7634,7 +7651,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000581">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">real-space</rdfs:label>
     </owl:Class>
     
@@ -7821,7 +7838,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000599">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Amber Replica Exchange Log</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">rem.log</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER REM log format</rdfs:label>
@@ -7833,7 +7850,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000600">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.dat</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.out</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER eigenvector format</rdfs:label>
@@ -7845,7 +7862,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000601">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.cpout</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER cpout format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">cpout format</rdfs:label>
@@ -7984,7 +8001,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000614">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">.off</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER Object File Format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER off format</oboInOwl:hasExactSynonym>
@@ -8656,9 +8673,9 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000679 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
-        <obo:IAO_0000115 xml:lang="en">Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">image bond fixing analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -8750,6 +8767,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000688">
         <obo:IAO_0000115 xml:lang="en">Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.</rdfs:comment>
         <rdfs:comment xml:lang="en">TODO:may be be replacable with IAO&apos;s information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import</rdfs:comment>
         <rdfs:label xml:lang="en">data source</rdfs:label>
     </owl:Class>
@@ -9526,7 +9544,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000775">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CP2K</rdfs:label>
     </owl:Class>
     
@@ -9717,7 +9735,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000794">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hoover barostat</rdfs:label>
     </owl:Class>
     
@@ -9727,7 +9745,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">M-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -9737,7 +9755,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000796">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">P-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -9747,7 +9765,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000797">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SETTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -9757,7 +9775,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000798">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAPE algorithm</rdfs:label>
     </owl:Class>
     
@@ -9777,7 +9795,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000800">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose thermostat</rdfs:label>
     </owl:Class>
     
@@ -9787,7 +9805,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000801">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose-Poincare thermostat</rdfs:label>
     </owl:Class>
     
@@ -9797,7 +9815,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000802">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">V-rescale thermostat</rdfs:label>
     </owl:Class>
     
@@ -9807,7 +9825,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000803">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">semi-empirical method</rdfs:label>
     </owl:Class>
     
@@ -9818,7 +9836,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000804">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">all-valence-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -9828,7 +9846,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000805">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PPP</rdfs:label>
     </owl:Class>
     
@@ -9838,7 +9856,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000806">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">pi-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -9848,7 +9866,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000807">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AM1</rdfs:label>
     </owl:Class>
     
@@ -9858,7 +9876,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000808">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CNDO/2</rdfs:label>
     </owl:Class>
     
@@ -9868,7 +9886,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000809">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">INDO</rdfs:label>
     </owl:Class>
     
@@ -9878,7 +9896,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000810">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000685"/>
-        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">HF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -9889,7 +9907,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000812">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">ROHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted open-shell Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -9900,7 +9918,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000813">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">self-consistent field</rdfs:label>
     </owl:Class>
@@ -9911,7 +9929,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000814">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">UHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Unrestricted Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -9922,7 +9940,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000815">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000809"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MINDO</rdfs:label>
     </owl:Class>
     
@@ -9932,7 +9950,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000816">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MNDO</rdfs:label>
     </owl:Class>
     
@@ -9942,7 +9960,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000817">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NDDO</rdfs:label>
     </owl:Class>
     
@@ -9952,7 +9970,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000818">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDDG</rdfs:label>
     </owl:Class>
     
@@ -9962,7 +9980,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000819">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3</rdfs:label>
     </owl:Class>
     
@@ -9972,7 +9990,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000820">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3MM</rdfs:label>
     </owl:Class>
     
@@ -9982,7 +10000,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000821">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM6</rdfs:label>
     </owl:Class>
     
@@ -9992,7 +10010,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000822">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RM1</rdfs:label>
     </owl:Class>
     
@@ -10002,7 +10020,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000823">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SAM1</rdfs:label>
     </owl:Class>
     
@@ -10012,7 +10030,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000824">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SINDO</rdfs:label>
     </owl:Class>
     
@@ -10022,7 +10040,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000825">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000807"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Sparkle/AM1</rdfs:label>
     </owl:Class>
     
@@ -10032,7 +10050,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000826">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ZANDO</rdfs:label>
     </owl:Class>
     
@@ -10097,7 +10115,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000832">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-reference</rdfs:label>
     </owl:Class>
     
@@ -10107,7 +10125,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000833">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">complete active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -10118,7 +10136,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000834">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">MC-SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-configurational self-consistent field</rdfs:label>
     </owl:Class>
@@ -10129,7 +10147,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000835">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CCSD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference coupled cluster with single and double excitations</rdfs:label>
     </owl:Class>
@@ -10140,7 +10158,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000836">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CI(SD)</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference configuration interaction with single and double excitations</rdfs:label>
     </owl:Class>
@@ -10151,7 +10169,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000837">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -10162,7 +10180,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000838">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quadratic configuration interaction</rdfs:label>
     </owl:Class>
     
@@ -10173,7 +10191,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000839">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000840"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD(T)</rdfs:label>
     </owl:Class>
     
@@ -10183,7 +10201,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000840">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD</rdfs:label>
     </owl:Class>
     
@@ -10868,9 +10886,9 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000905 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">small molecule structure (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11361,7 +11379,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000978">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000981"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">conformation validation analysis</rdfs:label>
     </owl:Class>
     
@@ -11372,7 +11390,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000979">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000980"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ramachandran analysis</rdfs:label>
     </owl:Class>
     
@@ -11435,7 +11453,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000985">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">matrix diagonalization analysis</rdfs:label>
     </owl:Class>
     
@@ -12252,9 +12270,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001087 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">macromolecular structure format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -12273,9 +12291,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001089 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">software-specific coordinate format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -13347,7 +13365,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001233"/>
-        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">GaMD potential boost stddev limit</rdfs:label>
     </owl:Class>
@@ -13720,7 +13738,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001270">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001268"/>
-        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">grid function</rdfs:label>
     </owl:Class>
     
@@ -13943,7 +13961,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001292 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001292">
-        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computed observable</rdfs:label>
     </owl:Class>
     
@@ -15133,9 +15151,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001404 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001404">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson product-moment correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - &apos;Pearson product-moment correlation coefficient&apos; is the full formal name of Pearson&apos;s correlation coefficient. Replaced by the reused STATO term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson product-moment correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15143,9 +15163,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001405 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001405">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Spearman rank correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000201"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM&apos;s (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson&apos;s). Note the symbol &apos;rho&apos; named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Spearman rank correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15153,7 +15175,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001406 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001406">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall&apos;s tau. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kendall tau correlation coefficient</rdfs:label>
     </owl:Class>
@@ -15183,9 +15205,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001409 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001409">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard error of the mean (SEM)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000037"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the &apos;(SEM)&apos; abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO&apos;s own definition spells out the abbreviation.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard error of the mean (SEM)</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15193,9 +15217,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001410 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001410">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">coefficient of determination</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000564"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete coefficient of determination</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15234,9 +15260,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001414 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001414">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000237"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard deviation</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -15948,8 +15976,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">statistical model</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">statistical model</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Not to be confused with STATO:0000107 &quot;statistical model&quot;, which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; &quot;statistical model&quot; is retained as an exact synonym.</rdfs:comment>
+        <rdfs:label xml:lang="en">statistical mechanics model</rdfs:label>
     </owl:Class>
     
 
@@ -15958,7 +15988,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Maxwell-Boltzmann distribution</rdfs:label>
     </owl:Class>
     
@@ -15968,7 +15998,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">two-state transition model</rdfs:label>
     </owl:Class>
@@ -17781,7 +17811,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001666">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
-        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metatwist</rdfs:label>
     </owl:Class>
     
@@ -18608,10 +18638,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001747 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations.</obo:IAO_0000115>
         <rdfs:comment>candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21</rdfs:comment>
-        <rdfs:label xml:lang="en">trajectory analysis algorithm (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete trajectory analysis algorithm</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -18731,10 +18761,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001759 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001759">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26</rdfs:comment>
-        <rdfs:label xml:lang="en">Miller indices (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete Miller indices</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19254,7 +19284,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001810 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001810">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system&apos;s dynamics, with a higher value indicating that the molecule&apos;s motions are more concerted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RMS average correlation</rdfs:label>
     </owl:Class>
@@ -20962,7 +20992,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001973">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERGS</rdfs:label>
     </owl:Class>
     
@@ -21249,9 +21279,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001515"/>
-        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the 
-C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 
-1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">repulsion interaction parameter</rdfs:label>
     </owl:Class>
     
@@ -21742,7 +21770,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -21752,7 +21780,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -21763,7 +21791,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -21843,7 +21871,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -22937,7 +22965,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_1000010"/>
-        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second.</obo:IAO_0000115>
+        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>fs</oboInOwl:hasExactSynonym>
         <rdfs:label>femtosecond</rdfs:label>
     </owl:Class>
@@ -22948,7 +22976,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000109"/>
-        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>atm</oboInOwl:hasExactSynonym>
         <rdfs:label>atmosphere</rdfs:label>
     </owl:Class>
@@ -22959,7 +22987,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000060"/>
-        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>Å/ns|angstrom/nanosecond</oboInOwl:hasExactSynonym>
         <rdfs:label>angstrom per nanosecond</rdfs:label>
     </owl:Class>
@@ -22970,7 +22998,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010004">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol|kilocalorie/mole</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole</rdfs:label>
     </owl:Class>
@@ -22981,7 +23009,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol/Å^2|kilocalorie/mole/angstrom^2</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole per square angstrom</rdfs:label>
     </owl:Class>
@@ -22992,7 +23020,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000219"/>
-        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>e</oboInOwl:hasExactSynonym>
         <rdfs:label>elementary charge</rdfs:label>
     </owl:Class>
@@ -23003,7 +23031,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>kinematic viscosity unit</rdfs:label>
     </owl:Class>
     
@@ -23013,7 +23041,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010007"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St).</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>cm^2/s|stokes|St</oboInOwl:hasExactSynonym>
         <rdfs:label>square centimeter per second</rdfs:label>
     </owl:Class>
@@ -23024,7 +23052,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>electric dipole moment unit</rdfs:label>
     </owl:Class>
     
@@ -23034,7 +23062,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010010">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010009"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters.</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>D</oboInOwl:hasExactSynonym>
         <rdfs:label>debye</rdfs:label>
     </owl:Class>
@@ -23045,7 +23073,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -23055,7 +23083,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein.</obo:IAO_0000115>
+        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23075,7 +23103,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -23085,7 +23113,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -23095,7 +23123,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Shrake-Rupley algorithm</rdfs:label>
     </owl:Class>
     
@@ -23226,6 +23254,12 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/SO_0000417 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000417"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000142"/>
     
 
 
@@ -23436,7 +23470,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000922">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000697"/>
-        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NCBI RefSeq Nucleotide</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23516,7 +23550,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000957">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000707"/>
-        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ChEMBL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23606,7 +23640,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000967">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000704"/>
-        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CDD</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23656,7 +23690,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000972">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000706"/>
-        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Reactome</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23787,6 +23821,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001001">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000710"/>
         <obo:IAO_0000115 xml:lang="en">A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">MoDEL database</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Distinct from the class &apos;model&apos; (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym &apos;MoDEL database&apos; when matching.</rdfs:comment>
         <rdfs:label xml:lang="en">MoDEL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23936,6 +23972,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001945 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001945">
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A redundant untyped individual that duplicated the class &apos;omni-path&apos; (MOLSIM:001949). It should not be used; use that class instead.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001949"/>
         <rdfs:comment xml:lang="en">Obsoleted: redundant untyped individual duplicating the class &apos;omni-path&apos; (MOLSIM_001949), which is the concept to use instead.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete Omni-Path</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -24181,7 +24219,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000895"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000896"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000897"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000906"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000907"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921"/>
@@ -24189,8 +24226,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001044"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001059"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001094"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001095"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001096"/>
@@ -24288,7 +24323,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001700"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001728"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001740"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001986"/>
         </owl:members>
     </rdf:Description>

--- a/molsim-full.json
+++ b/molsim-full.json
@@ -33,13 +33,19 @@
         "pred" : "http://www.geneontology.org/formats/oboInOwl#default-namespace",
         "val" : "molsim"
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification."
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-24"
+        "val" : "2026-07-29"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim-full.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-full.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/APOLLO_SV_00000008",
@@ -13356,7 +13362,8 @@
       "meta" : {
         "definition" : {
           "val" : "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000007",
@@ -13694,7 +13701,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis."
+          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -13703,7 +13710,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)"
         }
       }
     }, {
@@ -13712,7 +13719,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -13721,7 +13728,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)."
+          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)"
         }
       }
     }, {
@@ -13730,7 +13737,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)."
+          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)"
         }
       }
     }, {
@@ -13739,7 +13746,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)."
+          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -13748,7 +13755,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)."
+          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)"
         }
       }
     }, {
@@ -13757,7 +13764,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)."
+          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -13779,7 +13786,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)."
+          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -13788,7 +13795,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)."
+          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -13797,7 +13804,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)."
+          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13810,7 +13817,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -13819,7 +13826,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)."
+          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)"
         }
       }
     }, {
@@ -13828,7 +13835,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)."
+          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)"
         }
       }
     }, {
@@ -13837,7 +13844,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)."
+          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13853,7 +13860,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)."
+          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)"
         }
       }
     }, {
@@ -13862,7 +13869,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)."
+          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13875,7 +13882,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)."
+          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13888,7 +13895,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)."
+          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -14065,7 +14072,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)."
+          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -14074,7 +14081,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)."
+          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -14083,7 +14090,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules."
+          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -14092,7 +14099,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)."
+          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)"
         }
       }
     }, {
@@ -14101,7 +14108,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)."
+          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)"
         }
       }
     }, {
@@ -14128,7 +14135,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)."
+          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)"
         }
       }
     }, {
@@ -14137,7 +14144,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)."
+          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)"
         }
       }
     }, {
@@ -14146,7 +14153,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)."
+          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)"
         }
       }
     }, {
@@ -14155,7 +14162,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities."
+          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)"
         }
       }
     }, {
@@ -14164,7 +14171,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule."
+          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)"
         }
       }
     }, {
@@ -14173,7 +14180,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)."
+          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)"
         }
       }
     }, {
@@ -14182,7 +14189,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)."
+          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)"
         }
       }
     }, {
@@ -14191,7 +14198,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)."
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
         }
       }
     }, {
@@ -14200,7 +14207,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)."
+          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)"
         }
       }
     }, {
@@ -14209,7 +14216,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)."
+          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)"
         }
       }
     }, {
@@ -14218,7 +14225,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)."
+          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -14231,7 +14238,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)."
+          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)"
         }
       }
     }, {
@@ -14240,7 +14247,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)."
+          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)"
         }
       }
     }, {
@@ -14249,7 +14256,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)"
         }
       }
     }, {
@@ -14258,7 +14265,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)"
         }
       }
     }, {
@@ -14267,7 +14274,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)."
+          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)"
         }
       }
     }, {
@@ -14442,21 +14449,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "lbl" : "correlation coefficient",
+      "lbl" : "obsolete correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000142"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "lbl" : "Pearson's correlation coefficient",
+      "lbl" : "obsolete Pearson's correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
@@ -14603,7 +14622,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  "
+          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)"
         }
       }
     }, {
@@ -14834,7 +14853,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable"
+          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -15079,7 +15098,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)."
+          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -15110,7 +15129,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)"
+          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)"
         }
       }
     }, {
@@ -15938,7 +15957,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)."
+          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -15947,7 +15966,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)."
+          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -16381,7 +16400,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)"
+          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -16425,7 +16444,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)"
+          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)"
         }
       }
     }, {
@@ -16469,7 +16488,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)."
+          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -16812,7 +16831,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows."
+          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)"
         }
       }
     }, {
@@ -16861,7 +16880,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)."
+          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)"
         }
       }
     }, {
@@ -16870,7 +16889,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)."
+          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)"
         }
       }
     }, {
@@ -16994,7 +17013,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD."
+          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -17010,17 +17029,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)."
+          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)"
         }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "lbl" : "p-value",
+      "lbl" : "obsolete p-value",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000700"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
@@ -17865,7 +17890,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)."
+          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)"
         }
       }
     }, {
@@ -18208,7 +18233,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching."
+          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)"
         }
       }
     }, {
@@ -18602,7 +18627,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)."
+          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)"
         }
       }
     }, {
@@ -18611,7 +18636,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)."
+          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)"
         }
       }
     }, {
@@ -18687,7 +18712,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)"
+          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)"
         }
       }
     }, {
@@ -18714,7 +18739,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)"
+          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)"
         }
       }
     }, {
@@ -19254,7 +19279,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)"
+          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)"
         }
       }
     }, {
@@ -19281,7 +19306,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)."
+          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -19290,7 +19315,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)."
+          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)"
         }
       }
     }, {
@@ -19477,7 +19502,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process."
+          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19493,7 +19518,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),"
+          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19509,7 +19534,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations."
+          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19658,7 +19683,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)"
+          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)"
         },
         "comments" : [ "AMBER lib format" ],
         "synonyms" : [ {
@@ -20321,12 +20346,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "lbl" : "image bond fixing analysis",
+      "lbl" : "obsolete image bond fixing analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)"
-        }
+          "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
@@ -20420,7 +20446,7 @@
         "definition" : {
           "val" : "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)"
         },
-        "comments" : [ "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
+        "comments" : [ "How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.", "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
@@ -21170,7 +21196,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
+          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -21345,7 +21371,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)."
+          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)"
         }
       }
     }, {
@@ -21354,7 +21380,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)."
+          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)"
         }
       }
     }, {
@@ -21363,7 +21389,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)."
+          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -21372,7 +21398,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)."
+          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)"
         }
       }
     }, {
@@ -21381,7 +21407,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)."
+          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)"
         }
       }
     }, {
@@ -21399,7 +21425,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)."
+          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)"
         }
       }
     }, {
@@ -21408,7 +21434,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)."
+          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)"
         }
       }
     }, {
@@ -21417,7 +21443,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)."
+          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)"
         }
       }
     }, {
@@ -21426,7 +21452,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)."
+          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21435,7 +21461,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -21444,7 +21470,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)."
+          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)"
         }
       }
     }, {
@@ -21453,7 +21479,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)"
         }
       }
     }, {
@@ -21462,7 +21488,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)."
+          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)"
         }
       }
     }, {
@@ -21471,7 +21497,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)."
+          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)"
         }
       }
     }, {
@@ -21480,7 +21506,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)."
+          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)"
         }
       }
     }, {
@@ -21489,7 +21515,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)."
+          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21502,7 +21528,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21515,7 +21541,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)."
+          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21528,7 +21554,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21541,7 +21567,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)."
+          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)"
         }
       }
     }, {
@@ -21550,7 +21576,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)."
+          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)"
         }
       }
     }, {
@@ -21559,7 +21585,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)."
+          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21568,7 +21594,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)."
+          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -21577,7 +21603,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)."
+          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)"
         }
       }
     }, {
@@ -21586,7 +21612,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)."
+          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)"
         }
       }
     }, {
@@ -21595,7 +21621,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)."
+          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)"
         }
       }
     }, {
@@ -21604,7 +21630,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)."
+          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)"
         }
       }
     }, {
@@ -21613,7 +21639,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)."
+          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21622,7 +21648,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)."
+          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)"
         }
       }
     }, {
@@ -21631,7 +21657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)."
+          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)"
         }
       }
     }, {
@@ -21640,7 +21666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)."
+          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)"
         }
       }
     }, {
@@ -21705,7 +21731,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)."
+          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)"
         }
       }
     }, {
@@ -21714,7 +21740,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)."
+          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21727,7 +21753,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)."
+          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21740,7 +21766,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)."
+          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21753,7 +21779,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)."
+          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21766,7 +21792,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)."
+          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21779,7 +21805,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)."
+          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)"
         }
       }
     }, {
@@ -21788,7 +21814,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)"
         }
       }
     }, {
@@ -21797,7 +21823,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -22517,12 +22543,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "lbl" : "small molecule structure (deprecated)",
+      "lbl" : "obsolete small molecule structure",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
@@ -23007,7 +23034,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)."
+          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)"
         }
       }
     }, {
@@ -23016,7 +23043,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)."
+          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)"
         }
       }
     }, {
@@ -23082,7 +23109,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)."
+          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -23954,12 +23981,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "lbl" : "macromolecular structure format (deprecated)",
+      "lbl" : "obsolete macromolecular structure format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
@@ -23976,12 +24004,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "lbl" : "software-specific coordinate format (deprecated)",
+      "lbl" : "obsolete software-specific coordinate format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
@@ -25034,7 +25063,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D."
+          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -25410,7 +25439,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e"
+          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)"
         }
       }
     }, {
@@ -25624,7 +25653,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)"
+          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)"
         }
       }
     }, {
@@ -26892,21 +26921,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "lbl" : "Pearson product-moment correlation coefficient",
+      "lbl" : "obsolete Pearson product-moment correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "lbl" : "Spearman rank correlation coefficient",
+      "lbl" : "obsolete Spearman rank correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000201"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
@@ -26937,21 +26978,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "lbl" : "standard error of the mean (SEM)",
+      "lbl" : "obsolete standard error of the mean (SEM)",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000037"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
-      "lbl" : "coefficient of determination",
+      "lbl" : "obsolete coefficient of determination",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000564"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001411",
@@ -26986,12 +27039,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
-      "lbl" : "standard deviation",
+      "lbl" : "obsolete standard deviation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000237"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001415",
@@ -27668,12 +27727,17 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001484",
-      "lbl" : "statistical model",
+      "lbl" : "statistical mechanics model",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)"
-        }
+          "val" : "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)"
+        },
+        "comments" : [ "Not to be confused with STATO:0000107 \"statistical model\", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; \"statistical model\" is retained as an exact synonym." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "statistical model"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001485",
@@ -27681,7 +27745,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
+          "val" : "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
         }
       }
     }, {
@@ -27690,7 +27754,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
+          "val" : "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -29385,7 +29449,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)"
+          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)"
         }
       }
     }, {
@@ -30167,13 +30231,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "lbl" : "trajectory analysis algorithm (deprecated)",
+      "lbl" : "obsolete trajectory analysis algorithm",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)"
+          "val" : "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations."
         },
-        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ]
+        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
@@ -30284,13 +30349,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "lbl" : "Miller indices (deprecated)",
+      "lbl" : "obsolete Miller indices",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)"
+          "val" : "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model."
         },
-        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ]
+        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
@@ -32570,7 +32636,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)"
+          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)"
         }
       }
     }, {
@@ -32841,7 +32907,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
+          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
         }
       }
     }, {
@@ -33317,7 +33383,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)"
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -33326,7 +33392,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33339,7 +33405,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33438,7 +33504,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)"
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
         }
       }
     }, {
@@ -34491,7 +34557,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second."
+          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34504,7 +34570,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth."
+          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34517,7 +34583,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes."
+          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34530,7 +34596,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities."
+          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34543,7 +34609,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights."
+          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34556,7 +34622,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs."
+          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34569,7 +34635,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density."
+          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)"
         }
       }
     }, {
@@ -34578,7 +34644,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)."
+          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34591,7 +34657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity."
+          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -34600,7 +34666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters."
+          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34613,7 +34679,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector."
+          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)"
         }
       }
     }, {
@@ -34622,7 +34688,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein."
+          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)"
         }
       }
     }, {
@@ -34640,7 +34706,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods."
+          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -34649,7 +34715,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy."
+          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)"
         }
       }
     }, {
@@ -34658,7 +34724,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces."
+          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)"
         }
       }
     }, {
@@ -35430,6 +35496,241 @@
         } ]
       }
     }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000037",
+      "lbl" : "standard error of the mean",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean's estimate of a population mean.\nIt is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.\n\nA measure of dispersion applied to means across hypothetical repeated random samples."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
+          "val" : "http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "SEM"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "SEM"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.sem(a, axis=0, ddof=1)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+          "val" : "https://fevir.net/resources/CodeSystem/27270#STATO:0000037"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000142",
+      "lbl" : "correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "STATO"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "r"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "r statistic"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000201",
+      "lbl" : "Spearman's rank correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "Spearman's rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.\nSpearman's coefficient may be used when the conditions for computing Pearson's correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Spearman's rho"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "cor(x, y = NULL, use = \"everything\",method = c(\"spearman\"))"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.spearmanr(a, b=None, axis=0)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000237",
+      "lbl" : "standard deviation",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "σ"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "http://en.wikipedia.org/wiki/Standard_deviation"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "sd(x, na.rm = FALSE)\n\nhttp://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000280",
+      "lbl" : "Pearson's correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The Pearson's correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. \nThe coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Pearson product-moment correlation coefficient"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Pearson's r"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "r statistics"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "STATO, adapted from\nhttp://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient\nand from:\nhttp://stamash.org/pearsons-correlation-coefficient/\nhttp://stamash.org/kendalls-tau-correlation/"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "cor(x, y = NULL, use = \"everything\",method = c(\"pearson\"))"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.pearsonr(x, y)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000564",
+      "lbl" : "coefficient of determination",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).\nIn the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "r2"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "> eruption.lm = lm(eruptions ~ waiting, data=faithful)\n> summary(eruption.lm)$r.squared \n\n\nfrom:\nhttp://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000700",
+      "lbl" : "p-value",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.\n\nWithin the Bayesian framework, use the posterior predictive p-value."
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "P value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "P-value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "PValue"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "p value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "SEVCO group"
+        } ]
+      }
+    }, {
       "id" : "http://purl.obolibrary.org/obo/UO_0000000",
       "lbl" : "unit",
       "type" : "CLASS",
@@ -36034,7 +36335,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
+          "val" : "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
         }
       }
     }, {
@@ -36847,7 +37148,8 @@
       "meta" : {
         "definition" : {
           "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002125",
@@ -37838,7 +38140,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation"
+          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)"
         }
       }
     }, {
@@ -37910,7 +38212,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry."
+          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)"
         }
       }
     }, {
@@ -37991,7 +38293,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
+          "val" : "Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -38036,7 +38338,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis."
+          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -38154,7 +38456,12 @@
       "meta" : {
         "definition" : {
           "val" : "A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from the class 'model' (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym 'MoDEL database' when matching." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "MoDEL database"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001002",
@@ -38288,7 +38595,14 @@
       "lbl" : "obsolete Omni-Path",
       "type" : "INDIVIDUAL",
       "meta" : {
+        "definition" : {
+          "val" : "OBSOLETE. A redundant untyped individual that duplicated the class 'omni-path' (MOLSIM:001949). It should not be used; use that class instead."
+        },
         "comments" : [ "Obsoleted: redundant untyped individual duplicating the class 'omni-path' (MOLSIM_001949), which is the concept to use instead." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001949"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -38367,6 +38681,96 @@
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000111",
+      "lbl" : "editor preferred term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term~editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000112",
+      "lbl" : "example of usage",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "example"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "example of usage"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000114",
+      "lbl" : "has curation status",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "has curation status"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Alan Ruttenberg"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Bill Bug"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Melanie Courtot"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "OBI_0000281"
+        } ]
+      }
+    }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
       "lbl" : "definition",
       "type" : "PROPERTY",
@@ -38376,11 +38780,55 @@
           "val" : "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "definition"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "textual definition"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "2012-04-05: \nBarry Smith\n\nThe official OBI definition, explaining the meaning of a class or property: 'Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions'  is terrible.\n\nCan you fix to something like:\n\nA statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.\n\nAlan Ruttenberg\n\nYour proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can't be evaluated by those criteria. \n\nOn the specifics of the proposed definition:\n\nWe don't have definitions of 'meaning' or 'expression' or 'property'. For 'reference' in the intended sense I think we use the term 'denotation'. For 'expression', I think we you mean symbol, or identifier. For 'meaning' it differs for class and property. For class we want documentation that let's the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let's the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The 'intended reader' part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. \n\nPersonally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. \n\nWe also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  "
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000116",
+      "lbl" : "editor note",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor note"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obfoundry.org/obo/obi>"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -38393,11 +38841,49 @@
           "val" : "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "term editor"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000118",
+      "lbl" : "alternative term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "alternative term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000125"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -38410,6 +38896,12 @@
           "val" : "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "definition source"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
@@ -38417,7 +38909,77 @@
           "val" : "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000032",
+      "lbl" : "STATO alternative term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "an alternative term used for STATO statistical ontology and ISA team"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000041",
+      "lbl" : "R command",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "a R command syntax or link to a R documentation in support of Statistical Ontology Classes or Data Transformations"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000391",
+      "lbl" : "Python command",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "an annotation property to provide a canonical command to invoke a method implementation using Python programming language"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
         } ]
       }
     }, {
@@ -38537,7 +39099,22 @@
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
+      "id" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
       "id" : "http://www.w3.org/2000/01/rdf-schema#label",
+      "lbl" : "label",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "label"
+        } ]
+      }
+    }, {
+      "id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -40362,14 +40939,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001691"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001352"
@@ -41345,10 +41914,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000353",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000400"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
       "pred" : "is_a",
@@ -42638,10 +43203,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
@@ -43490,10 +44051,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001073"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -44006,17 +44563,9 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001091"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001085"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
       "pred" : "is_a",
@@ -45098,31 +45647,15 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001292"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001407",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001408",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -45135,10 +45668,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001411"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001413",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -46474,10 +47003,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001745"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000037"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001696"
@@ -46521,10 +47046,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001758",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001711"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
       "pred" : "is_a",
@@ -46728,7 +47249,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001810",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001811",
       "pred" : "is_a",
@@ -48397,6 +48918,34 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0100021",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0000839"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000037",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000142",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000201",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000237",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000280",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000564",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000700",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/UO_0000000",
       "pred" : "is_a",

--- a/molsim-full.obo
+++ b/molsim-full.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: molsim/releases/2026-07-24/molsim-full.owl
+data-version: molsim/releases/2026-07-29/molsim-full.owl
 default-namespace: molsim
 idspace: chemrof https://w3id.org/chemrof/ 
 idspace: dce http://purl.org/dc/elements/1.1/ 
@@ -10,6 +10,8 @@ idspace: orcid https://orcid.org/
 idspace: protege http://protege.stanford.edu/plugins/owl/protege# 
 idspace: swrl http://www.w3.org/2003/11/swrl# 
 idspace: swrlb http://www.w3.org/2003/11/swrlb# 
+remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
+remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
 ontology: molsim/molsim-full
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
 property_value: dcterms:contributor orcid:0009-0007-1391-4986
@@ -20,7 +22,7 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-24" xsd:string
+property_value: owl:versionInfo "2026-07-29" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
@@ -3968,6 +3970,7 @@ disjoint_from: MOLSIM:000208 ! thermalization
 id: MOLSIM:000006
 name: model
 def: "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)" []
+comment: Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.
 
 [Term]
 id: MOLSIM:000007
@@ -4178,12 +4181,12 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000037
 name: algorithm
-def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis." []
+def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:000038
 name: thermostat algorithm
-def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
@@ -4191,38 +4194,38 @@ disjoint_from: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000039
 name: barostat algorithm
-def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 
 [Term]
 id: MOLSIM:000040
 name: Berendsen barostat
-def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)." []
+def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000041 ! Monte Carlo barostat
 
 [Term]
 id: MOLSIM:000041
 name: Monte Carlo barostat
-def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)." []
+def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000042
 name: Andersen barostat
-def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)." []
+def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000043
 name: Parrinello-Rahman barostat
-def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)." []
+def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000044
 name: Langevin-piston barostat
-def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)." []
+def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
@@ -4237,46 +4240,46 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000046
 name: Berendsen thermostat
-def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)." []
+def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000047
 name: Andersen thermostat
-def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)." []
+def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000048
 name: Nosé-Hoover thermostat
-def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)." []
+def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)" []
 synonym: "Nose-Hoover" EXACT []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000049
 name: constraint algorithm
-def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 disjoint_from: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000050
 name: SHAKE algorithm
-def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)." []
+def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 disjoint_from: MOLSIM:000051 ! RATTLE algorithm
 
 [Term]
 id: MOLSIM:000051
 name: RATTLE algorithm
-def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)." []
+def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000052
 name: LINCS algorithm
-def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)." []
+def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)" []
 synonym: "LINCS" EXACT []
 synonym: "linear constraint solver algorithm" EXACT []
 is_a: MOLSIM:000049 ! constraint algorithm
@@ -4284,21 +4287,21 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000053
 name: electrostatic interaction algorithm
-def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)." []
+def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)" []
 is_a: MOLSIM:000384 ! force calculation algorithm
 disjoint_from: MOLSIM:001724 ! Treecode algorithm
 
 [Term]
 id: MOLSIM:000054
 name: particle mesh Ewald
-def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)." []
+def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)" []
 synonym: "PME" EXACT []
 is_a: MOLSIM:000428 ! Ewald summation
 
 [Term]
 id: MOLSIM:000055
 name: reaction field
-def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)." []
+def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)" []
 synonym: "RF" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
 disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
@@ -4306,7 +4309,7 @@ disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
 [Term]
 id: MOLSIM:000056
 name: particle-particle particle-mesh
-def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)." []
+def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)" []
 synonym: "P3M" EXACT []
 synonym: "PPPM" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
@@ -4422,32 +4425,32 @@ disjoint_from: MOLSIM:000270 ! Poisson-Boltzmann surface area
 [Term]
 id: MOLSIM:000074
 name: similarity calculation algorithm
-def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)." []
+def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000075
 name: Tanimoto similarity algorithm
-def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)." []
+def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 disjoint_from: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000076
 name: Tversky index algorithm
-def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules." []
+def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000077
 name: Dice coefficient algorithm
-def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)." []
+def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000078
 name: Euclidean distance
-def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)." []
+def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)" []
 is_a: MOLSIM:001403 ! statistical property
 
 [Term]
@@ -4465,100 +4468,100 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:000081
 name: Hamming distance algorithm
-def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)." []
+def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000082
 name: Jaccard index algorithm
-def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)." []
+def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000083
 name: overlap coefficient algorithm
-def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)." []
+def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000084
 name: fit Tversky combo
-def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities." []
+def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 disjoint_from: MOLSIM:000085 ! ref Tversky
 
 [Term]
 id: MOLSIM:000085
 name: ref Tversky
-def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule." []
+def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000086
 name: combo score algorithm
-def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)." []
+def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000087
 name: optimal transformation path algorithm
-def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)." []
+def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)." []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
 
 [Term]
 id: MOLSIM:000089
 name: Prim's algorithm
-def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)." []
+def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000090
 name: Dijkstra's algorithm
-def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)." []
+def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000091
 name: A* search algorithm
-def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)." []
+def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)" []
 synonym: "A-star search algorithm" EXACT []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000092
 name: nearest neighbor algorithm
-def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)." []
+def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000093
 name: genetic algorithm
-def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)." []
+def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000094
 name: simulated annealing algorithm
-def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000095
 name: ant colony optimization algorithm
-def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000096
 name: network flow algorithm
-def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)." []
+def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
@@ -4662,15 +4665,19 @@ disjoint_from: MOLSIM:001692 ! Beeman integrator
 
 [Term]
 id: MOLSIM:000111
-name: correlation coefficient
-def: "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete correlation coefficient
+def: "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.
+is_obsolete: true
+replaced_by: STATO:0000142
 
 [Term]
 id: MOLSIM:000112
-name: Pearson's correlation coefficient
-def: "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson's correlation coefficient
+def: "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:000113
@@ -4755,7 +4762,7 @@ is_a: MOLSIM:000348 ! hypothesis testing analysis
 [Term]
 id: MOLSIM:000125
 name: Kolmogorov-Smirnov test analysis
-def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  " []
+def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)" []
 is_a: MOLSIM:000124 ! statistical test analysis
 
 [Term]
@@ -4901,7 +4908,7 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000148
 name: experimental data availability
-def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable" []
+def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable." []
 is_a: MOLSIM:000143 ! ligand pairs selection criteria
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -5058,7 +5065,7 @@ is_a: MOLSIM:001850 ! modeling and setup tool
 [Term]
 id: MOLSIM:000173
 name: quantum mechanics
-def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)." []
+def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)" []
 synonym: "QM" EXACT []
 is_a: MOLSIM:000141 ! theoretical approach
 
@@ -5081,7 +5088,7 @@ disjoint_from: MOLSIM:000179 ! Q-Chem
 [Term]
 id: MOLSIM:000176
 name: GAMESS
-def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)" []
+def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -5588,13 +5595,13 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000253
 name: clustering algorithm
-def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)." []
+def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000254
 name: hierarchical agglomerative bottom-up algorithm
-def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)." []
+def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000253 ! clustering algorithm
 disjoint_from: MOLSIM:001707 ! DBSCAN clustering algorithm
 
@@ -5860,7 +5867,7 @@ is_a: MOLSIM:000286 ! thermodynamic integration approach
 [Term]
 id: MOLSIM:000294
 name: conveyor belt thermodynamic integration
-def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)" []
+def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)" []
 synonym: "CBTI" EXACT []
 is_a: MOLSIM:000286 ! thermodynamic integration approach
 
@@ -5886,7 +5893,7 @@ is_a: MOLSIM:000355 ! thermodynamic integration analysis
 [Term]
 id: MOLSIM:000299
 name: thermodynamic integration with linear extrapolation
-def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)" []
+def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)" []
 is_a: MOLSIM:000298 ! thermodynamic integration extrapolation approach
 disjoint_from: MOLSIM:000356 ! thermodynamic integration without linear extrapolation
 
@@ -5914,7 +5921,7 @@ is_a: MOLSIM:000300 ! free energy and molecular dynamics analysis
 [Term]
 id: MOLSIM:000303
 name: linear dependence evaluation analysis
-def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)." []
+def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -6122,7 +6129,7 @@ is_a: MOLSIM:000332 ! SCF convergence algorithm
 [Term]
 id: MOLSIM:000334
 name: fit color Tversky
-def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows." []
+def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -6153,13 +6160,13 @@ is_a: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000339
 name: numerical integration
-def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)." []
+def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)" []
 is_a: MOLSIM:000340 ! integration analysis
 
 [Term]
 id: MOLSIM:000340
 name: integration analysis
-def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)." []
+def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -6236,7 +6243,7 @@ is_a: MOLSIM:000400 ! statistical analysis
 [Term]
 id: MOLSIM:000352
 name: binpos format
-def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD." []
+def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)" []
 synonym: ".binpos" EXACT []
 synonym: "Scripps binpos format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
@@ -6244,14 +6251,16 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000353
 name: validation analysis
-def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)." []
+def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000354
-name: p-value
-def: "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete p-value
+def: "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000700
 
 [Term]
 id: MOLSIM:000355
@@ -6755,7 +6764,7 @@ is_a: MOLSIM:000331 ! force field component
 [Term]
 id: MOLSIM:000432
 name: quantum mechanics basis set
-def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)." []
+def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 disjoint_from: MOLSIM:000827 ! Moeller-Plesset
 
@@ -6964,7 +6973,7 @@ is_a: MOLSIM:000257 ! endpoint free energy tool
 [Term]
 id: MOLSIM:000463
 name: ref Tversky combo
-def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching." []
+def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -7218,13 +7227,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000502
 name: linear correlation significance determination analysis
-def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)." []
+def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000503
 name: determination by p-value analysis
-def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)." []
+def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
@@ -7273,7 +7282,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000514
 name: LANL2-[6s4p4d2f]
-def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)" []
+def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7291,7 +7300,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000517
 name: LANL2DZ+2s2p2d2f
-def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)" []
+def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7651,7 +7660,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000577
 name: Ahlrichs pvDZ
-def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)" []
+def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7669,13 +7678,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000580
 name: plane-wave
-def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)." []
+def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
 id: MOLSIM:000581
 name: real-space
-def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)." []
+def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
@@ -7791,7 +7800,7 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000599
 name: AMBER REM log format
-def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process." []
+def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)" []
 synonym: "Amber Replica Exchange Log" EXACT []
 synonym: "rem.log" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7799,7 +7808,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000600
 name: AMBER eigenvector format
-def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj)," []
+def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)" []
 synonym: "evecs.dat" EXACT []
 synonym: "evecs.out" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7807,7 +7816,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000601
 name: cpout format
-def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations." []
+def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)" []
 synonym: ".cpout" EXACT []
 synonym: "AMBER cpout format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7895,7 +7904,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000614
 name: off format
-def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)" []
+def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)" []
 comment: AMBER lib format
 synonym: ".off" EXACT []
 synonym: "AMBER Object File Format" EXACT []
@@ -8309,9 +8318,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 
 [Term]
 id: MOLSIM:000679
-name: image bond fixing analysis
-def: "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)" []
-is_a: MOLSIM:000659 ! periodic boundary imaging
+name: obsolete image bond fixing analysis
+def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000680
@@ -8368,7 +8377,7 @@ is_a: MOLSIM:000448 ! protein database ID
 id: MOLSIM:000688
 name: data source
 def: "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)" []
-comment: TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import
+comment: How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.
 
 [Term]
 id: MOLSIM:000689
@@ -8849,7 +8858,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:000775
 name: CP2K
-def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
+def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -8965,31 +8974,31 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000794
 name: Hoover barostat
-def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)." []
+def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000795
 name: M-SHAKE algorithm
-def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)." []
+def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000796
 name: P-SHAKE algorithm
-def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)." []
+def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000797
 name: SETTLE algorithm
-def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)." []
+def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000798
 name: SHAPE algorithm
-def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)." []
+def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
@@ -9001,76 +9010,76 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000800
 name: Nose thermostat
-def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)." []
+def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000801
 name: Nose-Poincare thermostat
-def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)." []
+def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000802
 name: V-rescale thermostat
-def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)." []
+def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000803
 name: semi-empirical method
-def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)." []
+def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000804
 name: all-valence-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 disjoint_from: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000805
 name: PPP
-def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)." []
+def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)" []
 is_a: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000806
 name: pi-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 
 [Term]
 id: MOLSIM:000807
 name: AM1
-def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)." []
+def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 disjoint_from: MOLSIM:000808 ! CNDO/2
 
 [Term]
 id: MOLSIM:000808
 name: CNDO/2
-def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)." []
+def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000809
 name: INDO
-def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)." []
+def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000810
 name: Hartree-Fock
-def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)." []
+def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)" []
 synonym: "HF" EXACT []
 is_a: MOLSIM:000685 ! ab-initio method
 
 [Term]
 id: MOLSIM:000812
 name: restricted open-shell Hartree-Fock
-def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "ROHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 disjoint_from: MOLSIM:000813 ! self-consistent field
@@ -9078,88 +9087,88 @@ disjoint_from: MOLSIM:000813 ! self-consistent field
 [Term]
 id: MOLSIM:000813
 name: self-consistent field
-def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)." []
+def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)" []
 synonym: "SCF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000814
 name: Unrestricted Hartree-Fock
-def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "UHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000815
 name: MINDO
-def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)." []
+def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)" []
 is_a: MOLSIM:000809 ! INDO
 
 [Term]
 id: MOLSIM:000816
 name: MNDO
-def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)." []
+def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000817
 name: NDDO
-def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)." []
+def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 disjoint_from: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000818
 name: PDDG
-def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)." []
+def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000819
 name: PM3
-def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)." []
+def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000820
 name: PM3MM
-def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)." []
+def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000821
 name: PM6
-def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)." []
+def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000822
 name: RM1
-def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)." []
+def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000823
 name: SAM1
-def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)." []
+def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000824
 name: SINDO
-def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)." []
+def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000825
 name: Sparkle/AM1
-def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)." []
+def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)" []
 is_a: MOLSIM:000807 ! AM1
 
 [Term]
 id: MOLSIM:000826
 name: ZANDO
-def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)." []
+def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
@@ -9201,13 +9210,13 @@ is_a: MOLSIM:000827 ! Moeller-Plesset
 [Term]
 id: MOLSIM:000832
 name: multi-reference
-def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)." []
+def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000833
 name: complete active space self-consistent field
-def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)." []
+def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)" []
 synonym: "CASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
@@ -9215,48 +9224,48 @@ disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
 [Term]
 id: MOLSIM:000834
 name: multi-configurational self-consistent field
-def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)." []
+def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)" []
 synonym: "MC-SCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000835
 name: multi-reference coupled cluster with single and double excitations
-def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)." []
+def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)" []
 synonym: "MR-CCSD" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000836
 name: multi-reference configuration interaction with single and double excitations
-def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)." []
+def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)" []
 synonym: "MR-CI(SD)" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000837
 name: restricted active space self-consistent field
-def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)." []
+def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)" []
 synonym: "RASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000838
 name: quadratic configuration interaction
-def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)." []
+def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000839
 name: QCISD(T)
-def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 disjoint_from: MOLSIM:000840 ! QCISD
 
 [Term]
 id: MOLSIM:000840
 name: QCISD
-def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 
 [Term]
@@ -9683,9 +9692,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:000905
-name: small molecule structure (deprecated)
-def: "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete small molecule structure
+def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000906
@@ -9988,14 +9997,14 @@ is_a: MOLSIM:000984 ! distribution analysis
 [Term]
 id: MOLSIM:000978
 name: conformation validation analysis
-def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)." []
+def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 disjoint_from: MOLSIM:000981 ! secondary structure assignment analysis
 
 [Term]
 id: MOLSIM:000979
 name: ramachandran analysis
-def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)." []
+def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)" []
 is_a: MOLSIM:000917 ! structural analysis
 disjoint_from: MOLSIM:000980 ! structural check analysis
 
@@ -10035,7 +10044,7 @@ is_a: MOLSIM:000974 ! solvent analysis
 [Term]
 id: MOLSIM:000985
 name: matrix diagonalization analysis
-def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)." []
+def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -10548,9 +10557,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 
 [Term]
 id: MOLSIM:001087
-name: macromolecular structure format (deprecated)
-def: "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete macromolecular structure format
+def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001088
@@ -10561,9 +10570,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001089
-name: software-specific coordinate format (deprecated)
-def: "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete software-specific coordinate format
+def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001090
@@ -11213,7 +11222,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001234
 name: GaMD potential boost stddev limit
-def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D." []
+def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D." []
 is_a: MOLSIM:001233 ! Gaussian accelerated MD parameter
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -11442,7 +11451,7 @@ is_a: MOLSIM:001268 ! volumetric analysis parameter
 [Term]
 id: MOLSIM:001270
 name: grid function
-def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e" []
+def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)" []
 is_a: MOLSIM:001268 ! volumetric analysis parameter
 
 [Term]
@@ -11578,7 +11587,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001292
 name: computed observable
-def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)" []
+def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:001293
@@ -12319,21 +12328,25 @@ is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:001404
-name: Pearson product-moment correlation coefficient
-def: "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson product-moment correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages." []
+comment: Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:001405
-name: Spearman rank correlation coefficient
-def: "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Spearman rank correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.
+is_obsolete: true
+replaced_by: STATO:0000201
 
 [Term]
 id: MOLSIM:001406
 name: Kendall tau correlation coefficient
 def: "A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall's tau. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142 ! correlation coefficient
 
 [Term]
 id: MOLSIM:001407
@@ -12349,15 +12362,19 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001409
-name: standard error of the mean (SEM)
-def: "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard error of the mean (SEM)
+def: "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation.
+is_obsolete: true
+replaced_by: STATO:0000037
 
 [Term]
 id: MOLSIM:001410
-name: coefficient of determination
-def: "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete coefficient of determination
+def: "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000564
 
 [Term]
 id: MOLSIM:001411
@@ -12380,9 +12397,11 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001414
-name: standard deviation
-def: "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard deviation
+def: "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000237
 
 [Term]
 id: MOLSIM:001415
@@ -12816,21 +12835,23 @@ is_a: MOLSIM:000007 ! force field
 
 [Term]
 id: MOLSIM:001484
-name: statistical model
-def: "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)" []
+name: statistical mechanics model
+def: "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)" []
+comment: Not to be confused with STATO:0000107 "statistical model", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; "statistical model" is retained as an exact synonym.
+synonym: "statistical model" EXACT []
 is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:001485
 name: Maxwell-Boltzmann distribution
-def: "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
-is_a: MOLSIM:001484 ! statistical model
+def: "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
+is_a: MOLSIM:001484 ! statistical mechanics model
 
 [Term]
 id: MOLSIM:001486
 name: two-state transition model
-def: "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
-is_a: MOLSIM:001484 ! statistical model
+def: "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
+is_a: MOLSIM:001484 ! statistical mechanics model
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -13930,7 +13951,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:001666
 name: metatwist
-def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)" []
+def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)" []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
@@ -14441,10 +14462,10 @@ disjoint_from: MOLSIM:010012 ! STRIDE algorithm
 
 [Term]
 id: MOLSIM:001747
-name: trajectory analysis algorithm (deprecated)
-def: "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)" []
+name: obsolete trajectory analysis algorithm
+def: "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations." []
 comment: candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21
-is_a: MOLSIM:000037 ! algorithm
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001748
@@ -14517,10 +14538,10 @@ is_a: MOLSIM:001711 ! residue library
 
 [Term]
 id: MOLSIM:001759
-name: Miller indices (deprecated)
-def: "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)" []
+name: obsolete Miller indices
+def: "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model." []
 comment: Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26
-is_a: MOLSIM:000447 ! identifier
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001760
@@ -14838,7 +14859,7 @@ is_a: MOLSIM:001403 ! statistical property
 id: MOLSIM:001810
 name: RMS average correlation
 def: "The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system's dynamics, with a higher value indicating that the molecule's motions are more concerted. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142 ! correlation coefficient
 
 [Term]
 id: MOLSIM:001811
@@ -15901,7 +15922,7 @@ is_a: MOLSIM:000172 ! topology and parameterization tool
 [Term]
 id: MOLSIM:001973
 name: AMBERGS
-def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)" []
+def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)" []
 is_a: MOLSIM:000009 ! protein force field
 
 [Term]
@@ -16077,7 +16098,7 @@ is_a: MOLSIM:001515 ! Lennard-Jones parameters
 [Term]
 id: MOLSIM:002001
 name: repulsion interaction parameter
-def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
+def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
 is_a: MOLSIM:001515 ! Lennard-Jones parameters
 
 [Term]
@@ -16377,20 +16398,20 @@ is_a: MOLSIM:001566 ! library
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
@@ -16441,7 +16462,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
@@ -17112,81 +17133,81 @@ is_a: MOLSIM:002162 ! system classification label
 [Term]
 id: MOLSIM:010001
 name: femtosecond
-def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second." []
+def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)" []
 synonym: "fs" EXACT []
 is_a: UO:1000010 ! second based unit
 
 [Term]
 id: MOLSIM:010002
 name: atmosphere
-def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth." []
+def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)" []
 synonym: "atm" EXACT []
 is_a: UO:0000109 ! pressure unit
 
 [Term]
 id: MOLSIM:010003
 name: angstrom per nanosecond
-def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes." []
+def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)" []
 synonym: "Å/ns|angstrom/nanosecond" EXACT []
 is_a: UO:0000060 ! speed/velocity unit
 
 [Term]
 id: MOLSIM:010004
 name: kilocalorie per mole
-def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities." []
+def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)" []
 synonym: "kcal/mol|kilocalorie/mole" EXACT []
 is_a: UO:0000111 ! energy unit
 
 [Term]
 id: MOLSIM:010005
 name: kilocalorie per mole per square angstrom
-def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights." []
+def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)" []
 synonym: "kcal/mol/Å^2|kilocalorie/mole/angstrom^2" EXACT []
 is_a: UO:0000111 ! energy unit
 
 [Term]
 id: MOLSIM:010006
 name: elementary charge
-def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs." []
+def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)" []
 synonym: "e" EXACT []
 is_a: UO:0000219 ! electric charge
 
 [Term]
 id: MOLSIM:010007
 name: kinematic viscosity unit
-def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density." []
+def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)" []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MOLSIM:010008
 name: square centimeter per second
-def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)." []
+def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)" []
 synonym: "cm^2/s|stokes|St" EXACT []
 is_a: MOLSIM:010007 ! kinematic viscosity unit
 
 [Term]
 id: MOLSIM:010009
 name: electric dipole moment unit
-def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity." []
+def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)" []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MOLSIM:010010
 name: debye
-def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters." []
+def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)" []
 synonym: "D" EXACT []
 is_a: MOLSIM:010009 ! electric dipole moment unit
 
 [Term]
 id: MOLSIM:010011
 name: Kabsch RMSD algorithm
-def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector." []
+def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)" []
 is_a: MOLSIM:001717 ! RMSD calculation algorithm
 
 [Term]
 id: MOLSIM:010012
 name: STRIDE algorithm
-def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein." []
+def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)" []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 
 [Term]
@@ -17198,19 +17219,19 @@ is_a: MOLSIM:001751 ! statistical algorithm
 [Term]
 id: MOLSIM:010014
 name: parametric distribution fitting algorithm
-def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods." []
+def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010015
 name: spline-based estimation algorithm
-def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy." []
+def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010016
 name: Shrake-Rupley algorithm
-def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces." []
+def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)" []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
 
 [Term]
@@ -17566,6 +17587,104 @@ def: "A subsection of sequence with biological interest that is conserved in dif
 subset: biosapiens
 synonym: "polypeptide conserved region" EXACT []
 is_a: SO:0000839 ! polypeptide_region
+
+[Term]
+id: STATO:0000037
+name: standard error of the mean
+def: "The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean's estimate of a population mean.\nIt is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.\n\nA measure of dispersion applied to means across hypothetical repeated random samples." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000112 "http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct" xsd:string
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "SEM" xsd:string
+property_value: IAO:0000119 "adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)" xsd:string
+property_value: seeAlso "https://fevir.net/resources/CodeSystem/27270#STATO:0000037" xsd:string
+property_value: STATO:0000032 "SEM" xsd:string
+property_value: STATO:0000391 "scipy.stats.sem(a, axis=0, ddof=1)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928" xsd:string
+
+[Term]
+id: STATO:0000142
+name: correlation coefficient
+def: "The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000119 "STATO" xsd:string
+property_value: STATO:0000032 "r" xsd:string
+property_value: STATO:0000032 "r statistic" xsd:string
+
+[Term]
+id: STATO:0000201
+name: Spearman's rank correlation coefficient
+def: "Spearman's rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.\nSpearman's coefficient may be used when the conditions for computing Pearson's correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables" []
+is_a: STATO:0000142 ! correlation coefficient
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "Spearman's rho" xsd:string
+property_value: IAO:0000119 "http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "cor(x, y = NULL, use = \"everything\",method = c(\"spearman\"))" xsd:string
+property_value: STATO:0000391 "scipy.stats.spearmanr(a, b=None, axis=0)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643" xsd:string
+
+[Term]
+id: STATO:0000237
+name: standard deviation
+def: "The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "σ" xsd:string
+property_value: IAO:0000119 "http://en.wikipedia.org/wiki/Standard_deviation" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "sd(x, na.rm = FALSE)\n\nhttp://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html" xsd:string
+
+[Term]
+id: STATO:0000280
+name: Pearson's correlation coefficient
+def: "The Pearson's correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. \nThe coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related." []
+is_a: STATO:0000142 ! correlation coefficient
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "Pearson product-moment correlation coefficient" xsd:string
+property_value: IAO:0000118 "Pearson's r" xsd:string
+property_value: IAO:0000118 "r statistics" xsd:string
+property_value: IAO:0000119 "STATO, adapted from\nhttp://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient\nand from:\nhttp://stamash.org/pearsons-correlation-coefficient/\nhttp://stamash.org/kendalls-tau-correlation/" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "cor(x, y = NULL, use = \"everything\",method = c(\"pearson\"))" xsd:string
+property_value: STATO:0000041 "http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html" xsd:string
+property_value: STATO:0000391 "scipy.stats.pearsonr(x, y)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427" xsd:string
+
+[Term]
+id: STATO:0000564
+name: coefficient of determination
+def: "The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).\nIn the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000118 "r2" xsd:string
+property_value: STATO:0000041 "> eruption.lm = lm(eruptions ~ waiting, data=faithful)\n> summary(eruption.lm)$r.squared \n\n\nfrom:\nhttp://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination" xsd:string
+
+[Term]
+id: STATO:0000700
+name: p-value
+def: "A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000116 "Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.\n\nWithin the Bayesian framework, use the posterior predictive p-value." xsd:string
+property_value: IAO:0000118 "P value" xsd:string
+property_value: IAO:0000118 "p value" xsd:string
+property_value: IAO:0000118 "P-value" xsd:string
+property_value: IAO:0000118 "PValue" xsd:string
+property_value: IAO:0000119 "SEVCO group" xsd:string
 
 [Term]
 id: UO:0000000
@@ -17941,7 +18060,7 @@ range: MOLSIM:000001 ! software
 [Typedef]
 id: MOLSIM:000508
 name: protein structure source
-def: "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
+def: "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
 domain: MOLSIM:000904 ! molecular structure
 range: MOLSIM:000688 ! data source
 

--- a/molsim-full.owl
+++ b/molsim-full.owl
@@ -17,7 +17,7 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim/molsim-full.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim-full.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-full.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
@@ -28,7 +28,9 @@
         <dcterms:subject xml:lang="en">biomolecular simulation</dcterms:subject>
         <dcterms:title>Molecular Simulation Ontology</dcterms:title>
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
-        <owl:versionInfo>2026-07-24</owl:versionInfo>
+        <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
+        <owl:versionInfo>2026-07-29</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -51,14 +53,99 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000111>editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term~editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+        <obo:IAO_0000111 xml:lang="en">example</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">example of usage</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">example of usage</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
+        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
+        <obo:IAO_0000111>textual definition</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2012-04-05: 
+Barry Smith
+
+The official OBI definition, explaining the meaning of a class or property: &apos;Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions&apos;  is terrible.
+
+Can you fix to something like:
+
+A statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.
+
+Alan Ruttenberg
+
+Your proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can&apos;t be evaluated by those criteria. 
+
+On the specifics of the proposed definition:
+
+We don&apos;t have definitions of &apos;meaning&apos; or &apos;expression&apos; or &apos;property&apos;. For &apos;reference&apos; in the intended sense I think we use the term &apos;denotation&apos;. For &apos;expression&apos;, I think we you mean symbol, or identifier. For &apos;meaning&apos; it differs for class and property. For class we want documentation that let&apos;s the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let&apos;s the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The &apos;intended reader&apos; part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. 
+
+Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
+
+We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  </obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label>definition</rdfs:label>
         <rdfs:label xml:lang="en">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
+        <obo:IAO_0000111 xml:lang="en">editor note</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obfoundry.org/obo/obi&gt;</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obofoundry.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor note</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -66,10 +153,28 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
+        <obo:IAO_0000111 xml:lang="en">term editor</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">term editor</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+        <obo:IAO_0000111 xml:lang="en">alternative term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">alternative term</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -77,11 +182,57 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+        <obo:IAO_0000111 xml:lang="en">definition source</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119>Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">definition source</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000032 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000032">
+        <obo:IAO_0000115 xml:lang="en">an alternative term used for STATO statistical ontology and ISA team</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">STATO alternative term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000041 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000041">
+        <obo:IAO_0000115 xml:lang="en">a R command syntax or link to a R documentation in support of Statistical Ontology Classes or Data Transformations</obo:IAO_0000115>
+        <obo:IAO_0000117>Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">R command</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000391 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000391">
+        <obo:IAO_0000115 xml:lang="en">an annotation property to provide a canonical command to invoke a method implementation using Python programming language</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">Python command</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -255,9 +406,24 @@
     
 
 
+    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+    
+
+
     <!-- http://www.w3.org/2000/01/rdf-schema#label -->
 
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+        <obo:IAO_0000111>label</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
     
 
 
@@ -468,7 +634,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000904"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000688"/>
-        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein structure source</rdfs:label>
     </owl:ObjectProperty>
     
@@ -1397,7 +1563,9 @@
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -15834,6 +16002,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000006">
         <obo:IAO_0000115 xml:lang="en">A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system&apos;s behavior. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Distinct from &apos;MoDEL&apos; (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.</rdfs:comment>
         <rdfs:label xml:lang="en">model</rdfs:label>
     </owl:Class>
     
@@ -16158,7 +16327,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000037">
-        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">algorithm</rdfs:label>
     </owl:Class>
     
@@ -16168,7 +16337,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000038">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -16178,7 +16347,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">barostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -16188,7 +16357,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen barostat</rdfs:label>
     </owl:Class>
     
@@ -16198,7 +16367,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Monte Carlo barostat</rdfs:label>
     </owl:Class>
     
@@ -16208,7 +16377,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen barostat</rdfs:label>
     </owl:Class>
     
@@ -16218,7 +16387,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Parrinello-Rahman barostat</rdfs:label>
     </owl:Class>
     
@@ -16228,7 +16397,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000044">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Langevin-piston barostat</rdfs:label>
     </owl:Class>
     
@@ -16249,7 +16418,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000046">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen thermostat</rdfs:label>
     </owl:Class>
     
@@ -16259,7 +16428,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000047">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen thermostat</rdfs:label>
     </owl:Class>
     
@@ -16269,7 +16438,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000048">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Nose-Hoover</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Nosé-Hoover thermostat</rdfs:label>
     </owl:Class>
@@ -16280,7 +16449,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">constraint algorithm</rdfs:label>
     </owl:Class>
     
@@ -16290,7 +16459,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -16300,7 +16469,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RATTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -16310,7 +16479,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000052">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">LINCS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">linear constraint solver algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">LINCS algorithm</rdfs:label>
@@ -16323,7 +16492,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000053">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000384"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001724"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">electrostatic interaction algorithm</rdfs:label>
     </owl:Class>
     
@@ -16333,7 +16502,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000054">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000428"/>
-        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">PME</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle mesh Ewald</rdfs:label>
     </owl:Class>
@@ -16344,7 +16513,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000055">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">reaction field</rdfs:label>
     </owl:Class>
@@ -16355,7 +16524,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000056">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">P3M</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">PPPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle-particle particle-mesh</rdfs:label>
@@ -16539,7 +16708,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000074">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">similarity calculation algorithm</rdfs:label>
     </owl:Class>
     
@@ -16549,7 +16718,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000075">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tanimoto similarity algorithm</rdfs:label>
     </owl:Class>
     
@@ -16559,7 +16728,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16569,7 +16738,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000077">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dice coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -16579,7 +16748,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000078">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Euclidean distance</rdfs:label>
     </owl:Class>
     
@@ -16609,7 +16778,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000081">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hamming distance algorithm</rdfs:label>
     </owl:Class>
     
@@ -16619,7 +16788,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000082">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Jaccard index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16629,7 +16798,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000083">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">overlap coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -16639,7 +16808,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000084">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -16649,7 +16818,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000085">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky</rdfs:label>
     </owl:Class>
     
@@ -16659,7 +16828,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000086">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">combo score algorithm</rdfs:label>
     </owl:Class>
     
@@ -16669,7 +16838,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000087">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">optimal transformation path algorithm</rdfs:label>
     </owl:Class>
     
@@ -16679,7 +16848,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16689,7 +16858,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000089">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Prim&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16699,7 +16868,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000090">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dijkstra&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16709,7 +16878,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000091">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">A-star search algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">A* search algorithm</rdfs:label>
     </owl:Class>
@@ -16720,7 +16889,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000092">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nearest neighbor algorithm</rdfs:label>
     </owl:Class>
     
@@ -16730,7 +16899,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">genetic algorithm</rdfs:label>
     </owl:Class>
     
@@ -16740,7 +16909,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000094">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulated annealing algorithm</rdfs:label>
     </owl:Class>
     
@@ -16750,7 +16919,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000095">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ant colony optimization algorithm</rdfs:label>
     </owl:Class>
     
@@ -16760,7 +16929,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000096">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">network flow algorithm</rdfs:label>
     </owl:Class>
     
@@ -16921,9 +17090,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000111 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000111">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16931,9 +17102,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000112 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000112">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson&apos;s correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson&apos;s correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17070,7 +17243,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000125">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000124"/>
-        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  </obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kolmogorov-Smirnov test analysis</rdfs:label>
     </owl:Class>
     
@@ -17306,7 +17479,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000148">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000143"/>
-        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">experimental data availability</rdfs:label>
     </owl:Class>
@@ -17561,7 +17734,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000173">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000141"/>
-        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">QM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">quantum mechanics</rdfs:label>
     </owl:Class>
@@ -17592,7 +17765,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000176">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">GAMESS</rdfs:label>
     </owl:Class>
     
@@ -18400,7 +18573,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000253">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">clustering algorithm</rdfs:label>
     </owl:Class>
     
@@ -18410,7 +18583,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000254">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000253"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hierarchical agglomerative bottom-up algorithm</rdfs:label>
     </owl:Class>
     
@@ -18831,7 +19004,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000294">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000286"/>
-        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CBTI</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">conveyor belt thermodynamic integration</rdfs:label>
     </owl:Class>
@@ -18874,7 +19047,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000299">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000298"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000356"/>
-        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermodynamic integration with linear extrapolation</rdfs:label>
     </owl:Class>
     
@@ -18917,7 +19090,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000303">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear dependence evaluation analysis</rdfs:label>
     </owl:Class>
     
@@ -19246,7 +19419,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit color Tversky</rdfs:label>
     </owl:Class>
     
@@ -19297,7 +19470,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000340"/>
-        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">numerical integration</rdfs:label>
     </owl:Class>
     
@@ -19307,7 +19480,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">integration analysis</rdfs:label>
     </owl:Class>
     
@@ -19432,7 +19605,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.binpos</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">Scripps binpos format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">binpos format</rdfs:label>
@@ -19444,7 +19617,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">validation analysis</rdfs:label>
     </owl:Class>
     
@@ -19453,9 +19626,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000354 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000354">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">p-value</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000700"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete p-value</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20270,7 +20445,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quantum mechanics basis set</rdfs:label>
     </owl:Class>
     
@@ -20596,7 +20771,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -20999,7 +21174,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear correlation significance determination analysis</rdfs:label>
     </owl:Class>
     
@@ -21009,7 +21184,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">determination by p-value analysis</rdfs:label>
     </owl:Class>
     
@@ -21090,7 +21265,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2-[6s4p4d2f]</rdfs:label>
     </owl:Class>
     
@@ -21120,7 +21295,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2DZ+2s2p2d2f</rdfs:label>
     </owl:Class>
     
@@ -21720,7 +21895,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000577">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Ahlrichs pvDZ</rdfs:label>
     </owl:Class>
     
@@ -21750,7 +21925,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000580">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">plane-wave</rdfs:label>
     </owl:Class>
     
@@ -21760,7 +21935,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000581">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">real-space</rdfs:label>
     </owl:Class>
     
@@ -21947,7 +22122,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000599">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Amber Replica Exchange Log</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">rem.log</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER REM log format</rdfs:label>
@@ -21959,7 +22134,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000600">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.dat</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.out</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER eigenvector format</rdfs:label>
@@ -21971,7 +22146,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000601">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.cpout</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER cpout format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">cpout format</rdfs:label>
@@ -22110,7 +22285,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000614">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">.off</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER Object File Format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER off format</oboInOwl:hasExactSynonym>
@@ -22782,9 +22957,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000679 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
-        <obo:IAO_0000115 xml:lang="en">Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">image bond fixing analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22876,6 +23051,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000688">
         <obo:IAO_0000115 xml:lang="en">Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.</rdfs:comment>
         <rdfs:comment xml:lang="en">TODO:may be be replacable with IAO&apos;s information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import</rdfs:comment>
         <rdfs:label xml:lang="en">data source</rdfs:label>
     </owl:Class>
@@ -23652,7 +23828,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000775">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CP2K</rdfs:label>
     </owl:Class>
     
@@ -23843,7 +24019,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000794">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hoover barostat</rdfs:label>
     </owl:Class>
     
@@ -23853,7 +24029,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">M-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23863,7 +24039,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000796">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">P-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23873,7 +24049,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000797">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SETTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23883,7 +24059,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000798">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAPE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23903,7 +24079,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000800">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose thermostat</rdfs:label>
     </owl:Class>
     
@@ -23913,7 +24089,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000801">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose-Poincare thermostat</rdfs:label>
     </owl:Class>
     
@@ -23923,7 +24099,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000802">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">V-rescale thermostat</rdfs:label>
     </owl:Class>
     
@@ -23933,7 +24109,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000803">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">semi-empirical method</rdfs:label>
     </owl:Class>
     
@@ -23944,7 +24120,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000804">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">all-valence-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -23954,7 +24130,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000805">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PPP</rdfs:label>
     </owl:Class>
     
@@ -23964,7 +24140,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000806">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">pi-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -23974,7 +24150,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000807">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AM1</rdfs:label>
     </owl:Class>
     
@@ -23984,7 +24160,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000808">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CNDO/2</rdfs:label>
     </owl:Class>
     
@@ -23994,7 +24170,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000809">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">INDO</rdfs:label>
     </owl:Class>
     
@@ -24004,7 +24180,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000810">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000685"/>
-        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">HF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24015,7 +24191,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000812">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">ROHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted open-shell Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24026,7 +24202,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000813">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">self-consistent field</rdfs:label>
     </owl:Class>
@@ -24037,7 +24213,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000814">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">UHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Unrestricted Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24048,7 +24224,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000815">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000809"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MINDO</rdfs:label>
     </owl:Class>
     
@@ -24058,7 +24234,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000816">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MNDO</rdfs:label>
     </owl:Class>
     
@@ -24068,7 +24244,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000817">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NDDO</rdfs:label>
     </owl:Class>
     
@@ -24078,7 +24254,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000818">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDDG</rdfs:label>
     </owl:Class>
     
@@ -24088,7 +24264,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000819">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3</rdfs:label>
     </owl:Class>
     
@@ -24098,7 +24274,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000820">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3MM</rdfs:label>
     </owl:Class>
     
@@ -24108,7 +24284,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000821">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM6</rdfs:label>
     </owl:Class>
     
@@ -24118,7 +24294,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000822">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RM1</rdfs:label>
     </owl:Class>
     
@@ -24128,7 +24304,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000823">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SAM1</rdfs:label>
     </owl:Class>
     
@@ -24138,7 +24314,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000824">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SINDO</rdfs:label>
     </owl:Class>
     
@@ -24148,7 +24324,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000825">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000807"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Sparkle/AM1</rdfs:label>
     </owl:Class>
     
@@ -24158,7 +24334,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000826">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ZANDO</rdfs:label>
     </owl:Class>
     
@@ -24223,7 +24399,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000832">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-reference</rdfs:label>
     </owl:Class>
     
@@ -24233,7 +24409,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000833">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">complete active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -24244,7 +24420,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000834">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">MC-SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-configurational self-consistent field</rdfs:label>
     </owl:Class>
@@ -24255,7 +24431,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000835">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CCSD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference coupled cluster with single and double excitations</rdfs:label>
     </owl:Class>
@@ -24266,7 +24442,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000836">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CI(SD)</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference configuration interaction with single and double excitations</rdfs:label>
     </owl:Class>
@@ -24277,7 +24453,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000837">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -24288,7 +24464,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000838">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quadratic configuration interaction</rdfs:label>
     </owl:Class>
     
@@ -24299,7 +24475,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000839">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000840"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD(T)</rdfs:label>
     </owl:Class>
     
@@ -24309,7 +24485,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000840">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD</rdfs:label>
     </owl:Class>
     
@@ -24994,9 +25170,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000905 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">small molecule structure (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -25487,7 +25663,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000978">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000981"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">conformation validation analysis</rdfs:label>
     </owl:Class>
     
@@ -25498,7 +25674,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000979">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000980"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ramachandran analysis</rdfs:label>
     </owl:Class>
     
@@ -25561,7 +25737,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000985">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">matrix diagonalization analysis</rdfs:label>
     </owl:Class>
     
@@ -26378,9 +26554,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001087 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">macromolecular structure format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26399,9 +26575,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001089 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">software-specific coordinate format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -27473,7 +27649,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001233"/>
-        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">GaMD potential boost stddev limit</rdfs:label>
     </owl:Class>
@@ -27846,7 +28022,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001270">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001268"/>
-        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">grid function</rdfs:label>
     </owl:Class>
     
@@ -28069,7 +28245,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001292 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001292">
-        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computed observable</rdfs:label>
     </owl:Class>
     
@@ -29259,9 +29435,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001404 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001404">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson product-moment correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - &apos;Pearson product-moment correlation coefficient&apos; is the full formal name of Pearson&apos;s correlation coefficient. Replaced by the reused STATO term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson product-moment correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29269,9 +29447,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001405 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001405">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Spearman rank correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000201"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM&apos;s (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson&apos;s). Note the symbol &apos;rho&apos; named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Spearman rank correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29279,7 +29459,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001406 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001406">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall&apos;s tau. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kendall tau correlation coefficient</rdfs:label>
     </owl:Class>
@@ -29309,9 +29489,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001409 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001409">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard error of the mean (SEM)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000037"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the &apos;(SEM)&apos; abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO&apos;s own definition spells out the abbreviation.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard error of the mean (SEM)</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29319,9 +29501,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001410 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001410">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">coefficient of determination</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000564"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete coefficient of determination</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29360,9 +29544,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001414 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001414">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000237"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard deviation</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -30074,8 +30260,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">statistical model</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">statistical model</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Not to be confused with STATO:0000107 &quot;statistical model&quot;, which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; &quot;statistical model&quot; is retained as an exact synonym.</rdfs:comment>
+        <rdfs:label xml:lang="en">statistical mechanics model</rdfs:label>
     </owl:Class>
     
 
@@ -30084,7 +30272,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Maxwell-Boltzmann distribution</rdfs:label>
     </owl:Class>
     
@@ -30094,7 +30282,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">two-state transition model</rdfs:label>
     </owl:Class>
@@ -31907,7 +32095,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001666">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
-        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metatwist</rdfs:label>
     </owl:Class>
     
@@ -32734,10 +32922,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001747 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations.</obo:IAO_0000115>
         <rdfs:comment>candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21</rdfs:comment>
-        <rdfs:label xml:lang="en">trajectory analysis algorithm (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete trajectory analysis algorithm</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -32857,10 +33045,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001759 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001759">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26</rdfs:comment>
-        <rdfs:label xml:lang="en">Miller indices (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete Miller indices</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33380,7 +33568,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001810 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001810">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system&apos;s dynamics, with a higher value indicating that the molecule&apos;s motions are more concerted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RMS average correlation</rdfs:label>
     </owl:Class>
@@ -35088,7 +35276,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001973">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERGS</rdfs:label>
     </owl:Class>
     
@@ -35375,9 +35563,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001515"/>
-        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the 
-C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 
-1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">repulsion interaction parameter</rdfs:label>
     </owl:Class>
     
@@ -35868,7 +36054,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -35878,7 +36064,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -35889,7 +36075,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -35969,7 +36155,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -37063,7 +37249,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_1000010"/>
-        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second.</obo:IAO_0000115>
+        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>fs</oboInOwl:hasExactSynonym>
         <rdfs:label>femtosecond</rdfs:label>
     </owl:Class>
@@ -37074,7 +37260,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000109"/>
-        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>atm</oboInOwl:hasExactSynonym>
         <rdfs:label>atmosphere</rdfs:label>
     </owl:Class>
@@ -37085,7 +37271,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000060"/>
-        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>Å/ns|angstrom/nanosecond</oboInOwl:hasExactSynonym>
         <rdfs:label>angstrom per nanosecond</rdfs:label>
     </owl:Class>
@@ -37096,7 +37282,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010004">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol|kilocalorie/mole</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole</rdfs:label>
     </owl:Class>
@@ -37107,7 +37293,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol/Å^2|kilocalorie/mole/angstrom^2</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole per square angstrom</rdfs:label>
     </owl:Class>
@@ -37118,7 +37304,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000219"/>
-        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>e</oboInOwl:hasExactSynonym>
         <rdfs:label>elementary charge</rdfs:label>
     </owl:Class>
@@ -37129,7 +37315,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>kinematic viscosity unit</rdfs:label>
     </owl:Class>
     
@@ -37139,7 +37325,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010007"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St).</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>cm^2/s|stokes|St</oboInOwl:hasExactSynonym>
         <rdfs:label>square centimeter per second</rdfs:label>
     </owl:Class>
@@ -37150,7 +37336,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>electric dipole moment unit</rdfs:label>
     </owl:Class>
     
@@ -37160,7 +37346,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010010">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010009"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters.</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>D</oboInOwl:hasExactSynonym>
         <rdfs:label>debye</rdfs:label>
     </owl:Class>
@@ -37171,7 +37357,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -37181,7 +37367,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein.</obo:IAO_0000115>
+        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -37201,7 +37387,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -37211,7 +37397,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -37221,7 +37407,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Shrake-Rupley algorithm</rdfs:label>
     </owl:Class>
     
@@ -37932,6 +38118,166 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
         <owl:annotatedTarget>A subsection of sequence with biological interest that is conserved in different proteins. They may or may not have functional or structural significance within the proteins in which they are found.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
     </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000037">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000112 xml:lang="en">http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean&apos;s estimate of a population mean.
+It is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.
+
+A measure of dispersion applied to means across hypothetical repeated random samples.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">SEM</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en">SEM</obo:STATO_0000032>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.sem(a, axis=0, ddof=1)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">standard error of the mean</rdfs:label>
+        <rdfs:seeAlso>https://fevir.net/resources/CodeSystem/27270#STATO:0000037</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000142">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
+        <obo:STATO_0000032>r</obo:STATO_0000032>
+        <obo:STATO_0000032 xml:lang="en">r statistic</obo:STATO_0000032>
+        <rdfs:label xml:lang="en">correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000201 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">Spearman&apos;s rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.
+Spearman&apos;s coefficient may be used when the conditions for computing Pearson&apos;s correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">Spearman&apos;s rho</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">cor(x, y = NULL, use = &quot;everything&quot;,method = c(&quot;spearman&quot;))</obo:STATO_0000041>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.spearmanr(a, b=None, axis=0)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">Spearman&apos;s rank correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000237 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">σ</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">http://en.wikipedia.org/wiki/Standard_deviation</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">sd(x, na.rm = FALSE)
+
+http://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html</obo:STATO_0000041>
+        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000280">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The Pearson&apos;s correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. 
+The coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">Pearson product-moment correlation coefficient</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">Pearson&apos;s r</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">r statistics</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">STATO, adapted from
+http://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient
+and from:
+http://stamash.org/pearsons-correlation-coefficient/
+http://stamash.org/kendalls-tau-correlation/</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">cor(x, y = NULL, use = &quot;everything&quot;,method = c(&quot;pearson&quot;))</obo:STATO_0000041>
+        <obo:STATO_0000041 xml:lang="en">http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html</obo:STATO_0000041>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.pearsonr(x, y)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">Pearson&apos;s correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000564 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000564">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).
+In the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">r2</obo:IAO_0000118>
+        <obo:STATO_0000041 xml:lang="en">&gt; eruption.lm = lm(eruptions ~ waiting, data=faithful)
+&gt; summary(eruption.lm)$r.squared 
+
+
+from:
+http://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination</obo:STATO_0000041>
+        <rdfs:label xml:lang="en">coefficient of determination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000700 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000700">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000115 xml:lang="en">A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.
+
+Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_0000116>
+        <obo:IAO_0000118 xml:lang="en">P value</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">P-value</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">PValue</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">p value</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">SEVCO group</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">p-value</rdfs:label>
+    </owl:Class>
     
 
 
@@ -38949,7 +39295,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000922">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000697"/>
-        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NCBI RefSeq Nucleotide</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39029,7 +39375,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000957">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000707"/>
-        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ChEMBL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39119,7 +39465,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000967">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000704"/>
-        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CDD</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39169,7 +39515,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000972">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000706"/>
-        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Reactome</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39300,6 +39646,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001001">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000710"/>
         <obo:IAO_0000115 xml:lang="en">A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">MoDEL database</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Distinct from the class &apos;model&apos; (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym &apos;MoDEL database&apos; when matching.</rdfs:comment>
         <rdfs:label xml:lang="en">MoDEL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39449,6 +39797,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001945 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001945">
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A redundant untyped individual that duplicated the class &apos;omni-path&apos; (MOLSIM:001949). It should not be used; use that class instead.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001949"/>
         <rdfs:comment xml:lang="en">Obsoleted: redundant untyped individual duplicating the class &apos;omni-path&apos; (MOLSIM_001949), which is the concept to use instead.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete Omni-Path</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -39716,7 +40066,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000895"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000896"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000897"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000906"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000907"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921"/>
@@ -39724,8 +40073,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001044"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001059"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001094"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001095"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001096"/>
@@ -39823,7 +40170,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001700"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001728"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001740"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001986"/>
         </owl:members>
     </rdf:Description>

--- a/molsim.json
+++ b/molsim.json
@@ -33,13 +33,19 @@
         "pred" : "http://www.geneontology.org/formats/oboInOwl#default-namespace",
         "val" : "molsim"
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification."
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-24"
+        "val" : "2026-07-29"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/APOLLO_SV_00000008",
@@ -13356,7 +13362,8 @@
       "meta" : {
         "definition" : {
           "val" : "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000007",
@@ -13694,7 +13701,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis."
+          "val" : "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -13703,7 +13710,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)"
         }
       }
     }, {
@@ -13712,7 +13719,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -13721,7 +13728,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)."
+          "val" : "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)"
         }
       }
     }, {
@@ -13730,7 +13737,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)."
+          "val" : "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)"
         }
       }
     }, {
@@ -13739,7 +13746,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)."
+          "val" : "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -13748,7 +13755,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)."
+          "val" : "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)"
         }
       }
     }, {
@@ -13757,7 +13764,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)."
+          "val" : "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -13779,7 +13786,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)."
+          "val" : "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -13788,7 +13795,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)."
+          "val" : "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)"
         }
       }
     }, {
@@ -13797,7 +13804,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)."
+          "val" : "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13810,7 +13817,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)."
+          "val" : "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -13819,7 +13826,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)."
+          "val" : "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)"
         }
       }
     }, {
@@ -13828,7 +13835,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)."
+          "val" : "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)"
         }
       }
     }, {
@@ -13837,7 +13844,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)."
+          "val" : "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13853,7 +13860,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)."
+          "val" : "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)"
         }
       }
     }, {
@@ -13862,7 +13869,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)."
+          "val" : "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13875,7 +13882,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)."
+          "val" : "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -13888,7 +13895,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)."
+          "val" : "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -14065,7 +14072,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)."
+          "val" : "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -14074,7 +14081,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)."
+          "val" : "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -14083,7 +14090,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules."
+          "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -14092,7 +14099,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)."
+          "val" : "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)"
         }
       }
     }, {
@@ -14101,7 +14108,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)."
+          "val" : "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)"
         }
       }
     }, {
@@ -14128,7 +14135,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)."
+          "val" : "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)"
         }
       }
     }, {
@@ -14137,7 +14144,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)."
+          "val" : "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)"
         }
       }
     }, {
@@ -14146,7 +14153,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)."
+          "val" : "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)"
         }
       }
     }, {
@@ -14155,7 +14162,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities."
+          "val" : "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)"
         }
       }
     }, {
@@ -14164,7 +14171,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule."
+          "val" : "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)"
         }
       }
     }, {
@@ -14173,7 +14180,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)."
+          "val" : "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)"
         }
       }
     }, {
@@ -14182,7 +14189,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)."
+          "val" : "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)"
         }
       }
     }, {
@@ -14191,7 +14198,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)."
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
         }
       }
     }, {
@@ -14200,7 +14207,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)."
+          "val" : "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)"
         }
       }
     }, {
@@ -14209,7 +14216,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)."
+          "val" : "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)"
         }
       }
     }, {
@@ -14218,7 +14225,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)."
+          "val" : "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -14231,7 +14238,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)."
+          "val" : "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)"
         }
       }
     }, {
@@ -14240,7 +14247,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)."
+          "val" : "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)"
         }
       }
     }, {
@@ -14249,7 +14256,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)"
         }
       }
     }, {
@@ -14258,7 +14265,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)."
+          "val" : "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)"
         }
       }
     }, {
@@ -14267,7 +14274,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)."
+          "val" : "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)"
         }
       }
     }, {
@@ -14442,21 +14449,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "lbl" : "correlation coefficient",
+      "lbl" : "obsolete correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000142"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "lbl" : "Pearson's correlation coefficient",
+      "lbl" : "obsolete Pearson's correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
@@ -14603,7 +14622,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  "
+          "val" : "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)"
         }
       }
     }, {
@@ -14834,7 +14853,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable"
+          "val" : "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -15079,7 +15098,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)."
+          "val" : "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -15110,7 +15129,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)"
+          "val" : "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)"
         }
       }
     }, {
@@ -15938,7 +15957,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)."
+          "val" : "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -15947,7 +15966,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)."
+          "val" : "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -16381,7 +16400,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)"
+          "val" : "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -16425,7 +16444,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)"
+          "val" : "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)"
         }
       }
     }, {
@@ -16469,7 +16488,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)."
+          "val" : "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -16812,7 +16831,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows."
+          "val" : "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)"
         }
       }
     }, {
@@ -16861,7 +16880,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)."
+          "val" : "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)"
         }
       }
     }, {
@@ -16870,7 +16889,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)."
+          "val" : "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)"
         }
       }
     }, {
@@ -16994,7 +17013,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD."
+          "val" : "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -17010,17 +17029,23 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)."
+          "val" : "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)"
         }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "lbl" : "p-value",
+      "lbl" : "obsolete p-value",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000700"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
@@ -17865,7 +17890,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)."
+          "val" : "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)"
         }
       }
     }, {
@@ -18208,7 +18233,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching."
+          "val" : "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)"
         }
       }
     }, {
@@ -18602,7 +18627,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)."
+          "val" : "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)"
         }
       }
     }, {
@@ -18611,7 +18636,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)."
+          "val" : "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)"
         }
       }
     }, {
@@ -18687,7 +18712,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)"
+          "val" : "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)"
         }
       }
     }, {
@@ -18714,7 +18739,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)"
+          "val" : "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)"
         }
       }
     }, {
@@ -19254,7 +19279,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)"
+          "val" : "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)"
         }
       }
     }, {
@@ -19281,7 +19306,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)."
+          "val" : "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -19290,7 +19315,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)."
+          "val" : "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)"
         }
       }
     }, {
@@ -19477,7 +19502,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process."
+          "val" : "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19493,7 +19518,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),"
+          "val" : "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19509,7 +19534,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations."
+          "val" : "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -19658,7 +19683,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)"
+          "val" : "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)"
         },
         "comments" : [ "AMBER lib format" ],
         "synonyms" : [ {
@@ -20321,12 +20346,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "lbl" : "image bond fixing analysis",
+      "lbl" : "obsolete image bond fixing analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)"
-        }
+          "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
@@ -20420,7 +20446,7 @@
         "definition" : {
           "val" : "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)"
         },
-        "comments" : [ "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
+        "comments" : [ "How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.", "TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import" ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
@@ -21170,7 +21196,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
+          "val" : "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -21345,7 +21371,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)."
+          "val" : "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)"
         }
       }
     }, {
@@ -21354,7 +21380,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)."
+          "val" : "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)"
         }
       }
     }, {
@@ -21363,7 +21389,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)."
+          "val" : "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -21372,7 +21398,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)."
+          "val" : "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)"
         }
       }
     }, {
@@ -21381,7 +21407,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)."
+          "val" : "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)"
         }
       }
     }, {
@@ -21399,7 +21425,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)."
+          "val" : "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)"
         }
       }
     }, {
@@ -21408,7 +21434,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)."
+          "val" : "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)"
         }
       }
     }, {
@@ -21417,7 +21443,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)."
+          "val" : "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)"
         }
       }
     }, {
@@ -21426,7 +21452,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)."
+          "val" : "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21435,7 +21461,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -21444,7 +21470,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)."
+          "val" : "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)"
         }
       }
     }, {
@@ -21453,7 +21479,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)."
+          "val" : "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)"
         }
       }
     }, {
@@ -21462,7 +21488,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)."
+          "val" : "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)"
         }
       }
     }, {
@@ -21471,7 +21497,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)."
+          "val" : "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)"
         }
       }
     }, {
@@ -21480,7 +21506,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)."
+          "val" : "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)"
         }
       }
     }, {
@@ -21489,7 +21515,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)."
+          "val" : "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21502,7 +21528,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21515,7 +21541,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)."
+          "val" : "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21528,7 +21554,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)."
+          "val" : "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21541,7 +21567,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)."
+          "val" : "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)"
         }
       }
     }, {
@@ -21550,7 +21576,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)."
+          "val" : "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)"
         }
       }
     }, {
@@ -21559,7 +21585,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)."
+          "val" : "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21568,7 +21594,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)."
+          "val" : "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -21577,7 +21603,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)."
+          "val" : "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)"
         }
       }
     }, {
@@ -21586,7 +21612,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)."
+          "val" : "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)"
         }
       }
     }, {
@@ -21595,7 +21621,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)."
+          "val" : "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)"
         }
       }
     }, {
@@ -21604,7 +21630,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)."
+          "val" : "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)"
         }
       }
     }, {
@@ -21613,7 +21639,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)."
+          "val" : "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)"
         }
       }
     }, {
@@ -21622,7 +21648,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)."
+          "val" : "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)"
         }
       }
     }, {
@@ -21631,7 +21657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)."
+          "val" : "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)"
         }
       }
     }, {
@@ -21640,7 +21666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)."
+          "val" : "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)"
         }
       }
     }, {
@@ -21705,7 +21731,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)."
+          "val" : "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)"
         }
       }
     }, {
@@ -21714,7 +21740,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)."
+          "val" : "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21727,7 +21753,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)."
+          "val" : "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21740,7 +21766,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)."
+          "val" : "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21753,7 +21779,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)."
+          "val" : "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21766,7 +21792,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)."
+          "val" : "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -21779,7 +21805,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)."
+          "val" : "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)"
         }
       }
     }, {
@@ -21788,7 +21814,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)"
         }
       }
     }, {
@@ -21797,7 +21823,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)."
+          "val" : "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)"
         }
       }
     }, {
@@ -22517,12 +22543,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "lbl" : "small molecule structure (deprecated)",
+      "lbl" : "obsolete small molecule structure",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
@@ -23007,7 +23034,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)."
+          "val" : "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)"
         }
       }
     }, {
@@ -23016,7 +23043,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)."
+          "val" : "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)"
         }
       }
     }, {
@@ -23082,7 +23109,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)."
+          "val" : "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -23954,12 +23981,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "lbl" : "macromolecular structure format (deprecated)",
+      "lbl" : "obsolete macromolecular structure format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
@@ -23976,12 +24004,13 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "lbl" : "software-specific coordinate format (deprecated)",
+      "lbl" : "obsolete software-specific coordinate format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
+        },
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
@@ -25034,7 +25063,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D."
+          "val" : "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -25410,7 +25439,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e"
+          "val" : "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)"
         }
       }
     }, {
@@ -25624,7 +25653,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)"
+          "val" : "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)"
         }
       }
     }, {
@@ -26892,21 +26921,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "lbl" : "Pearson product-moment correlation coefficient",
+      "lbl" : "obsolete Pearson product-moment correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000280"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "lbl" : "Spearman rank correlation coefficient",
+      "lbl" : "obsolete Spearman rank correlation coefficient",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000201"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
@@ -26937,21 +26978,33 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "lbl" : "standard error of the mean (SEM)",
+      "lbl" : "obsolete standard error of the mean (SEM)",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000037"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
-      "lbl" : "coefficient of determination",
+      "lbl" : "obsolete coefficient of determination",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000564"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001411",
@@ -26986,12 +27039,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
-      "lbl" : "standard deviation",
+      "lbl" : "obsolete standard deviation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev."
+        },
+        "comments" : [ "Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/STATO_0000237"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001415",
@@ -27668,12 +27727,17 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001484",
-      "lbl" : "statistical model",
+      "lbl" : "statistical mechanics model",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)"
-        }
+          "val" : "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)"
+        },
+        "comments" : [ "Not to be confused with STATO:0000107 \"statistical model\", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; \"statistical model\" is retained as an exact synonym." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "statistical model"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001485",
@@ -27681,7 +27745,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
+          "val" : "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)"
         }
       }
     }, {
@@ -27690,7 +27754,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
+          "val" : "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -29385,7 +29449,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)"
+          "val" : "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)"
         }
       }
     }, {
@@ -30167,13 +30231,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "lbl" : "trajectory analysis algorithm (deprecated)",
+      "lbl" : "obsolete trajectory analysis algorithm",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)"
+          "val" : "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations."
         },
-        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ]
+        "comments" : [ "candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
@@ -30284,13 +30349,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "lbl" : "Miller indices (deprecated)",
+      "lbl" : "obsolete Miller indices",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)"
+          "val" : "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model."
         },
-        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ]
+        "comments" : [ "Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26" ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
@@ -32570,7 +32636,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)"
+          "val" : "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)"
         }
       }
     }, {
@@ -32841,7 +32907,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
+          "val" : "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)"
         }
       }
     }, {
@@ -33317,7 +33383,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)"
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -33326,7 +33392,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33339,7 +33405,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33438,7 +33504,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)"
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
         }
       }
     }, {
@@ -34491,7 +34557,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second."
+          "val" : "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34504,7 +34570,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth."
+          "val" : "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34517,7 +34583,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes."
+          "val" : "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34530,7 +34596,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities."
+          "val" : "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34543,7 +34609,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights."
+          "val" : "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34556,7 +34622,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs."
+          "val" : "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34569,7 +34635,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density."
+          "val" : "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)"
         }
       }
     }, {
@@ -34578,7 +34644,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)."
+          "val" : "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34591,7 +34657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity."
+          "val" : "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)"
         }
       }
     }, {
@@ -34600,7 +34666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters."
+          "val" : "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)"
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -34613,7 +34679,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector."
+          "val" : "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)"
         }
       }
     }, {
@@ -34622,7 +34688,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein."
+          "val" : "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)"
         }
       }
     }, {
@@ -34640,7 +34706,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods."
+          "val" : "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)"
         }
       }
     }, {
@@ -34649,7 +34715,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy."
+          "val" : "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)"
         }
       }
     }, {
@@ -34658,7 +34724,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces."
+          "val" : "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)"
         }
       }
     }, {
@@ -35430,6 +35496,241 @@
         } ]
       }
     }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000037",
+      "lbl" : "standard error of the mean",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean's estimate of a population mean.\nIt is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.\n\nA measure of dispersion applied to means across hypothetical repeated random samples."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000112",
+          "val" : "http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "SEM"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "SEM"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.sem(a, axis=0, ddof=1)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+          "val" : "https://fevir.net/resources/CodeSystem/27270#STATO:0000037"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000142",
+      "lbl" : "correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "STATO"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "r"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032",
+          "val" : "r statistic"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000201",
+      "lbl" : "Spearman's rank correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "Spearman's rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.\nSpearman's coefficient may be used when the conditions for computing Pearson's correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Spearman's rho"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "cor(x, y = NULL, use = \"everything\",method = c(\"spearman\"))"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.spearmanr(a, b=None, axis=0)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000237",
+      "lbl" : "standard deviation",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "σ"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "http://en.wikipedia.org/wiki/Standard_deviation"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "sd(x, na.rm = FALSE)\n\nhttp://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000280",
+      "lbl" : "Pearson's correlation coefficient",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The Pearson's correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. \nThe coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Pearson product-moment correlation coefficient"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "Pearson's r"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "r statistics"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "STATO, adapted from\nhttp://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient\nand from:\nhttp://stamash.org/pearsons-correlation-coefficient/\nhttp://stamash.org/kendalls-tau-correlation/"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000032"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "cor(x, y = NULL, use = \"everything\",method = c(\"pearson\"))"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000391",
+          "val" : "scipy.stats.pearsonr(x, y)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000564",
+      "lbl" : "coefficient of determination",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).\nIn the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "r2"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/STATO_0000041",
+          "val" : "> eruption.lm = lm(eruptions ~ waiting, data=faithful)\n> summary(eruption.lm)$r.squared \n\n\nfrom:\nhttp://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000700",
+      "lbl" : "p-value",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.\n\nWithin the Bayesian framework, use the posterior predictive p-value."
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "P value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "P-value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "PValue"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000118",
+          "val" : "p value"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "SEVCO group"
+        } ]
+      }
+    }, {
       "id" : "http://purl.obolibrary.org/obo/UO_0000000",
       "lbl" : "unit",
       "type" : "CLASS",
@@ -36034,7 +36335,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
+          "val" : "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)"
         }
       }
     }, {
@@ -36847,7 +37148,8 @@
       "meta" : {
         "definition" : {
           "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002125",
@@ -37838,7 +38140,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation"
+          "val" : "The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)"
         }
       }
     }, {
@@ -37910,7 +38212,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry."
+          "val" : "A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)"
         }
       }
     }, {
@@ -37991,7 +38293,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
+          "val" : "Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -38036,7 +38338,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis."
+          "val" : "A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -38154,7 +38456,12 @@
       "meta" : {
         "definition" : {
           "val" : "A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)"
-        }
+        },
+        "comments" : [ "Distinct from the class 'model' (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym 'MoDEL database' when matching." ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "MoDEL database"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001002",
@@ -38288,7 +38595,14 @@
       "lbl" : "obsolete Omni-Path",
       "type" : "INDIVIDUAL",
       "meta" : {
+        "definition" : {
+          "val" : "OBSOLETE. A redundant untyped individual that duplicated the class 'omni-path' (MOLSIM:001949). It should not be used; use that class instead."
+        },
         "comments" : [ "Obsoleted: redundant untyped individual duplicating the class 'omni-path' (MOLSIM_001949), which is the concept to use instead." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001949"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -38367,6 +38681,96 @@
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000111",
+      "lbl" : "editor preferred term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor preferred term~editor preferred label"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000112",
+      "lbl" : "example of usage",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "example"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "example of usage"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000114",
+      "lbl" : "has curation status",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "has curation status"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Alan Ruttenberg"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Bill Bug"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Melanie Courtot"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "OBI_0000281"
+        } ]
+      }
+    }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
       "lbl" : "definition",
       "type" : "PROPERTY",
@@ -38376,11 +38780,55 @@
           "val" : "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "definition"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "textual definition"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "2012-04-05: \nBarry Smith\n\nThe official OBI definition, explaining the meaning of a class or property: 'Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions'  is terrible.\n\nCan you fix to something like:\n\nA statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.\n\nAlan Ruttenberg\n\nYour proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can't be evaluated by those criteria. \n\nOn the specifics of the proposed definition:\n\nWe don't have definitions of 'meaning' or 'expression' or 'property'. For 'reference' in the intended sense I think we use the term 'denotation'. For 'expression', I think we you mean symbol, or identifier. For 'meaning' it differs for class and property. For class we want documentation that let's the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let's the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The 'intended reader' part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. \n\nPersonally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. \n\nWe also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  "
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000116",
+      "lbl" : "editor note",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "editor note"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obfoundry.org/obo/obi>"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -38393,11 +38841,49 @@
           "val" : "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "term editor"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000118",
+      "lbl" : "alternative term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "alternative term"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000125"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "PERSON:Daniel Schober"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
         } ]
       }
     }, {
@@ -38410,6 +38896,12 @@
           "val" : "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "definition source"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000114",
+          "val" : "http://purl.obolibrary.org/obo/IAO_0000122"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "PERSON:Daniel Schober"
         }, {
@@ -38417,7 +38909,77 @@
           "val" : "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"
         }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
+          "val" : "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000119",
           "val" : "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"
+        }, {
+          "pred" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+          "val" : "http://purl.obolibrary.org/obo/iao.owl"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000032",
+      "lbl" : "STATO alternative term",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "an alternative term used for STATO statistical ontology and ISA team"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000041",
+      "lbl" : "R command",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "a R command syntax or link to a R documentation in support of Statistical Ontology Classes or Data Transformations"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/STATO_0000391",
+      "lbl" : "Python command",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "definition" : {
+          "val" : "an annotation property to provide a canonical command to invoke a method implementation using Python programming language"
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Alejandra Gonzalez-Beltran"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Orlaith Burke"
+        }, {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "Philippe Rocca-Serra"
         } ]
       }
     }, {
@@ -38537,7 +39099,22 @@
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
+      "id" : "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
       "id" : "http://www.w3.org/2000/01/rdf-schema#label",
+      "lbl" : "label",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION",
+      "meta" : {
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000111",
+          "val" : "label"
+        } ]
+      }
+    }, {
+      "id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -40362,14 +40939,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001691"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000111",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000112",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000113",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001352"
@@ -41345,10 +41914,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000353",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000400"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000354",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000355",
       "pred" : "is_a",
@@ -42638,10 +43203,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000679",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000680",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000328"
@@ -43490,10 +44051,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001073"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000905",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000906",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -44006,17 +44563,9 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001091"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001087",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001088",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001085"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001089",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001090",
       "pred" : "is_a",
@@ -45098,31 +45647,15 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001292"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001404",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001405",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001406",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001407",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001408",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001409",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001410",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -45135,10 +45668,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001411"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001413",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001414",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
@@ -46474,10 +47003,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001745"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000037"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001748",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001696"
@@ -46521,10 +47046,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001758",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001711"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001759",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001760",
       "pred" : "is_a",
@@ -46728,7 +47249,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001810",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000111"
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001811",
       "pred" : "is_a",
@@ -48397,6 +48918,34 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0100021",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0000839"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000037",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000142",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000201",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000237",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000280",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/STATO_0000142"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000564",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/STATO_0000700",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001403"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/UO_0000000",
       "pred" : "is_a",

--- a/molsim.obo
+++ b/molsim.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: releases/2026-07-24
+data-version: releases/2026-07-29
 default-namespace: molsim
 idspace: chemrof https://w3id.org/chemrof/ 
 idspace: dce http://purl.org/dc/elements/1.1/ 
@@ -10,6 +10,8 @@ idspace: orcid https://orcid.org/
 idspace: protege http://protege.stanford.edu/plugins/owl/protege# 
 idspace: swrl http://www.w3.org/2003/11/swrl# 
 idspace: swrlb http://www.w3.org/2003/11/swrlb# 
+remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
+remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
 ontology: molsim
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
 property_value: dcterms:contributor orcid:0009-0007-1391-4986
@@ -20,7 +22,7 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-24" xsd:string
+property_value: owl:versionInfo "2026-07-29" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
@@ -3968,6 +3970,7 @@ disjoint_from: MOLSIM:000208 ! thermalization
 id: MOLSIM:000006
 name: model
 def: "A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system's behavior. (UNVERIFIED)" []
+comment: Distinct from 'MoDEL' (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.
 
 [Term]
 id: MOLSIM:000007
@@ -4178,12 +4181,12 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000037
 name: algorithm
-def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis." []
+def: "A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:000038
 name: thermostat algorithm
-def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000039 ! barostat algorithm
@@ -4191,38 +4194,38 @@ disjoint_from: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000039
 name: barostat algorithm
-def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)" []
 is_a: MOLSIM:000382 ! simulation control algorithm
 
 [Term]
 id: MOLSIM:000040
 name: Berendsen barostat
-def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED)." []
+def: "A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 disjoint_from: MOLSIM:000041 ! Monte Carlo barostat
 
 [Term]
 id: MOLSIM:000041
 name: Monte Carlo barostat
-def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED)." []
+def: "A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000042
 name: Andersen barostat
-def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED)." []
+def: "A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious \"piston\" mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000043
 name: Parrinello-Rahman barostat
-def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED)." []
+def: "An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000044
 name: Langevin-piston barostat
-def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED)." []
+def: "A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
@@ -4237,46 +4240,46 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000046
 name: Berendsen thermostat
-def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED)." []
+def: "A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000047
 name: Andersen thermostat
-def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED)." []
+def: "A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle \"collides,\" its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000048
 name: Nosé-Hoover thermostat
-def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED)." []
+def: "A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system's kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system's temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)" []
 synonym: "Nose-Hoover" EXACT []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000049
 name: constraint algorithm
-def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED)." []
+def: "An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 disjoint_from: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000050
 name: SHAKE algorithm
-def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED)." []
+def: "An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 disjoint_from: MOLSIM:000051 ! RATTLE algorithm
 
 [Term]
 id: MOLSIM:000051
 name: RATTLE algorithm
-def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED)." []
+def: "A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000052
 name: LINCS algorithm
-def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED)." []
+def: "A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)" []
 synonym: "LINCS" EXACT []
 synonym: "linear constraint solver algorithm" EXACT []
 is_a: MOLSIM:000049 ! constraint algorithm
@@ -4284,21 +4287,21 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000053
 name: electrostatic interaction algorithm
-def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED)." []
+def: "An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)" []
 is_a: MOLSIM:000384 ! force calculation algorithm
 disjoint_from: MOLSIM:001724 ! Treecode algorithm
 
 [Term]
 id: MOLSIM:000054
 name: particle mesh Ewald
-def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED)." []
+def: "A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)" []
 synonym: "PME" EXACT []
 is_a: MOLSIM:000428 ! Ewald summation
 
 [Term]
 id: MOLSIM:000055
 name: reaction field
-def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED)." []
+def: "An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)" []
 synonym: "RF" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
 disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
@@ -4306,7 +4309,7 @@ disjoint_from: MOLSIM:000056 ! particle-particle particle-mesh
 [Term]
 id: MOLSIM:000056
 name: particle-particle particle-mesh
-def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED)." []
+def: "An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)" []
 synonym: "P3M" EXACT []
 synonym: "PPPM" EXACT []
 is_a: MOLSIM:000053 ! electrostatic interaction algorithm
@@ -4422,32 +4425,32 @@ disjoint_from: MOLSIM:000270 ! Poisson-Boltzmann surface area
 [Term]
 id: MOLSIM:000074
 name: similarity calculation algorithm
-def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED)." []
+def: "An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000075
 name: Tanimoto similarity algorithm
-def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED)." []
+def: "This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 disjoint_from: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000076
 name: Tversky index algorithm
-def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules." []
+def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000077
 name: Dice coefficient algorithm
-def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED)." []
+def: "A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000078
 name: Euclidean distance
-def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED)." []
+def: "A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)" []
 is_a: MOLSIM:001403 ! statistical property
 
 [Term]
@@ -4465,100 +4468,100 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:000081
 name: Hamming distance algorithm
-def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED)." []
+def: "A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000082
 name: Jaccard index algorithm
-def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED)." []
+def: "A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000083
 name: overlap coefficient algorithm
-def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED)." []
+def: "A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000084
 name: fit Tversky combo
-def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities." []
+def: "A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule's characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 disjoint_from: MOLSIM:000085 ! ref Tversky
 
 [Term]
 id: MOLSIM:000085
 name: ref Tversky
-def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule." []
+def: "A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
 id: MOLSIM:000086
 name: combo score algorithm
-def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED)." []
+def: "A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
 
 [Term]
 id: MOLSIM:000087
 name: optimal transformation path algorithm
-def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED)." []
+def: "An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED)." []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
 
 [Term]
 id: MOLSIM:000089
 name: Prim's algorithm
-def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST (UNVERIFIED)." []
+def: "Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal's for constructing an MST. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000090
 name: Dijkstra's algorithm
-def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED)." []
+def: "An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000091
 name: A* search algorithm
-def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED)." []
+def: "An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra's algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)" []
 synonym: "A-star search algorithm" EXACT []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000092
 name: nearest neighbor algorithm
-def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED)." []
+def: "Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000093
 name: genetic algorithm
-def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED)." []
+def: "A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000094
 name: simulated annealing algorithm
-def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a \"temperature\" parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000095
 name: ant colony optimization algorithm
-def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED)." []
+def: "A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
 id: MOLSIM:000096
 name: network flow algorithm
-def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED)." []
+def: "A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)" []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 
 [Term]
@@ -4662,15 +4665,19 @@ disjoint_from: MOLSIM:001692 ! Beeman integrator
 
 [Term]
 id: MOLSIM:000111
-name: correlation coefficient
-def: "A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete correlation coefficient
+def: "OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.
+is_obsolete: true
+replaced_by: STATO:0000142
 
 [Term]
 id: MOLSIM:000112
-name: Pearson's correlation coefficient
-def: "Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson's correlation coefficient
+def: "OBSOLETE. Pearson's correlation coefficient (often denoted as 'r') measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:000113
@@ -4755,7 +4762,7 @@ is_a: MOLSIM:000348 ! hypothesis testing analysis
 [Term]
 id: MOLSIM:000125
 name: Kolmogorov-Smirnov test analysis
-def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  " []
+def: "The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)" []
 is_a: MOLSIM:000124 ! statistical test analysis
 
 [Term]
@@ -4901,7 +4908,7 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000148
 name: experimental data availability
-def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable" []
+def: "This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable." []
 is_a: MOLSIM:000143 ! ligand pairs selection criteria
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -5058,7 +5065,7 @@ is_a: MOLSIM:001850 ! modeling and setup tool
 [Term]
 id: MOLSIM:000173
 name: quantum mechanics
-def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED)." []
+def: "The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)" []
 synonym: "QM" EXACT []
 is_a: MOLSIM:000141 ! theoretical approach
 
@@ -5081,7 +5088,7 @@ disjoint_from: MOLSIM:000179 ! Q-Chem
 [Term]
 id: MOLSIM:000176
 name: GAMESS
-def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)" []
+def: "This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -5588,13 +5595,13 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000253
 name: clustering algorithm
-def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED)." []
+def: "An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000037 ! algorithm
 
 [Term]
 id: MOLSIM:000254
 name: hierarchical agglomerative bottom-up algorithm
-def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED)." []
+def: "A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)" []
 is_a: MOLSIM:000253 ! clustering algorithm
 disjoint_from: MOLSIM:001707 ! DBSCAN clustering algorithm
 
@@ -5860,7 +5867,7 @@ is_a: MOLSIM:000286 ! thermodynamic integration approach
 [Term]
 id: MOLSIM:000294
 name: conveyor belt thermodynamic integration
-def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)" []
+def: "Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)" []
 synonym: "CBTI" EXACT []
 is_a: MOLSIM:000286 ! thermodynamic integration approach
 
@@ -5886,7 +5893,7 @@ is_a: MOLSIM:000355 ! thermodynamic integration analysis
 [Term]
 id: MOLSIM:000299
 name: thermodynamic integration with linear extrapolation
-def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)" []
+def: "Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)" []
 is_a: MOLSIM:000298 ! thermodynamic integration extrapolation approach
 disjoint_from: MOLSIM:000356 ! thermodynamic integration without linear extrapolation
 
@@ -5914,7 +5921,7 @@ is_a: MOLSIM:000300 ! free energy and molecular dynamics analysis
 [Term]
 id: MOLSIM:000303
 name: linear dependence evaluation analysis
-def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED)." []
+def: "A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -6122,7 +6129,7 @@ is_a: MOLSIM:000332 ! SCF convergence algorithm
 [Term]
 id: MOLSIM:000334
 name: fit color Tversky
-def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows." []
+def: "A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -6153,13 +6160,13 @@ is_a: MOLSIM:000039 ! barostat algorithm
 [Term]
 id: MOLSIM:000339
 name: numerical integration
-def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED)." []
+def: "Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system's state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)" []
 is_a: MOLSIM:000340 ! integration analysis
 
 [Term]
 id: MOLSIM:000340
 name: integration analysis
-def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED)." []
+def: "A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -6236,7 +6243,7 @@ is_a: MOLSIM:000400 ! statistical analysis
 [Term]
 id: MOLSIM:000352
 name: binpos format
-def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD." []
+def: "A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for \"binary position.\" This format is often referred to as the \"Scripps 'binpos' format\" and is recognized by Amber's analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)" []
 synonym: ".binpos" EXACT []
 synonym: "Scripps binpos format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
@@ -6244,14 +6251,16 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000353
 name: validation analysis
-def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED)." []
+def: "A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000354
-name: p-value
-def: "A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete p-value
+def: "OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically < 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000700
 
 [Term]
 id: MOLSIM:000355
@@ -6755,7 +6764,7 @@ is_a: MOLSIM:000331 ! force field component
 [Term]
 id: MOLSIM:000432
 name: quantum mechanics basis set
-def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED)." []
+def: "A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 disjoint_from: MOLSIM:000827 ! Moeller-Plesset
 
@@ -6964,7 +6973,7 @@ is_a: MOLSIM:000257 ! endpoint free energy tool
 [Term]
 id: MOLSIM:000463
 name: ref Tversky combo
-def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching." []
+def: "A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)" []
 is_a: MOLSIM:000076 ! Tversky index algorithm
 
 [Term]
@@ -7218,13 +7227,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000502
 name: linear correlation significance determination analysis
-def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED)." []
+def: "A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
 id: MOLSIM:000503
 name: determination by p-value analysis
-def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED)." []
+def: "A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)" []
 is_a: MOLSIM:000400 ! statistical analysis
 
 [Term]
@@ -7273,7 +7282,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000514
 name: LANL2-[6s4p4d2f]
-def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)" []
+def: "This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The \"[6s4p4d2f]\" part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7291,7 +7300,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000517
 name: LANL2DZ+2s2p2d2f
-def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)" []
+def: "This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7651,7 +7660,7 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000577
 name: Ahlrichs pvDZ
-def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)" []
+def: "Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions ('p') are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)" []
 is_a: MOLSIM:000485 ! split-valence
 
 [Term]
@@ -7669,13 +7678,13 @@ is_a: MOLSIM:000485 ! split-valence
 [Term]
 id: MOLSIM:000580
 name: plane-wave
-def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED)." []
+def: "A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
 id: MOLSIM:000581
 name: real-space
-def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED)." []
+def: "Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)" []
 is_a: MOLSIM:000432 ! quantum mechanics basis set
 
 [Term]
@@ -7791,7 +7800,7 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:000599
 name: AMBER REM log format
-def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process." []
+def: "Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)" []
 synonym: "Amber Replica Exchange Log" EXACT []
 synonym: "rem.log" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7799,7 +7808,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000600
 name: AMBER eigenvector format
-def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj)," []
+def: "The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed \"file extension\" required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)" []
 synonym: "evecs.dat" EXACT []
 synonym: "evecs.out" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7807,7 +7816,7 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000601
 name: cpout format
-def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations." []
+def: "A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)" []
 synonym: ".cpout" EXACT []
 synonym: "AMBER cpout format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
@@ -7895,7 +7904,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000614
 name: off format
-def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)" []
+def: "An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)" []
 comment: AMBER lib format
 synonym: ".off" EXACT []
 synonym: "AMBER Object File Format" EXACT []
@@ -8309,9 +8318,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 
 [Term]
 id: MOLSIM:000679
-name: image bond fixing analysis
-def: "Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)" []
-is_a: MOLSIM:000659 ! periodic boundary imaging
+name: obsolete image bond fixing analysis
+def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000680
@@ -8368,7 +8377,7 @@ is_a: MOLSIM:000448 ! protein database ID
 id: MOLSIM:000688
 name: data source
 def: "Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)" []
-comment: TODO:may be be replacable with IAO's information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import
+comment: How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.
 
 [Term]
 id: MOLSIM:000689
@@ -8849,7 +8858,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:000775
 name: CP2K
-def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
+def: "An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It's highly parallelized and versatile for demanding simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000161 ! quantum chemistry engine
 
 [Term]
@@ -8965,31 +8974,31 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000794
 name: Hoover barostat
-def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED)." []
+def: "Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat's concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system's phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)" []
 is_a: MOLSIM:000039 ! barostat algorithm
 
 [Term]
 id: MOLSIM:000795
 name: M-SHAKE algorithm
-def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED)." []
+def: "A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000796
 name: P-SHAKE algorithm
-def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED)." []
+def: "Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000797
 name: SETTLE algorithm
-def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED)." []
+def: "An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
 id: MOLSIM:000798
 name: SHAPE algorithm
-def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED)." []
+def: "A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)" []
 is_a: MOLSIM:000049 ! constraint algorithm
 
 [Term]
@@ -9001,76 +9010,76 @@ is_a: MOLSIM:000049 ! constraint algorithm
 [Term]
 id: MOLSIM:000800
 name: Nose thermostat
-def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically (UNVERIFIED)." []
+def: "Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system's phase space to control temperature deterministically. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000801
 name: Nose-Poincare thermostat
-def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED)." []
+def: "A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré's canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000802
 name: V-rescale thermostat
-def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED)." []
+def: "Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system's kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)" []
 is_a: MOLSIM:000038 ! thermostat algorithm
 
 [Term]
 id: MOLSIM:000803
 name: semi-empirical method
-def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED)." []
+def: "A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000804
 name: all-valence-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 disjoint_from: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000805
 name: PPP
-def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED)." []
+def: "The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)" []
 is_a: MOLSIM:000806 ! pi-electron restricted
 
 [Term]
 id: MOLSIM:000806
 name: pi-electron restricted
-def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED)." []
+def: "Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)" []
 is_a: MOLSIM:000803 ! semi-empirical method
 
 [Term]
 id: MOLSIM:000807
 name: AM1
-def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED)." []
+def: "Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 disjoint_from: MOLSIM:000808 ! CNDO/2
 
 [Term]
 id: MOLSIM:000808
 name: CNDO/2
-def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED)." []
+def: "Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000809
 name: INDO
-def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED)." []
+def: "Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000810
 name: Hartree-Fock
-def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED)." []
+def: "A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)" []
 synonym: "HF" EXACT []
 is_a: MOLSIM:000685 ! ab-initio method
 
 [Term]
 id: MOLSIM:000812
 name: restricted open-shell Hartree-Fock
-def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "ROHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 disjoint_from: MOLSIM:000813 ! self-consistent field
@@ -9078,88 +9087,88 @@ disjoint_from: MOLSIM:000813 ! self-consistent field
 [Term]
 id: MOLSIM:000813
 name: self-consistent field
-def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED)." []
+def: "Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)" []
 synonym: "SCF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000814
 name: Unrestricted Hartree-Fock
-def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED)." []
+def: "Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)" []
 synonym: "UHF" EXACT []
 is_a: MOLSIM:000810 ! Hartree-Fock
 
 [Term]
 id: MOLSIM:000815
 name: MINDO
-def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED)." []
+def: "Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)" []
 is_a: MOLSIM:000809 ! INDO
 
 [Term]
 id: MOLSIM:000816
 name: MNDO
-def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED)." []
+def: "Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000817
 name: NDDO
-def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED)." []
+def: "Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 disjoint_from: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000818
 name: PDDG
-def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED)." []
+def: "Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
 id: MOLSIM:000819
 name: PM3
-def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED)." []
+def: "Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000820
 name: PM3MM
-def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region (UNVERIFIED)." []
+def: "A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3's balance of speed and accuracy for the QM region. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000821
 name: PM6
-def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED)." []
+def: "Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)" []
 is_a: MOLSIM:000819 ! PM3
 
 [Term]
 id: MOLSIM:000822
 name: RM1
-def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED)." []
+def: "Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1's accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000823
 name: SAM1
-def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED)." []
+def: "Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000824
 name: SINDO
-def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED)." []
+def: "Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)" []
 is_a: MOLSIM:000804 ! all-valence-electron restricted
 
 [Term]
 id: MOLSIM:000825
 name: Sparkle/AM1
-def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED)." []
+def: "A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)" []
 is_a: MOLSIM:000807 ! AM1
 
 [Term]
 id: MOLSIM:000826
 name: ZANDO
-def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED)." []
+def: "An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)" []
 is_a: MOLSIM:000817 ! NDDO
 
 [Term]
@@ -9201,13 +9210,13 @@ is_a: MOLSIM:000827 ! Moeller-Plesset
 [Term]
 id: MOLSIM:000832
 name: multi-reference
-def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED)." []
+def: "A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000833
 name: complete active space self-consistent field
-def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED)." []
+def: "Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)" []
 synonym: "CASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
@@ -9215,48 +9224,48 @@ disjoint_from: MOLSIM:000834 ! multi-configurational self-consistent field
 [Term]
 id: MOLSIM:000834
 name: multi-configurational self-consistent field
-def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED)." []
+def: "Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)" []
 synonym: "MC-SCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000835
 name: multi-reference coupled cluster with single and double excitations
-def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED)." []
+def: "Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)" []
 synonym: "MR-CCSD" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000836
 name: multi-reference configuration interaction with single and double excitations
-def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED)." []
+def: "Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)" []
 synonym: "MR-CI(SD)" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000837
 name: restricted active space self-consistent field
-def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED)." []
+def: "Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)" []
 synonym: "RASSCF" EXACT []
 is_a: MOLSIM:000832 ! multi-reference
 
 [Term]
 id: MOLSIM:000838
 name: quadratic configuration interaction
-def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED)." []
+def: "A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)" []
 is_a: MOLSIM:000173 ! quantum mechanics
 
 [Term]
 id: MOLSIM:000839
 name: QCISD(T)
-def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 disjoint_from: MOLSIM:000840 ! QCISD
 
 [Term]
 id: MOLSIM:000840
 name: QCISD
-def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED)." []
+def: "Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)" []
 is_a: MOLSIM:000838 ! quadratic configuration interaction
 
 [Term]
@@ -9683,9 +9692,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:000905
-name: small molecule structure (deprecated)
-def: "Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete small molecule structure
+def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000906
@@ -9988,14 +9997,14 @@ is_a: MOLSIM:000984 ! distribution analysis
 [Term]
 id: MOLSIM:000978
 name: conformation validation analysis
-def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED)." []
+def: "A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 disjoint_from: MOLSIM:000981 ! secondary structure assignment analysis
 
 [Term]
 id: MOLSIM:000979
 name: ramachandran analysis
-def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED)." []
+def: "A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)" []
 is_a: MOLSIM:000917 ! structural analysis
 disjoint_from: MOLSIM:000980 ! structural check analysis
 
@@ -10035,7 +10044,7 @@ is_a: MOLSIM:000974 ! solvent analysis
 [Term]
 id: MOLSIM:000985
 name: matrix diagonalization analysis
-def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED)." []
+def: "A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000383 ! mathematical analysis
 
 [Term]
@@ -10548,9 +10557,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 
 [Term]
 id: MOLSIM:001087
-name: macromolecular structure format (deprecated)
-def: "A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete macromolecular structure format
+def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001088
@@ -10561,9 +10570,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001089
-name: software-specific coordinate format (deprecated)
-def: "A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001088 ! molecular structure format
+name: obsolete software-specific coordinate format
+def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001090
@@ -11213,7 +11222,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001234
 name: GaMD potential boost stddev limit
-def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D." []
+def: "A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D." []
 is_a: MOLSIM:001233 ! Gaussian accelerated MD parameter
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -11442,7 +11451,7 @@ is_a: MOLSIM:001268 ! volumetric analysis parameter
 [Term]
 id: MOLSIM:001270
 name: grid function
-def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e" []
+def: "A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)" []
 is_a: MOLSIM:001268 ! volumetric analysis parameter
 
 [Term]
@@ -11578,7 +11587,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001292
 name: computed observable
-def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)" []
+def: "A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)" []
 
 [Term]
 id: MOLSIM:001293
@@ -12319,21 +12328,25 @@ is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:001404
-name: Pearson product-moment correlation coefficient
-def: "A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Pearson product-moment correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply 'r'. This is a standard output of statistical packages." []
+comment: Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - 'Pearson product-moment correlation coefficient' is the full formal name of Pearson's correlation coefficient. Replaced by the reused STATO term.
+is_obsolete: true
+replaced_by: STATO:0000280
 
 [Term]
 id: MOLSIM:001405
-name: Spearman rank correlation coefficient
-def: "A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+name: obsolete Spearman rank correlation coefficient
+def: "OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman's rho." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM's (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson's). Note the symbol 'rho' named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.
+is_obsolete: true
+replaced_by: STATO:0000201
 
 [Term]
 id: MOLSIM:001406
 name: Kendall tau correlation coefficient
 def: "A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall's tau. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142 ! correlation coefficient
 
 [Term]
 id: MOLSIM:001407
@@ -12349,15 +12362,19 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001409
-name: standard error of the mean (SEM)
-def: "A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard error of the mean (SEM)
+def: "OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the '(SEM)' abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO's own definition spells out the abbreviation.
+is_obsolete: true
+replaced_by: STATO:0000037
 
 [Term]
 id: MOLSIM:001410
-name: coefficient of determination
-def: "A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete coefficient of determination
+def: "OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000564
 
 [Term]
 id: MOLSIM:001411
@@ -12380,9 +12397,11 @@ is_a: MOLSIM:001403 ! statistical property
 
 [Term]
 id: MOLSIM:001414
-name: standard deviation
-def: "A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)" []
-is_a: MOLSIM:001403 ! statistical property
+name: obsolete standard deviation
+def: "OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev." []
+comment: Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.
+is_obsolete: true
+replaced_by: STATO:0000237
 
 [Term]
 id: MOLSIM:001415
@@ -12816,21 +12835,23 @@ is_a: MOLSIM:000007 ! force field
 
 [Term]
 id: MOLSIM:001484
-name: statistical model
-def: "A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)" []
+name: statistical mechanics model
+def: "A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)" []
+comment: Not to be confused with STATO:0000107 "statistical model", which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; "statistical model" is retained as an exact synonym.
+synonym: "statistical model" EXACT []
 is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:001485
 name: Maxwell-Boltzmann distribution
-def: "The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
-is_a: MOLSIM:001484 ! statistical model
+def: "The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system's kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)" []
+is_a: MOLSIM:001484 ! statistical mechanics model
 
 [Term]
 id: MOLSIM:001486
 name: two-state transition model
-def: "A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
-is_a: MOLSIM:001484 ! statistical model
+def: "A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes." []
+is_a: MOLSIM:001484 ! statistical mechanics model
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -13930,7 +13951,7 @@ is_a: MOLSIM:001664 ! software suite
 [Term]
 id: MOLSIM:001666
 name: metatwist
-def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)" []
+def: "Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)" []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
@@ -14441,10 +14462,10 @@ disjoint_from: MOLSIM:010012 ! STRIDE algorithm
 
 [Term]
 id: MOLSIM:001747
-name: trajectory analysis algorithm (deprecated)
-def: "A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)" []
+name: obsolete trajectory analysis algorithm
+def: "OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations." []
 comment: candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21
-is_a: MOLSIM:000037 ! algorithm
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001748
@@ -14517,10 +14538,10 @@ is_a: MOLSIM:001711 ! residue library
 
 [Term]
 id: MOLSIM:001759
-name: Miller indices (deprecated)
-def: "Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)" []
+name: obsolete Miller indices
+def: "OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model." []
 comment: Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26
-is_a: MOLSIM:000447 ! identifier
+is_obsolete: true
 
 [Term]
 id: MOLSIM:001760
@@ -14838,7 +14859,7 @@ is_a: MOLSIM:001403 ! statistical property
 id: MOLSIM:001810
 name: RMS average correlation
 def: "The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system's dynamics, with a higher value indicating that the molecule's motions are more concerted. (UNVERIFIED)" []
-is_a: MOLSIM:000111 ! correlation coefficient
+is_a: STATO:0000142 ! correlation coefficient
 
 [Term]
 id: MOLSIM:001811
@@ -15901,7 +15922,7 @@ is_a: MOLSIM:000172 ! topology and parameterization tool
 [Term]
 id: MOLSIM:001973
 name: AMBERGS
-def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)" []
+def: "AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)" []
 is_a: MOLSIM:000009 ! protein force field
 
 [Term]
@@ -16077,7 +16098,7 @@ is_a: MOLSIM:001515 ! Lennard-Jones parameters
 [Term]
 id: MOLSIM:002001
 name: repulsion interaction parameter
-def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the \nC12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the \n1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
+def: "A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)" []
 is_a: MOLSIM:001515 ! Lennard-Jones parameters
 
 [Term]
@@ -16377,20 +16398,20 @@ is_a: MOLSIM:001566 ! library
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
 
@@ -16441,7 +16462,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
@@ -17112,81 +17133,81 @@ is_a: MOLSIM:002162 ! system classification label
 [Term]
 id: MOLSIM:010001
 name: femtosecond
-def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second." []
+def: "An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)" []
 synonym: "fs" EXACT []
 is_a: UO:1000010 ! second based unit
 
 [Term]
 id: MOLSIM:010002
 name: atmosphere
-def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth." []
+def: "A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)" []
 synonym: "atm" EXACT []
 is_a: UO:0000109 ! pressure unit
 
 [Term]
 id: MOLSIM:010003
 name: angstrom per nanosecond
-def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes." []
+def: "A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)" []
 synonym: "Å/ns|angstrom/nanosecond" EXACT []
 is_a: UO:0000060 ! speed/velocity unit
 
 [Term]
 id: MOLSIM:010004
 name: kilocalorie per mole
-def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities." []
+def: "A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)" []
 synonym: "kcal/mol|kilocalorie/mole" EXACT []
 is_a: UO:0000111 ! energy unit
 
 [Term]
 id: MOLSIM:010005
 name: kilocalorie per mole per square angstrom
-def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights." []
+def: "A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)" []
 synonym: "kcal/mol/Å^2|kilocalorie/mole/angstrom^2" EXACT []
 is_a: UO:0000111 ! energy unit
 
 [Term]
 id: MOLSIM:010006
 name: elementary charge
-def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs." []
+def: "A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)" []
 synonym: "e" EXACT []
 is_a: UO:0000219 ! electric charge
 
 [Term]
 id: MOLSIM:010007
 name: kinematic viscosity unit
-def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density." []
+def: "A unit that measures a fluid's resistance to flow under the influence of gravity. It is the ratio of the fluid's dynamic viscosity to its density. (UNVERIFIED)" []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MOLSIM:010008
 name: square centimeter per second
-def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St)." []
+def: "A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)" []
 synonym: "cm^2/s|stokes|St" EXACT []
 is_a: MOLSIM:010007 ! kinematic viscosity unit
 
 [Term]
 id: MOLSIM:010009
 name: electric dipole moment unit
-def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity." []
+def: "A unit that measures the separation of positive and negative electrical charges within a system, indicating the system's overall polarity. (UNVERIFIED)" []
 is_a: UO:0000000 ! unit
 
 [Term]
 id: MOLSIM:010010
 name: debye
-def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters." []
+def: "A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)" []
 synonym: "D" EXACT []
 is_a: MOLSIM:010009 ! electric dipole moment unit
 
 [Term]
 id: MOLSIM:010011
 name: Kabsch RMSD algorithm
-def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector." []
+def: "The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)" []
 is_a: MOLSIM:001717 ! RMSD calculation algorithm
 
 [Term]
 id: MOLSIM:010012
 name: STRIDE algorithm
-def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein." []
+def: "In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)" []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 
 [Term]
@@ -17198,19 +17219,19 @@ is_a: MOLSIM:001751 ! statistical algorithm
 [Term]
 id: MOLSIM:010014
 name: parametric distribution fitting algorithm
-def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods." []
+def: "Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010015
 name: spline-based estimation algorithm
-def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy." []
+def: "Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)" []
 is_a: MOLSIM:001751 ! statistical algorithm
 
 [Term]
 id: MOLSIM:010016
 name: Shrake-Rupley algorithm
-def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces." []
+def: "The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by \"rolling\" a probe sphere over the atoms' van der Waals surfaces. (UNVERIFIED)" []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
 
 [Term]
@@ -17566,6 +17587,104 @@ def: "A subsection of sequence with biological interest that is conserved in dif
 subset: biosapiens
 synonym: "polypeptide conserved region" EXACT []
 is_a: SO:0000839 ! polypeptide_region
+
+[Term]
+id: STATO:0000037
+name: standard error of the mean
+def: "The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean's estimate of a population mean.\nIt is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.\n\nA measure of dispersion applied to means across hypothetical repeated random samples." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000112 "http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct" xsd:string
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "SEM" xsd:string
+property_value: IAO:0000119 "adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)" xsd:string
+property_value: seeAlso "https://fevir.net/resources/CodeSystem/27270#STATO:0000037" xsd:string
+property_value: STATO:0000032 "SEM" xsd:string
+property_value: STATO:0000391 "scipy.stats.sem(a, axis=0, ddof=1)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928" xsd:string
+
+[Term]
+id: STATO:0000142
+name: correlation coefficient
+def: "The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000119 "STATO" xsd:string
+property_value: STATO:0000032 "r" xsd:string
+property_value: STATO:0000032 "r statistic" xsd:string
+
+[Term]
+id: STATO:0000201
+name: Spearman's rank correlation coefficient
+def: "Spearman's rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.\nSpearman's coefficient may be used when the conditions for computing Pearson's correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables" []
+is_a: STATO:0000142 ! correlation coefficient
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "Spearman's rho" xsd:string
+property_value: IAO:0000119 "http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "cor(x, y = NULL, use = \"everything\",method = c(\"spearman\"))" xsd:string
+property_value: STATO:0000391 "scipy.stats.spearmanr(a, b=None, axis=0)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643" xsd:string
+
+[Term]
+id: STATO:0000237
+name: standard deviation
+def: "The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "σ" xsd:string
+property_value: IAO:0000119 "http://en.wikipedia.org/wiki/Standard_deviation" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "sd(x, na.rm = FALSE)\n\nhttp://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html" xsd:string
+
+[Term]
+id: STATO:0000280
+name: Pearson's correlation coefficient
+def: "The Pearson's correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. \nThe coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related." []
+is_a: STATO:0000142 ! correlation coefficient
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000117 "Alejandra Gonzalez-Beltran" xsd:string
+property_value: IAO:0000117 "Orlaith Burke" xsd:string
+property_value: IAO:0000117 "Philippe Rocca-Serra" xsd:string
+property_value: IAO:0000118 "Pearson product-moment correlation coefficient" xsd:string
+property_value: IAO:0000118 "Pearson's r" xsd:string
+property_value: IAO:0000118 "r statistics" xsd:string
+property_value: IAO:0000119 "STATO, adapted from\nhttp://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient\nand from:\nhttp://stamash.org/pearsons-correlation-coefficient/\nhttp://stamash.org/kendalls-tau-correlation/" xsd:string
+property_value: STATO:0000032 "" xsd:string
+property_value: STATO:0000041 "cor(x, y = NULL, use = \"everything\",method = c(\"pearson\"))" xsd:string
+property_value: STATO:0000041 "http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html" xsd:string
+property_value: STATO:0000391 "scipy.stats.pearsonr(x, y)\n\nhttp://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr\n\nsource:\nhttps://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427" xsd:string
+
+[Term]
+id: STATO:0000564
+name: coefficient of determination
+def: "The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).\nIn the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000114 IAO:0000122
+property_value: IAO:0000118 "r2" xsd:string
+property_value: STATO:0000041 "> eruption.lm = lm(eruptions ~ waiting, data=faithful)\n> summary(eruption.lm)$r.squared \n\n\nfrom:\nhttp://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination" xsd:string
+
+[Term]
+id: STATO:0000700
+name: p-value
+def: "A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true." []
+is_a: MOLSIM:001403 ! statistical property
+property_value: IAO:0000116 "Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.\n\nWithin the Bayesian framework, use the posterior predictive p-value." xsd:string
+property_value: IAO:0000118 "P value" xsd:string
+property_value: IAO:0000118 "p value" xsd:string
+property_value: IAO:0000118 "P-value" xsd:string
+property_value: IAO:0000118 "PValue" xsd:string
+property_value: IAO:0000119 "SEVCO group" xsd:string
 
 [Term]
 id: UO:0000000
@@ -17941,7 +18060,7 @@ range: MOLSIM:000001 ! software
 [Typedef]
 id: MOLSIM:000508
 name: protein structure source
-def: "The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
+def: "The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein's 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)" []
 domain: MOLSIM:000904 ! molecular structure
 range: MOLSIM:000688 ! data source
 

--- a/molsim.owl
+++ b/molsim.owl
@@ -17,7 +17,7 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-24/molsim.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
@@ -28,7 +28,9 @@
         <dcterms:subject xml:lang="en">biomolecular simulation</dcterms:subject>
         <dcterms:title>Molecular Simulation Ontology</dcterms:title>
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
-        <owl:versionInfo>2026-07-24</owl:versionInfo>
+        <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
+        <owl:versionInfo>2026-07-29</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -51,14 +53,99 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000111>editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000111>editor preferred term~editor preferred label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+        <obo:IAO_0000111 xml:lang="en">example</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">example of usage</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">example of usage</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
+        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000281</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
+        <obo:IAO_0000111>textual definition</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2012-04-05: 
+Barry Smith
+
+The official OBI definition, explaining the meaning of a class or property: &apos;Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions&apos;  is terrible.
+
+Can you fix to something like:
+
+A statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.
+
+Alan Ruttenberg
+
+Your proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can&apos;t be evaluated by those criteria. 
+
+On the specifics of the proposed definition:
+
+We don&apos;t have definitions of &apos;meaning&apos; or &apos;expression&apos; or &apos;property&apos;. For &apos;reference&apos; in the intended sense I think we use the term &apos;denotation&apos;. For &apos;expression&apos;, I think we you mean symbol, or identifier. For &apos;meaning&apos; it differs for class and property. For class we want documentation that let&apos;s the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let&apos;s the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The &apos;intended reader&apos; part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. 
+
+Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
+
+We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  </obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label>definition</rdfs:label>
         <rdfs:label xml:lang="en">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
+        <obo:IAO_0000111 xml:lang="en">editor note</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obfoundry.org/obo/obi&gt;</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obofoundry.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor note</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -66,10 +153,28 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
+        <obo:IAO_0000111 xml:lang="en">term editor</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115.</obo:IAO_0000116>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">term editor</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+        <obo:IAO_0000111 xml:lang="en">alternative term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">alternative term</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -77,11 +182,57 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+        <obo:IAO_0000111 xml:lang="en">definition source</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
         <obo:IAO_0000115 xml:lang="en">Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119>Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w</obo:IAO_0000119>
         <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">definition source</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000032 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000032">
+        <obo:IAO_0000115 xml:lang="en">an alternative term used for STATO statistical ontology and ISA team</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">STATO alternative term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000041 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000041">
+        <obo:IAO_0000115 xml:lang="en">a R command syntax or link to a R documentation in support of Statistical Ontology Classes or Data Transformations</obo:IAO_0000115>
+        <obo:IAO_0000117>Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">R command</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000391 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/STATO_0000391">
+        <obo:IAO_0000115 xml:lang="en">an annotation property to provide a canonical command to invoke a method implementation using Python programming language</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">Python command</rdfs:label>
     </owl:AnnotationProperty>
     
 
@@ -255,9 +406,24 @@
     
 
 
+    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+    
+
+
     <!-- http://www.w3.org/2000/01/rdf-schema#label -->
 
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
+        <obo:IAO_0000111>label</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
     
 
 
@@ -468,7 +634,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000904"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000688"/>
-        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB).  It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The source for the used protein structures (e.g. PDB). It indicates the origin or method by which a specific protein&apos;s 3D structural coordinates, used as input for a simulation or analysis, were obtained. This could be an entry in an experimental database like the Protein Data Bank (PDB), a result from a computational prediction method (e.g., homology modeling, ab initio prediction), or another defined source. This property is crucial for tracing the provenance and assessing the initial quality of structural data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein structure source</rdfs:label>
     </owl:ObjectProperty>
     
@@ -1397,7 +1563,9 @@
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -15834,6 +16002,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000006">
         <obo:IAO_0000115 xml:lang="en">A simplified representation used to study a real-world system, such as a molecule or collection of molecules. In biomolecular simulation, it defines the components (atoms, residues) and their properties needed for computational analysis. This framework allows scientists to simulate and predict the system&apos;s behavior. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Distinct from &apos;MoDEL&apos; (MOLSIM:001001), a named simulation data repository whose name differs from this term only by capitalisation. This term is the general class of representations used in simulation.</rdfs:comment>
         <rdfs:label xml:lang="en">model</rdfs:label>
     </owl:Class>
     
@@ -16158,7 +16327,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000037">
-        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A well-defined sequence of steps or rules designed to perform a specific task or solve a particular problem. In computational science, algorithms provide the precise instructions for a computer to follow to achieve a desired outcome, such as simulating molecular motion or analyzing data. They are the fundamental building blocks of computational methods used in biomolecular simulation and analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">algorithm</rdfs:label>
     </owl:Class>
     
@@ -16168,7 +16337,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000038">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to control the temperature of the simulated system, ensuring it samples configurations corresponding to a specific target temperature (e.g., for the NVT or NPT ensembles). Thermostats work by adjusting particle velocities or adding/removing kinetic energy in various ways to mimic coupling with an external heat bath. Different thermostat algorithms vary in their theoretical basis, efficiency, and how accurately they reproduce correct statistical mechanics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -16178,7 +16347,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000382"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations, typically alongside a thermostat, to control the pressure of the simulated system by adjusting the simulation box volume. This allows simulations to be performed under conditions of constant pressure and temperature (NPT ensemble), mimicking typical laboratory conditions. Different barostats vary in how they couple the volume changes to the pressure difference and whether they allow anisotropic box changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">barostat algorithm</rdfs:label>
     </owl:Class>
     
@@ -16188,7 +16357,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that weakly couples the system to an external pressure bath by rescaling the simulation box volume and particle coordinates based on the difference between the current instantaneous pressure and the target pressure. Similar to the Berendsen thermostat, it is computationally simple and effective for equilibration but does not rigorously sample the correct NPT ensemble. It allows isotropic or anisotropic pressure coupling. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen barostat</rdfs:label>
     </owl:Class>
     
@@ -16198,7 +16367,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where trial changes to the simulation box volume are attempted periodically during a molecular dynamics simulation using a Monte Carlo acceptance criterion. Accepted moves rescale the box dimensions and particle coordinates. This method correctly samples the NPT ensemble but can be less efficient than continuous barostats for large volume fluctuations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Monte Carlo barostat</rdfs:label>
     </owl:Class>
     
@@ -16208,7 +16377,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm where the simulation box volume is treated as a dynamic variable coupled to a fictitious &quot;piston&quot; mass, interacting with the internal pressure of the system. This extended Lagrangian approach allows the volume to fluctuate dynamically around the value corresponding to the target external pressure, correctly generating the NPT ensemble. It typically assumes isotropic volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen barostat</rdfs:label>
     </owl:Class>
     
@@ -16218,7 +16387,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An extension of the Andersen barostat that allows the simulation box shape and volume to change anisotropically, meaning the lengths of the box edges and the angles between them can fluctuate independently. This is crucial for simulating phase transitions or studying materials under anisotropic stress conditions while correctly sampling the NPT ensemble. It uses a matrix of barostat variables coupled to the pressure tensor. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Parrinello-Rahman barostat</rdfs:label>
     </owl:Class>
     
@@ -16228,7 +16397,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000044">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A barostat algorithm that combines the extended Lagrangian approach (like Andersen or Parrinello-Rahman) with Langevin dynamics applied to the piston/box degrees of freedom. This introduces stochastic and frictional terms to the equation of motion for the box volume, helping to control pressure fluctuations and potentially improving sampling efficiency. It aims to provide robust pressure control while correctly sampling the NPT ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Langevin-piston barostat</rdfs:label>
     </owl:Class>
     
@@ -16249,7 +16418,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000046">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that weakly couples the system to an external heat bath by rescaling particle velocities at each step based on the difference between the current instantaneous temperature and the target temperature. While computationally simple and effective at bringing the system to the target temperature, it does not rigorously generate configurations from the correct canonical (NVT) ensemble. It is often used for equilibration phases rather than production simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Berendsen thermostat</rdfs:label>
     </owl:Class>
     
@@ -16259,7 +16428,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000047">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermostat algorithm that maintains temperature by introducing stochastic collisions between randomly selected particles and fictitious heat bath particles. When a particle &quot;collides,&quot; its velocity is reassigned from a Maxwell-Boltzmann distribution corresponding to the target temperature. This method correctly generates configurations from the canonical (NVT) ensemble. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Andersen thermostat</rdfs:label>
     </owl:Class>
     
@@ -16269,7 +16438,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000048">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deterministic thermostat algorithm that controls temperature by introducing an extended degree of freedom (a thermostat variable) that dynamically couples to the physical system&apos;s kinetic energy. This extended variable evolves according to its own equation of motion, causing the physical system&apos;s temperature to fluctuate around the target value in a way consistent with the canonical (NVT) ensemble. It avoids the stochastic elements of Langevin or Andersen thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Nose-Hoover</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Nosé-Hoover thermostat</rdfs:label>
     </owl:Class>
@@ -16280,7 +16449,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in molecular dynamics simulations to fix certain geometric parameters, most commonly bond lengths involving light atoms like hydrogen. By constraining these fast vibrations, longer simulation time steps can be used, significantly speeding up the simulation while having minimal impact on slower, large-scale motions. These algorithms iteratively adjust particle positions or use analytical solutions to satisfy the constraint conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">constraint algorithm</rdfs:label>
     </owl:Class>
     
@@ -16290,7 +16459,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An iterative constraint algorithm widely used in molecular dynamics to fix bond lengths. It adjusts the positions of atoms involved in a constraint at the end of a time step until the constraint condition (e.g., fixed bond distance) is satisfied within a defined tolerance. It handles coupled constraints involving multiple atoms connected together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -16300,7 +16469,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm similar to SHAKE but designed for velocity-Verlet type integrators, ensuring that both positions and velocities satisfy the constraint conditions at the end of each time step. It involves solving constraint equations for positions first, then using those positions to solve for constrained velocities. This maintains consistency between positions and velocities under constraint. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RATTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -16310,7 +16479,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000052">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for algorithms designed to solve systems of linear equations that arise from geometric constraints in molecular simulations, particularly when constraints are applied before integrating equations of motion (e.g., in Lagrangian multiplier methods). While iterative methods like SHAKE/RATTLE solve non-linear equations implicitly, linear solvers might be used in different formulations. It represents the mathematical task underlying some constraint methods. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">LINCS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">linear constraint solver algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">LINCS algorithm</rdfs:label>
@@ -16323,7 +16492,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000053">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000384"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001724"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to efficiently calculate the long-range electrostatic forces between charged particles (atoms) in molecular simulations, which is computationally demanding due to the N-squared complexity if all pairs are considered directly. These methods employ various approximations or techniques like grid-based calculations, truncation schemes, or multipole expansions to reduce the computational cost while maintaining acceptable accuracy. They are essential for simulating realistic biomolecular systems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">electrostatic interaction algorithm</rdfs:label>
     </owl:Class>
     
@@ -16333,7 +16502,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000054">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000428"/>
-        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly efficient grid-based algorithm for calculating long-range electrostatic interactions in periodic systems, based on the Ewald summation technique. It splits the calculation into a short-range part computed directly in real space and a long-range part computed efficiently in reciprocal space using Fast Fourier Transforms (FFTs) on a grid. PME is a standard method for accurate electrostatics in biomolecular simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">PME</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle mesh Ewald</rdfs:label>
     </owl:Class>
@@ -16344,7 +16513,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000055">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An approximate method for handling long-range electrostatic interactions where direct interactions are calculated only up to a certain cutoff distance. The effect of charges beyond the cutoff is approximated by embedding the cutoff sphere within a continuous dielectric medium representing the solvent. While computationally cheaper than PME, its accuracy depends on the system and parameters chosen. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">reaction field</rdfs:label>
     </owl:Class>
@@ -16355,7 +16524,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000056">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000053"/>
-        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An efficient algorithm for calculating long-range forces (like electrostatic or gravitational) in particle simulations, conceptually similar to Particle Mesh Ewald (PME). It splits the force calculation into a short-range part computed directly between nearby particles (particle-particle) and a long-range part computed using a grid and Fast Fourier Transforms (particle-mesh). PPPM is widely used in both astrophysics and molecular simulation for its performance and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">P3M</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">PPPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">particle-particle particle-mesh</rdfs:label>
@@ -16539,7 +16708,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000074">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used to quantify the degree of resemblance between two objects, often molecules represented by chemical fingerprints or structural features, or between simulation data like conformations or trajectories. These methods employ various mathematical formulas (metrics or coefficients) to compute a numerical score indicating similarity or distance. They are widely used in cheminformatics, drug discovery, and simulation analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">similarity calculation algorithm</rdfs:label>
     </owl:Class>
     
@@ -16549,7 +16718,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000075">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity.  (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to a similarity score derived by combining the standard Tanimoto coefficient (often calculated on molecular fingerprints) with other similarity measures or scores. The goal of combining scores is often to leverage the strengths of different metrics to get a more robust or comprehensive assessment of similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tanimoto similarity algorithm</rdfs:label>
     </owl:Class>
     
@@ -16559,7 +16728,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16569,7 +16738,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000077">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used to compare two sets (e.g., features in molecular fingerprints), closely related to the Tanimoto coefficient and Jaccard index. It measures the overlap between the sets, normalized by the average size of the two sets. It is often used in information retrieval and cheminformatics as an alternative similarity metric. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dice coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -16579,7 +16748,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000078">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common method for calculating the distance between two points (e.g., representing molecules in a multi-dimensional property space or conformations by atom coordinates) based on the straight-line distance in that space. It is calculated as the square root of the sum of squared differences between corresponding coordinates or features. Lower Euclidean distance implies higher similarity in the context of the chosen space. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Euclidean distance</rdfs:label>
     </owl:Class>
     
@@ -16609,7 +16778,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000081">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method specifically used for comparing two strings or bit vectors (like binary molecular fingerprints) of equal length. It counts the number of positions at which the corresponding symbols or bits are different. A lower Hamming distance indicates higher similarity between the binary representations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hamming distance algorithm</rdfs:label>
     </owl:Class>
     
@@ -16619,7 +16788,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000082">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets) (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method used for comparing two sets, defined as the size of the intersection divided by the size of the union of the sets. It is identical to the Tanimoto coefficient when applied to binary data (like molecular fingerprints). It provides a normalized measure of overlap between feature sets, ranging from 0 (no overlap) to 1 (identical sets). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Jaccard index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16629,7 +16798,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000083">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity calculation method that measures the overlap between two sets, defined as the size of the intersection divided by the size of the smaller of the two sets. Unlike Tanimoto/Jaccard, it reaches 1 if one set is a subset of the other. It is useful for assessing containment or sub-structure relationships. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">overlap coefficient algorithm</rdfs:label>
     </owl:Class>
     
@@ -16639,7 +16808,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000084">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines FitTversky shape matching with FitColorTversky chemical feature matching into a single metric. This measure emphasizes the database (fit) molecule&apos;s characteristics through its high β parameter value (0.95), making it particularly useful for identifying compounds where the query molecule is a substructure of database molecules. Like RefTverskyCombo, it produces scores typically ranging from 0 to 2, providing a balanced assessment of both geometric shape and chemical functionality similarities. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -16649,7 +16818,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000085">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of  = 0.95, and beta (β) value of = 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specialized variant of the Tversky Index that uses fixed parameters with the alpha (α) value of 0.95, and beta (β) value of 0.05 to heavily weight the reference molecule in the comparison. This asymmetric weighting makes it particularly effective at finding molecules that contain the reference structure as a substructure. RefTversky is commonly used in virtual screening to identify compounds that preserve key structural features of a reference molecule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky</rdfs:label>
     </owl:Class>
     
@@ -16659,7 +16828,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000086">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
-        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A general term for a similarity score obtained by combining results from multiple different similarity calculation methods or metrics. The rationale is often to capture different aspects of similarity (e.g., structural, feature-based) into a single, potentially more informative score. The specific combination formula and constituent metrics define the particular combo score. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">combo score algorithm</rdfs:label>
     </owl:Class>
     
@@ -16669,7 +16838,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000087">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm designed to find the best path or connection between states or nodes according to some defined criteria, such as minimum cost, shortest distance, or maximum flow. These algorithms are used in various contexts, including finding minimum energy pathways for reactions, constructing minimum spanning trees for clustering, optimizing network routes, or solving complex search problems. They employ different strategies ranging from exact graph traversals to heuristic searches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">optimal transformation path algorithm</rdfs:label>
     </owl:Class>
     
@@ -16679,7 +16848,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16689,7 +16858,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000089">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Another greedy algorithm for finding a Minimum Spanning Tree (MST) in a connected, undirected graph with weighted edges. It works by starting with an arbitrary vertex and iteratively adding the cheapest edge that connects a vertex in the growing tree to a vertex outside the tree, until all vertices are included. It provides an alternative approach to Kruskal&apos;s for constructing an MST. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Prim&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16699,7 +16868,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000090">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm for finding the shortest path between a starting node and all other nodes in a graph with non-negative edge weights. It works by iteratively exploring the graph, maintaining the shortest distance found so far to each node, and always extending the path from the node with the current shortest distance. It is fundamental in graph theory and network routing. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Dijkstra&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -16709,7 +16878,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000091">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An informed search algorithm used for finding the shortest path between a starting node and a target node in a graph, commonly used in pathfinding and planning problems. It extends Dijkstra&apos;s algorithm by using a heuristic function to estimate the cost from the current node to the target, guiding the search towards the goal more efficiently. Its performance depends on the quality of the heuristic used. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">A-star search algorithm</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">A* search algorithm</rdfs:label>
     </owl:Class>
@@ -16720,7 +16889,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000092">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Generally refers to algorithms that operate based on proximity, often used in classification, clustering, or search problems. In pathfinding or optimization, a simple nearest neighbor approach might involve iteratively moving to the closest unvisited node, which is a heuristic that does not guarantee finding the globally optimal path (e.g., in the Traveling Salesperson Problem). It can also refer to K-Nearest Neighbors (KNN) classification/regression. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nearest neighbor algorithm</rdfs:label>
     </owl:Class>
     
@@ -16730,7 +16899,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of heuristic optimization algorithms inspired by the process of natural selection and evolution. They maintain a population of candidate solutions (chromosomes) that evolve over generations through processes like selection, crossover (recombination), and mutation, guided by a fitness function that evaluates solution quality. Genetic algorithms are often used for complex optimization problems where exact methods are infeasible. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">genetic algorithm</rdfs:label>
     </owl:Class>
     
@@ -16740,7 +16909,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000094">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm used for finding the global optimum of a function in a large search space, inspired by the annealing process in metallurgy. It starts with an initial solution and iteratively explores neighboring solutions, accepting worse solutions with a probability that decreases over time (controlled by a &quot;temperature&quot; parameter), allowing it to escape local optima. It is a metaheuristic for global optimization. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulated annealing algorithm</rdfs:label>
     </owl:Class>
     
@@ -16750,7 +16919,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000095">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A probabilistic heuristic algorithm for finding good paths through graphs, inspired by the foraging behavior of ants who deposit pheromones. Artificial ants construct candidate solutions (paths) by moving through the graph, probabilistically choosing edges based on distance and accumulated artificial pheromone trails, which are updated based on the quality of solutions found. It is often applied to combinatorial optimization problems like the Traveling Salesperson Problem. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ant colony optimization algorithm</rdfs:label>
     </owl:Class>
     
@@ -16760,7 +16929,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000096">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of algorithms designed to solve problems related to flows in networks (graphs where edges have capacities), such as finding the maximum flow possible between a source and a sink node. Examples include the Ford-Fulkerson algorithm and its variations (e.g., Edmonds-Karp). These algorithms are used in logistics, scheduling, network design, and resource allocation problems. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">network flow algorithm</rdfs:label>
     </owl:Class>
     
@@ -16921,9 +17090,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000111 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000111">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the strength and direction of the linear association between two variables. It is a value between -1 and 1, where 1 indicates a perfect positive correlation and -1 indicates a perfect negative correlation. The correlation coefficient is widely used to identify relationships between different properties in a simulation. This is often reported as r or rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000142. STATO is the canonical OBO home for statistics; reused in place of this term. Its four children were re-parented under STATO:0000142 in the same edit - retiring a parent necessarily re-points every child that named it.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -16931,9 +17102,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000112 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000112">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson&apos;s correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Pearson&apos;s correlation coefficient (often denoted as &apos;r&apos;) measures the strength and direction of the linear relationship between two continuous variables. It assumes the data are approximately normally distributed and calculates the covariance of the two variables divided by the product of their standard deviations. It is perhaps the most widely used measure of linear correlation.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000280. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson&apos;s correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -17070,7 +17243,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000125">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000124"/>
-        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)  </obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kolmogorov-Smirnov (KS) test is a non-parametric statistical test used to determine if two underlying one-dimensional probability distributions differ, or if a sample of data comes from a specific reference probability distribution. It quantifies the maximum distance between the empirical distribution function of the sample(s) and the cumulative distribution function of the reference distribution or the other sample. It is sensitive to differences in location, scale, and shape. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kolmogorov-Smirnov test analysis</rdfs:label>
     </owl:Class>
     
@@ -17306,7 +17479,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000148">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000143"/>
-        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This practical criterion emphasizes selecting ligands for which reliable experimental data, particularly binding affinity measurements (like Ki, Kd, or IC50), already exist. Having high-quality experimental data is essential for validating the computational predictions and assessing the accuracy of the methods used. Availability of structural data (e.g., co-crystal structures) is also highly valuable.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">experimental data availability</rdfs:label>
     </owl:Class>
@@ -17561,7 +17734,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000173">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000141"/>
-        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The fundamental physical theory describing the behavior of nature at the scale of atoms and subatomic particles, forming the theoretical basis for understanding chemical bonding and molecular properties. In computational chemistry, its principles are used to develop mathematical models and simulation methods for predicting molecular structures, energies, and reactivity. It provides the underlying rules for how electrons and nuclei interact within a molecule. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">QM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">quantum mechanics</rdfs:label>
     </owl:Class>
@@ -17592,7 +17765,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000176">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (UNVERIFIED) (If GAMESS-UK was intended, see previous definition)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This likely refers to GAMESS-US (General Atomic and Molecular Electronic Structure System), a widely used, freely available quantum chemistry software package. It provides a broad range of quantum mechanical methods (HF, DFT, MP2, CCSD, MCSCF) and features for geometry optimization, vibrational analysis, property calculation, and QM/MM simulations. GAMESS-US is extensively used in computational chemistry research and education for electronic structure calculations relevant to biomolecular systems. (If GAMESS-UK was intended, see previous definition) (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">GAMESS</rdfs:label>
     </owl:Class>
     
@@ -18400,7 +18573,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000253">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An algorithm used in data analysis to group a set of objects (e.g., molecular conformations, data points) such that objects in the same group (cluster) are more similar to each other than to those in other groups. Clustering algorithms use various criteria and methods (e.g., distance-based, density-based, hierarchical) to identify inherent structures or patterns within unlabeled data. They are essential tools for exploring and understanding complex datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">clustering algorithm</rdfs:label>
     </owl:Class>
     
@@ -18410,7 +18583,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000254">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000253"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of clustering algorithm that builds a hierarchy of clusters starting with each data point as its own cluster and iteratively merging the two closest clusters until only one cluster (containing all points) remains. This process creates a tree-like structure (dendrogram) that can be cut at different levels to obtain different numbers of clusters. It provides a nested partitioning of the data based on similarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hierarchical agglomerative bottom-up algorithm</rdfs:label>
     </owl:Class>
     
@@ -18831,7 +19004,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000294">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000286"/>
-        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (...) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conveyor Belt Thermodynamic Integration (CBTI) approach is a newer method that uses multiple replicas moving in a coordinated fashion along λ. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CBTI</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">conveyor belt thermodynamic integration</rdfs:label>
     </owl:Class>
@@ -18874,7 +19047,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000299">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000298"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000356"/>
-        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Thermodynamic Integration with linear extrapolation likely refers to an approach where the integrand ⟨∂H/∂λ⟩ λ is calculated only at or very near the endpoints (λ=0 and λ=1). The total free energy difference (ΔG) is then estimated by assuming the integrand varies linearly between these two points and calculating the integral of this linear function (equivalent to the trapezoidal rule with only the endpoints). This is a strong approximation, only accurate if the integrand is indeed nearly linear across the entire path. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">thermodynamic integration with linear extrapolation</rdfs:label>
     </owl:Class>
     
@@ -18917,7 +19090,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000303">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A mathematical technique used to determine if a set of variables or vectors (e.g., descriptive coordinates or components from data analysis) are linearly related, meaning one can be expressed as a combination of the others. In simulation analysis, this is often used to check for redundancy in sets of collective variables or principal components derived from trajectory data. Identifying such dependencies can help simplify models or analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear dependence evaluation analysis</rdfs:label>
     </owl:Class>
     
@@ -19246,7 +19419,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000334">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A similarity measure that specifically compares the chemical features and atom types between molecules, focusing on their functional groups and chemical properties rather than their shape. This measure evaluates the similarity of atomic properties and chemical functionalities between molecules, making it valuable for identifying compounds with similar chemical behavior. It complements shape-based similarity measures in molecular comparison workflows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">fit color Tversky</rdfs:label>
     </owl:Class>
     
@@ -19297,7 +19470,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000340"/>
-        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers specifically to integration methods that use numerical approximations to solve differential equations, which is necessary for the equations of motion in complex biomolecular systems where exact analytical solutions are impossible. These algorithms iteratively calculate the system&apos;s state at successive small time steps, with the choice of method (e.g., Verlet, Leapfrog) affecting simulation accuracy, stability, and computational cost. It emphasizes the approximate, step-by-step nature of solving the motion computationally. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">numerical integration</rdfs:label>
     </owl:Class>
     
@@ -19307,7 +19480,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of mathematical techniques specifically used in molecular dynamics simulations to numerically solve the equations of motion governing particle movement. These algorithms approximate the positions and velocities of atoms at future discrete time steps based on the forces acting upon them at the current step. They are fundamental for generating the trajectory of the molecular system over time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">integration analysis</rdfs:label>
     </owl:Class>
     
@@ -19432,7 +19605,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A .binpos file is a binary format used to store atomic coordinate frames from a molecular dynamics simulation. The name itself stands for &quot;binary position.&quot; This format is often referred to as the &quot;Scripps &apos;binpos&apos; format&quot; and is recognized by Amber&apos;s analysis tools like cpptraj and other programs such as VMD. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.binpos</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">Scripps binpos format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">binpos format</rdfs:label>
@@ -19444,7 +19617,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A method used to check whether the results or models generated by biomolecular simulations are accurate, physically realistic, and reliable. These techniques assess the quality of simulation outputs by comparing them against known experimental data or established theoretical principles. Their goal is to ensure the simulation provides a meaningful representation of the molecular system being studied. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">validation analysis</rdfs:label>
     </owl:Class>
     
@@ -19453,9 +19626,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000354 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000354">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">p-value</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that represents the probability of obtaining results at least as extreme as the observed results, assuming that the null hypothesis is true. A small p-value (typically &lt; 0.05) is used to argue that the observed result is statistically significant. It is a fundamental concept in hypothesis testing. This is a standard output of statistical tests.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000700"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000700. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete p-value</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20270,7 +20445,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A set of mathematical functions, often resembling atomic orbitals, used in quantum chemical calculations to represent the spatial distribution of electrons within a molecule (molecular orbitals). The choice and size of the basis set significantly impact the accuracy and computational cost of a simulation; larger, more flexible basis sets generally yield more accurate results but require more computer resources. These functions serve as the building blocks for constructing the calculated electronic wavefunction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quantum mechanics basis set</rdfs:label>
     </owl:Class>
     
@@ -20596,7 +20771,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000076"/>
-        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A comprehensive molecular similarity measure that combines both shape-based RefTversky and chemical feature-based RefColorTversky scores into a single metric. This combined measure provides a more complete assessment of molecular similarity by considering both geometric shape and chemical functionality simultaneously. The resulting score typically ranges from 0 to 2, though it can occasionally exceed this range due to the field-based nature of shape matching. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ref Tversky combo</rdfs:label>
     </owl:Class>
     
@@ -20999,7 +21174,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A statistical mathematical technique used to assess whether an observed linear relationship (correlation) between two variables, calculated from simulation data, is statistically meaningful. It evaluates the probability that such a correlation could have occurred simply by random chance if no true underlying relationship existed. This helps researchers confidently interpret potential connections found in simulation results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">linear correlation significance determination analysis</rdfs:label>
     </owl:Class>
     
@@ -21009,7 +21184,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000400"/>
-        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A common specific method for linear correlation significance determination (and statistical testing in general) that involves calculating a probability value, the p-value. The p-value represents the probability of observing the calculated correlation, or a stronger one, assuming that there is actually no real correlation (the null hypothesis). A small p-value (typically below a threshold like 0.05) leads to the conclusion that the observed correlation is statistically significant and unlikely due to chance. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">determination by p-value analysis</rdfs:label>
     </owl:Class>
     
@@ -21090,7 +21265,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This notation likely refers to a specific basis set combination utilizing the Los Alamos LANL2 effective core potential (ECP) for core electrons. The &quot;[6s4p4d2f]&quot; part specifies a large, custom valence basis set for the outer electrons, explicitly containing 6 s-type, 4 p-type, 4 d-type, and 2 f-type basis functions. Such explicit notation usually indicates a non-standard or research-specific valence basis designed for high accuracy on heavy elements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2-[6s4p4d2f]</rdfs:label>
     </owl:Class>
     
@@ -21120,7 +21295,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)(...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This term likely represents the LANL2DZ ECP basis set augmented with a significant number of additional functions: two s-type, two p-type, two d-type, and two f-type. These extra functions could be diffuse or polarization functions, intended to provide much greater flexibility for describing the valence electrons of heavy atoms than standard LANL2DZ. This indicates a larger, potentially custom augmentation for specific research purposes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">LANL2DZ+2s2p2d2f</rdfs:label>
     </owl:Class>
     
@@ -21720,7 +21895,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000577">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000485"/>
-        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED) (...)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Ahlrichs pvDZ likely stands for a polarized valence Double-Zeta basis set from the Ahlrichs group. This typically implies a basis set where core electrons might be treated minimally or with few functions, valence electrons are described by two functions per orbital (DZ), and polarization functions (&apos;p&apos;) are included (e.g., d-functions on heavy atoms, p-functions on hydrogen). Examples include the DZP or the more modern def2-SVP basis sets from the Ahlrichs school. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Ahlrichs pvDZ</rdfs:label>
     </owl:Class>
     
@@ -21750,7 +21925,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000580">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of quantum mechanics basis set consisting of periodic sine and cosine functions (waves) defined by their direction and wavelength. Plane waves are particularly well-suited for calculations on periodic systems like crystals or surfaces, often used in conjunction with Density Functional Theory and pseudopotentials. Their systematic improvability by increasing the number of waves (controlled by an energy cutoff) is a key advantage in solid-state simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">plane-wave</rdfs:label>
     </owl:Class>
     
@@ -21760,7 +21935,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000581">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000432"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to methods that represent electronic wavefunctions or density directly on a grid of points in three-dimensional coordinate space, rather than expanding them in analytical basis functions like Gaussians or plane waves. This approach avoids basis set superposition errors and can be systematically improved by refining the grid spacing. Real-space grid methods are often employed in Density Functional Theory calculations, particularly for large systems or complex geometries. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">real-space</rdfs:label>
     </owl:Class>
     
@@ -21947,7 +22122,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000599">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Log file from an Amber Replica Exchange MD simulation. The main file extension for Amber REM (Replica Exchange Molecular Dynamics) log files is .log, typically named as rem.log, according to the Amber documentation and tutorial resources. This log file tracks exchanges, replica temperatures, and relevant statistics for the REMD process. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Amber Replica Exchange Log</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">rem.log</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER REM log format</rdfs:label>
@@ -21959,7 +22134,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000600">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj),</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Amber evecs eigenvector file is a specialized output from Principal Component Analysis (PCA), normal mode analysis, or quasiharmonic analysis in AMBER (using cpptraj or ptraj). This file stores the eigenvectors (or “principal modes”) and eigenvalues resulting from the diagonalization of a covariance or mass-weighted covariance matrix, commonly used in essential dynamics analysis of molecular simulations. The output file is usually called evecs.dat, evecs.out, or follows a similar naming scheme. There is no fixed &quot;file extension&quot; required; however, the content and formatting are standardized for compatibility with AMBER utilities (e.g., cpptraj, ptraj) that read and write them. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.dat</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">evecs.out</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">AMBER eigenvector format</rdfs:label>
@@ -21971,7 +22146,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000601">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cpout (constant pH output) file is generated during constant pH Molecular Dynamics (CpHMD) simulations in AMBER, contain the results of the simulation—such as pH-dependent state changes, lambda values, protonation fractions, and statistics relevant to titratable groups. These files are produced as a result of the simulation or post-simulation analysis, not used to initiate or restart simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.cpout</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER cpout format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">cpout format</rdfs:label>
@@ -22110,7 +22285,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000614">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An Amber OFF Library file (Object File Format) is a text file that stores a library of molecular units or residues, including their force field parameters, atom types, connectivity, and charges. These files are a fundamental part of the Amber software suite, allowing the LEaP program to build simulation-ready topology files for systems containing non-standard molecules or modified residues (like amino acids with post-translational modifications). The file extension can be interchangeably provided as .lib/.off files. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">.off</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER Object File Format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER off format</oboInOwl:hasExactSynonym>
@@ -22782,9 +22957,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000679 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
-        <obo:IAO_0000115 xml:lang="en">Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis. (UNVERIFIED) (DEPRECATED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">image bond fixing analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22876,6 +23051,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000688">
         <obo:IAO_0000115 xml:lang="en">Represents any origin from which information or data relevant to biomolecular studies and simulations is obtained. This broad category includes everything from experimental databases and scientific literature to computational predictions and raw output files. Understanding the data source is crucial for assessing data reliability, reproducibility, and context in biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">How this branch is built. The classes here are KINDS of data source, for example protein structural database, pathway database, or simulation data repository. Each real, named resource is then added as an individual of one of those classes, not as a class of its own. PDB, UniProt, ChEMBL, Reactome, MoDEL and AlphaFold DB are individuals in this way. This is on purpose: a named database is one single thing in the world, not a kind of thing, so it fits better as an individual. Please keep this pattern, and do not turn these individuals into classes as a tidy-up. Two things to know. First, individuals are not copied into the OBO-format file (see the release-format note in the ontology header). Second, most OBO ontologies use classes for everything, so a reviewer may ask why we did this.</rdfs:comment>
         <rdfs:comment xml:lang="en">TODO:may be be replacable with IAO&apos;s information content entity (http://purl.obolibrary.org/obo/IAO_0000030 ) as an import. discussion needed: the definition there is however rather abstract. #ontologyengineer #import</rdfs:comment>
         <rdfs:label xml:lang="en">data source</rdfs:label>
     </owl:Class>
@@ -23652,7 +23828,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000775">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000161"/>
-        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations  of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An open-source quantum chemistry and solid-state physics software package designed for performing atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K is particularly known for its efficient DFT calculations using a hybrid Gaussian and Plane Waves (GPW) method and its Quickstep module, enabling QM and QM/MM simulations of large systems, including ab initio MD. It&apos;s highly parallelized and versatile for demanding simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CP2K</rdfs:label>
     </owl:Class>
     
@@ -23843,7 +24019,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000794">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000039"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to implementations of constant pressure simulation based on the work of W. G. Hoover, often utilizing Nosé-Hoover style deterministic equations of motion applied to the volume degree of freedom (similar to the Andersen barostat&apos;s concept but using the Nosé-Hoover thermostat formalism). It provides a deterministic way to sample the NPT ensemble by extending the system&apos;s phase space. It can be formulated for isotropic or anisotropic pressure control. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Hoover barostat</rdfs:label>
     </owl:Class>
     
@@ -23853,7 +24029,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the SHAKE algorithm designed to handle constraints more efficiently in parallel computing environments. It addresses issues related to communication overhead when constraints span across different processors by optimizing the way constraint information is shared and processed. It aims to improve the scalability of constrained simulations on parallel machines. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">M-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23863,7 +24039,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000796">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parallel SHAKE, another variation of the SHAKE algorithm optimized for parallel execution. Similar to M-SHAKE, it focuses on efficiently handling the communication and computation required for constraints that involve atoms distributed across multiple processors. The goal is to minimize the performance bottleneck caused by constraints in large-scale parallel simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">P-SHAKE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23873,7 +24049,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000797">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analytical (non-iterative) constraint algorithm specifically designed for rigid water models like TIP3P or SPC/E, where both bond lengths and the bond angle are fixed. Because the geometry is simple and fixed, the constraint equations for a water molecule can be solved analytically, making SETTLE significantly faster than iterative methods like SHAKE for constraining water. It is highly efficient for simulations with explicit water. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SETTLE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23883,7 +24059,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000798">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000049"/>
-        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A constraint algorithm related to SHAKE, often used for fixing distances within rigid clusters of atoms larger than simple bonds or angles. It iteratively adjusts the positions of atoms within the defined rigid body to maintain their relative positions. It extends the concept of bond constraints to more complex rigid units. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SHAPE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23903,7 +24079,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000800">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Refers to the original formulation by Shuichi Nosé of the deterministic thermostat algorithm that introduces an extended degree of freedom and time scaling to generate dynamics consistent with the canonical ensemble. The later Nosé-Hoover formulation modified this approach to simplify the equations of motion in physical time. The core idea is extending the system&apos;s phase space to control temperature deterministically. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose thermostat</rdfs:label>
     </owl:Class>
     
@@ -23913,7 +24089,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000801">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific mathematical formulation of the Nosé thermostat dynamics based on Poincaré&apos;s canonical transformations. It offers insights into the theoretical foundations and conservation laws of the Nosé thermostatting mechanism. It represents a rigorous theoretical framework for this class of deterministic thermostats. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Nose-Poincare thermostat</rdfs:label>
     </owl:Class>
     
@@ -23923,7 +24099,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000802">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000038"/>
-        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Velocity Rescaling thermostat, an algorithm that modifies the Berendsen weak coupling approach to correctly generate configurations from the canonical (NVT) ensemble. It rescales velocities based on the kinetic energy difference but includes a stochastic term related to the system&apos;s kinetic energy fluctuations, ensuring proper statistical sampling. It combines the simplicity of Berendsen-like scaling with rigorous ensemble generation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">V-rescale thermostat</rdfs:label>
     </owl:Class>
     
@@ -23933,7 +24109,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000803">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A category of quantum chemistry calculation methods that bridges the gap between highly accurate but slow ab initio methods and very fast but simple molecular mechanics. It simplifies the complex equations of quantum mechanics (often starting from the Hartree-Fock framework) by neglecting certain terms and using parameters derived from experimental data to approximate others. These methods aim to provide a reasonable balance between computational cost and accuracy for studying molecular properties like geometry and energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">semi-empirical method</rdfs:label>
     </owl:Class>
     
@@ -23944,7 +24120,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000804">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that explicitly considers all valence electrons (the outermost electrons involved in bonding) of the atoms in a molecule. These methods make approximations regarding the interactions between these electrons to speed up calculations, differing in the severity of these approximations (like CNDO, INDO, NDDO schemes). They offer a more comprehensive electronic description than pi-electron methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">all-valence-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -23954,7 +24130,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000805">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000806"/>
-        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Pariser-Parr-Pople method, a classic semi-empirical technique specifically designed for calculating the electronic structure of conjugated systems (molecules with alternating single and double bonds). It is a pi-electron restricted method, meaning it only explicitly treats the pi electrons, which are crucial for the properties of these specific systems. Note: This is typically classified as a pi-electron method, not an all-valence-electron method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PPP</rdfs:label>
     </owl:Class>
     
@@ -23964,7 +24140,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000806">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000803"/>
-        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Describes a type of semi-empirical quantum chemistry method that simplifies calculations by only explicitly considering the pi electrons in a molecule, treating the sigma electrons as part of a fixed core. These methods are primarily applicable to planar, conjugated organic molecules where pi electron interactions dominate electronic properties like UV-Vis spectra. The PPP method is a prime example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">pi-electron restricted</rdfs:label>
     </owl:Class>
     
@@ -23974,7 +24150,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000807">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Austin Model 1, a popular semi-empirical quantum method based on the NDDO (Neglect of Diatomic Differential Overlap) approximation. It includes parameters adjusted to reproduce experimental molecular properties like heats of formation and geometries for a wide range of organic molecules. AM1 aimed to improve upon the earlier MNDO method, particularly regarding hydrogen bonding. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AM1</rdfs:label>
     </owl:Class>
     
@@ -23984,7 +24160,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000808">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Neglect of Differential Overlap, version 2, an early all-valence-electron semi-empirical method. It employs severe approximations, ignoring most interactions between electron distributions on different atoms to achieve high computational speed. While largely superseded by more accurate methods, it was foundational in the development of semi-empirical QM. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CNDO/2</rdfs:label>
     </owl:Class>
     
@@ -23994,7 +24170,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000809">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Intermediate Neglect of Differential Overlap, an all-valence-electron semi-empirical method that is an improvement over CNDO. It retains one-center electron repulsion integrals between orbitals on the same atom, which CNDO neglects, allowing it to better describe electron spin distributions and properties dependent on them. It is computationally slightly more demanding than CNDO but generally more accurate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">INDO</rdfs:label>
     </owl:Class>
     
@@ -24004,7 +24180,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000810">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000685"/>
-        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A fundamental ab initio quantum chemistry method that approximates the solution to the electronic Schrödinger equation for a multi-electron system. It treats each electron as moving in an average field created by all other electrons, neglecting instantaneous electron correlation but including exact exchange interaction. It serves as a starting point for more sophisticated ab initio methods and is the foundation simplified by semi-empirical approaches. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">HF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24015,7 +24191,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000812">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Open-shell Hartree-Fock, a specific formulation of the Hartree-Fock method designed for molecules with unpaired electrons (open-shell systems) where constraints are applied to keep spatial orbitals doubly occupied where possible. It provides a wavefunction that is an eigenfunction of the spin operator, which is often desirable but can be more computationally challenging than UHF for some systems. It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">ROHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted open-shell Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24026,7 +24202,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000813">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Self-Consistent Field, the iterative computational procedure used to solve the equations in Hartree-Fock theory (and also in Density Functional Theory and some semi-empirical methods). The calculation starts with an initial guess for the electron distribution (orbitals), calculates the average field, finds new orbitals in that field, and repeats the process until the orbitals and the field they generate are consistent with each other. It is the numerical method for finding the Hartree-Fock solution, not the theory itself. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">self-consistent field</rdfs:label>
     </owl:Class>
@@ -24037,7 +24213,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000814">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000810"/>
-        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Unrestricted Hartree-Fock, a formulation of the Hartree-Fock method primarily used for open-shell systems (molecules with unpaired electrons). It allows alpha-spin electrons and beta-spin electrons to occupy different spatial orbitals, providing more flexibility than ROHF but resulting in a wavefunction that may not be a pure spin state (spin contamination). It is a type of ab initio calculation. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">UHF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Unrestricted Hartree-Fock</rdfs:label>
     </owl:Class>
@@ -24048,7 +24224,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000815">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000809"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Intermediate Neglect of Differential Overlap, a family of all-valence-electron semi-empirical methods (e.g., MINDO/3) developed as successors to INDO. They aimed for better accuracy, particularly in predicting heats of formation for organic molecules, through refined approximations and parameterization. Like INDO, they retain some one-center electron interactions neglected in CNDO. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MINDO</rdfs:label>
     </owl:Class>
     
@@ -24058,7 +24234,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000816">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3 (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modified Neglect of Diatomic Overlap, an all-valence-electron semi-empirical method based on the NDDO approximation scheme, representing an improvement over CNDO and INDO. It was parameterized to reproduce experimental heats of formation, geometries, and dipole moments for a range of molecules. It formed the basis for subsequent developments like AM1 and PM3. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">MNDO</rdfs:label>
     </owl:Class>
     
@@ -24068,7 +24244,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000817">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Neglect of Diatomic Differential Overlap, an approximation scheme used in many all-valence-electron semi-empirical quantum methods like MNDO, AM1, and PMx. It simplifies calculations by neglecting interactions involving electron distributions arising from orbitals on two different atoms unless both orbitals belong to the same atom pair (i.e., it keeps one- and two-center terms). This approximation is less severe than CNDO or INDO, generally leading to better accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NDDO</rdfs:label>
     </owl:Class>
     
@@ -24078,7 +24254,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000818">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Pairwise Distance Directed Gaussian, a modification primarily applied to the MNDO and AM1 methods to improve their performance, particularly for intermolecular interactions. It introduces Gaussian functions dependent on interatomic distances to modify the core-repulsion function used in these semi-empirical models. The goal is to achieve better descriptions of non-covalent interactions compared to the parent methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDDG</rdfs:label>
     </owl:Class>
     
@@ -24088,7 +24264,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000819">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 3, a popular all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed concurrently with AM1 as an evolution of MNDO. It differs from AM1 mainly in its parameterization strategy, which was more automated and aimed to reproduce a larger set of experimental data, including geometries and heats of formation. PM3 often gives different results from AM1, with varying accuracy depending on the system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3</rdfs:label>
     </owl:Class>
     
@@ -24098,7 +24274,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000820">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid method that combines the PM3 semi-empirical quantum mechanical treatment for a part of the system (e.g., the active site of an enzyme) with a faster molecular mechanics (MM) force field for the remainder (e.g., the surrounding protein or solvent). This QM/MM approach allows computationally feasible studies of large systems where quantum effects are important locally. It leverages PM3&apos;s balance of speed and accuracy for the QM region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM3MM</rdfs:label>
     </owl:Class>
     
@@ -24108,7 +24284,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000821">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000819"/>
-        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Parameterization Method 6, a relatively recent all-valence-electron semi-empirical quantum method based on the NDDO approximation, intended as an improvement over PM3 and AM1. It was parameterized against a broader range of experimental and high-level theoretical data, including data for more elements, aiming for greater accuracy and applicability across the periodic table. It often includes corrections for dispersion interactions and hydrogen bonds. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PM6</rdfs:label>
     </owl:Class>
     
@@ -24118,7 +24294,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000822">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Recife Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed as a re-parameterization of AM1. The goal was to improve upon AM1&apos;s accuracy, particularly for geometries and heats of formation of organic molecules containing common heteroatoms like N, O, P, S, and halogens. It uses the same underlying theoretical model as AM1 but employs updated parameters. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RM1</rdfs:label>
     </owl:Class>
     
@@ -24128,7 +24304,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000823">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Semi-Ab initio Model 1, an all-valence-electron semi-empirical quantum method based on the NDDO approximation, developed alongside AM1 and PM3. It aimed to incorporate certain theoretical aspects from ab initio methods more rigorously than earlier semi-empirical models, particularly regarding core-electron interactions and repulsion integrals. SAM1 sought improved theoretical foundations while still relying on parameterization for speed and accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SAM1</rdfs:label>
     </owl:Class>
     
@@ -24138,7 +24314,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000824">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000804"/>
-        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Symmetrically orthogonalized INDO, an all-valence-electron semi-empirical method based on the INDO level of approximation but employing a specific orthogonalization procedure for the atomic orbitals. This procedure aimed to improve the theoretical consistency and performance compared to earlier INDO versions like MINDO. It focuses on refining the INDO framework for better property prediction. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SINDO</rdfs:label>
     </owl:Class>
     
@@ -24148,7 +24324,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000825">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000807"/>
-        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modification of the AM1 semi-empirical method specifically parameterized to handle lanthanide elements (rare earth metals). Standard AM1 parameters are not available or reliable for these heavy elements, so Sparkle/AM1 replaces the core description of the lanthanide ion with a point charge dressed by Gaussian functions, adjusted to reproduce structural data. It enables AM1-level calculations on complexes containing lanthanides. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Sparkle/AM1</rdfs:label>
     </owl:Class>
     
@@ -24158,7 +24334,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000826">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000817"/>
-        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An all-valence-electron semi-empirical method likely based on the INDO or NDDO approximation schemes, developed by Zhidomirov and coworkers. It represents one of the many variations within the semi-empirical framework, likely with specific parameterizations or modifications to the integral approximations aimed at particular applications or accuracy improvements. Note: This method is less common than MNDO/AM1/PMx variants, and specific details might require consulting specialized literature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ZANDO</rdfs:label>
     </owl:Class>
     
@@ -24223,7 +24399,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000832">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A class of advanced quantum mechanics methods required for accurately describing molecules or chemical processes where the electronic structure cannot be well represented by a single dominant electron configuration (as assumed in basic Hartree-Fock theory). These situations often involve stretched bonds, excited states, diradicals, or transition metals, necessitating the use of multiple electronic configurations to capture the essential physics. These methods are typically more computationally demanding than single-reference approaches. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-reference</rdfs:label>
     </owl:Class>
     
@@ -24233,7 +24409,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000833">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Complete Active Space Self-Consistent Field, a specific and widely used type of multi-reference method (falling under the MC-SCF umbrella). It involves selecting a subset of electrons and orbitals deemed most important for the problem (the active space) and then performing a full configuration interaction calculation within that space while simultaneously optimizing the orbitals. CASSCF provides a qualitatively correct description of complex electronic structures but often needs further corrections for quantitative accuracy. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">CASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">complete active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -24244,7 +24420,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000834">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Configurational Self-Consistent Field (MC-SCF), a general category of multi-reference quantum chemistry methods. These methods determine the electronic wavefunction by optimizing both the shapes of the molecular orbitals and the mixing coefficients of multiple electron configurations simultaneously. CASSCF and RASSCF are specific types of MC-SCF calculations, differing in how the included configurations are selected. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">MC-SCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-configurational self-consistent field</rdfs:label>
     </owl:Class>
@@ -24255,7 +24431,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000835">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Coupled Cluster with Single and Double excitations, a high-accuracy quantum chemistry method that incorporates dynamic electron correlation using the coupled-cluster approach built upon a multi-reference starting wavefunction (obtained from methods like CASSCF). It aims to provide a highly accurate description for systems where both static (multi-reference character) and dynamic correlation effects are significant. These calculations are computationally very expensive. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CCSD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference coupled cluster with single and double excitations</rdfs:label>
     </owl:Class>
@@ -24266,7 +24442,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000836">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Multi-Reference Configuration Interaction with Single and Double excitations, a quantum chemistry method that accounts for electron correlation by performing a configuration interaction calculation (including configurations generated by single and double electron excitations) starting from a multi-reference wavefunction (e.g., from CASSCF). Like MR-CCSD, it targets high accuracy for electronically complex systems but is computationally demanding and may suffer from size-consistency issues depending on the formulation. It offers an alternative way to add dynamic correlation to a multi-reference description. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>MR-CI(SD)</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">multi-reference configuration interaction with single and double excitations</rdfs:label>
     </owl:Class>
@@ -24277,7 +24453,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000837">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000832"/>
-        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restricted Active Space Self-Consistent Field, a flexible type of multi-reference method (within the MC-SCF family) similar to CASSCF but offering more control over the included electron configurations. The active space is divided into subspaces (RAS1, RAS2, RAS3) with restrictions on the number of electrons or excitations allowed within and between them, making calculations feasible for larger active spaces than typically possible with CASSCF. It allows a tailored balance between computational cost and the desired level of multi-reference treatment. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">RASSCF</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">restricted active space self-consistent field</rdfs:label>
     </owl:Class>
@@ -24288,7 +24464,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000838">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000173"/>
-        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantum chemistry method developed to account for electron correlation, closely related to the Coupled Cluster (CC) family of methods. It was designed to ensure size-consistency, an important theoretical property meaning the energy of two non-interacting systems is the sum of their individual energies, which is not guaranteed by standard truncated Configuration Interaction (CI). It offers a systematic way to improve upon the Hartree-Fock description. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">quadratic configuration interaction</rdfs:label>
     </owl:Class>
     
@@ -24299,7 +24475,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000839">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000840"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles, Doubles, and a perturbative estimate of Triple excitations. This method adds an approximate correction for the effects of triple electron excitations onto the QCISD calculation, significantly improving accuracy for many chemical properties. QCISD(T) is considered a high-accuracy method, often yielding results close to experimental values, and is comparable in accuracy and cost to the widely used CCSD(T) method. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD(T)</rdfs:label>
     </owl:Class>
     
@@ -24309,7 +24485,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000840">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000838"/>
-        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Quadratic Configuration Interaction with Singles and Doubles, the specific level of QCI theory that includes electron configurations generated by single and double excitations from the reference (usually Hartree-Fock) configuration. Its formulation makes it very similar in performance and cost to the CCSD (Coupled Cluster Singles and Doubles) method. It provides a reliable way to capture a large fraction of the electron correlation energy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QCISD</rdfs:label>
     </owl:Class>
     
@@ -24994,9 +25170,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000905 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">small molecule structure (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -25487,7 +25663,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000978">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000981"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of validation technique focused on assessing the quality of the three-dimensional arrangement of atoms (the conformation) in simulated biomolecules. It evaluates whether the molecular geometry, including bond lengths, angles, and steric arrangements, is plausible according to known chemical and physical rules. This ensures the structural models generated or sampled during a simulation are stereochemically sound. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">conformation validation analysis</rdfs:label>
     </owl:Class>
     
@@ -25498,7 +25674,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000979">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000980"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used graphical tool for conformation validation specifically applied to proteins. It plots the distribution of backbone dihedral angles (phi and psi) for each amino acid residue, allowing visualization of whether these angles fall into sterically allowed or disallowed regions. This provides a crucial check for the quality and realism of the protein backbone structure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ramachandran analysis</rdfs:label>
     </owl:Class>
     
@@ -25561,7 +25737,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000985">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000383"/>
-        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics (UNVERIFIED).</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A core mathematical technique from linear algebra used to simplify a square matrix by finding its characteristic values (eigenvalues) and directions (eigenvectors), effectively transforming it into a diagonal matrix. In biomolecular simulations, this is heavily used in methods like Principal Component Analysis (PCA) to identify dominant modes of collective atomic motion from covariance matrices, or in Normal Mode Analysis (NMA) to find vibrational frequencies from Hessian matrices. Diagonalization reveals the fundamental components or modes underlying complex data or system dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">matrix diagonalization analysis</rdfs:label>
     </owl:Class>
     
@@ -26378,9 +26554,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001087 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">macromolecular structure format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26399,9 +26575,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001089 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">software-specific coordinate format (deprecated)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -27473,7 +27649,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001233"/>
-        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. . This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Gaussian accelerated MD parameter that specifies the upper limit of the standard deviation for the potential energy boost. This parameter controls the maximum strength of the applied bias. This is often set with keywords like sigma0P or sigma0D.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">GaMD potential boost stddev limit</rdfs:label>
     </owl:Class>
@@ -27846,7 +28022,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001270">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001268"/>
-        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)e</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A volumetric analysis parameter that specifies the mathematical function or algorithm used when calculating properties on a 3D grid. Different functions might be used for averaging, summing, or mapping specific atomic properties onto the grid points. The grid function determines what property is being represented by the volumetric data. This is often set with a keyword that specifies the function name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">grid function</rdfs:label>
     </owl:Class>
     
@@ -28069,7 +28245,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001292 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001292">
-        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs).  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A quantitative or qualitative output data item generated by a simulation or analysis process. It represents the actual measured state, derived metric, or calculated result of the system (e.g., instantaneous potential energy, calculated RMSD, assigned cluster IDs). (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computed observable</rdfs:label>
     </owl:Class>
     
@@ -29259,9 +29435,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001404 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001404">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Pearson product-moment correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the linear relationship between two continuous variables. It is the most common method for calculating correlation. This value is often reported in analysis as the Pearson correlation coefficient or simply &apos;r&apos;. This is a standard output of statistical packages.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000280"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated both MOLSIM:000112 and STATO:0000280 - &apos;Pearson product-moment correlation coefficient&apos; is the full formal name of Pearson&apos;s correlation coefficient. Replaced by the reused STATO term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Pearson product-moment correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29269,9 +29447,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001405 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001405">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Spearman rank correlation coefficient</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A specific type of correlation coefficient that measures the monotonic relationship between two variables, based on their ranks rather than their raw values. It is less sensitive to outliers than the Pearson correlation. The Spearman rank correlation coefficient is a non-parametric measure of association. This is often reported as rho or Spearman&apos;s rho.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000201"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000201. STATO is the canonical OBO home for statistics and its definition of this term is fuller than MOLSIM&apos;s (it covers the monotonic-function reading, the perfect +/-1 case, and when to prefer it over Pearson&apos;s). Note the symbol &apos;rho&apos; named in the retired definition is not carried on the STATO term, which has no synonyms, because MOLSIM must not annotate a foreign IRI.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete Spearman rank correlation coefficient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29279,7 +29459,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001406 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001406">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">A specific type of correlation coefficient that measures the ordinal association between two variables. It is based on counting the number of concordant and discordant pairs in the data. The Kendall tau correlation coefficient is a non-parametric statistic used to measure the strength of the relationship between two ranked variables. This is often reported as tau or Kendall&apos;s tau. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kendall tau correlation coefficient</rdfs:label>
     </owl:Class>
@@ -29309,9 +29489,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001409 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001409">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard error of the mean (SEM)</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that estimates the standard deviation of the sample mean, quantifying how precisely the sample mean represents the true population mean. It is calculated by dividing the sample standard deviation by the square root of the sample size. The standard error of the mean is a key measure of the uncertainty of a calculated average value. This is often abbreviated as SEM.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000037"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000037. STATO is the canonical OBO home for statistics; reused in place of this term. Note the &apos;(SEM)&apos; abbreviation carried by the retired label is not reproduced on the STATO term, because MOLSIM must not annotate a foreign IRI; STATO&apos;s own definition spells out the abbreviation.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard error of the mean (SEM)</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29319,9 +29501,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001410 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001410">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">coefficient of determination</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property, also known as R-squared, that indicates the proportion of the variance in the dependent variable that is predictable from the independent variable(s). It provides a measure of how well the observed outcomes are replicated by the model. The coefficient of determination is a key metric for assessing the goodness of fit of a regression model. This is often reported as R^2 or R-squared.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000564"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000564. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete coefficient of determination</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -29360,9 +29544,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001414 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001414">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
-        <obo:IAO_0000115 xml:lang="en">A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A type of statistical property that measures the amount of variation or dispersion of a set of values. A low standard deviation indicates that the values tend to be close to the mean, while a high value indicates that the values are spread out over a wider range. It is a fundamental measure of the variability of a calculated property. This is often abbreviated as sd or stdev.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/STATO_0000237"/>
+        <rdfs:comment xml:lang="en">Obsoleted 2026-07-29: duplicated STATO:0000237. STATO is the canonical OBO home for statistics; reused in place of this term.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete standard deviation</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -30074,8 +30260,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A statistical model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">statistical model</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A statistical mechanics model is a mathematical representation of a system that is based on the principles of statistical mechanics, describing the system in terms of probabilities and distributions. In the context of simulation, this refers to the underlying theoretical framework that connects the microscopic movements of atoms to the macroscopic thermodynamic properties we observe. For experts, the simulation itself is a method to generate a series of snapshots that sample from the probability distribution defined by the chosen statistical mechanics model, such as the canonical ensemble. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">statistical model</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Not to be confused with STATO:0000107 &quot;statistical model&quot;, which is a statistics and inference concept: a formalization of relationships between random variables. This term is the statistical-MECHANICS sense - the theoretical framework connecting the microscopic motion of atoms to macroscopic thermodynamic properties, for example the canonical ensemble. Renamed 2026-07-29 to remove that ambiguity; &quot;statistical model&quot; is retained as an exact synonym.</rdfs:comment>
+        <rdfs:label xml:lang="en">statistical mechanics model</rdfs:label>
     </owl:Class>
     
 
@@ -30084,7 +30272,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001485">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maxwell-Boltzmann distribution is a statistical mechanics model that describes the distribution of speeds or kinetic energies for particles in a gas or liquid at thermal equilibrium. In molecular dynamics simulations, thermostat algorithms are designed to ensure that the velocities of the atoms in the system correctly follow this distribution for the target temperature. For experts, verifying that the system&apos;s kinetic energy distribution matches the Maxwell-Boltzmann curve is a key check that the simulation is correctly sampling the desired temperature. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Maxwell-Boltzmann distribution</rdfs:label>
     </owl:Class>
     
@@ -30094,7 +30282,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001484"/>
-        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A two-state transition model is a simplified statistical mechanics model used to describe a system that can exist in two distinct states, such as a protein in a folded or unfolded state. The model characterizes the probability of switching from one state to the other, often used to analyze the kinetics of conformational changes.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <rdfs:label xml:lang="en">two-state transition model</rdfs:label>
     </owl:Class>
@@ -31907,7 +32095,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001666">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
-        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (VERY-) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Metatwist is an analysis tool for studying the twisting motions of helical molecules, such as DNA, using data from a metadynamics simulation. It is probably designed to analyze a free energy surface calculated as a function of a helical twist collective variable. This would allow a researcher to quantify the energetic cost and identify the pathways associated with the twisting and untwisting of a molecular helix. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metatwist</rdfs:label>
     </owl:Class>
     
@@ -32734,10 +32922,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001747 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000037"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A trajectory analysis algorithm is a computational procedure that processes the time-series of atomic coordinates from a simulation to calculate a specific property. These algorithms are the engines of analysis tools, turning raw simulation output into interpretable scientific data. For experts, this includes the specific algorithms for tasks like imaging periodic trajectories, calculating correlation functions, or clustering conformations.</obo:IAO_0000115>
         <rdfs:comment>candidate for removal per https://github.com/CPCLab/molsim-ontology/issues/21</rdfs:comment>
-        <rdfs:label xml:lang="en">trajectory analysis algorithm (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete trajectory analysis algorithm</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -32857,10 +33045,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001759 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001759">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. Miller indices are a set of three integers (h, k, l) that uniquely describe the orientation of a plane of atoms within a crystal lattice. These indices are determined from the positions of the spots in an X-ray diffraction pattern and are fundamental to crystallography. They are used to define the specific crystal faces and to calculate the theoretical diffraction pattern from a structural model.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">Marked for removal. See: https://github.com/CPCLab/molsim-ontology/issues/26</rdfs:comment>
-        <rdfs:label xml:lang="en">Miller indices (deprecated)</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete Miller indices</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33380,7 +33568,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001810 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001810">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000111"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
         <obo:IAO_0000115 xml:lang="en">The RMS average correlation is a statistical measure that quantifies the average degree of correlated motion between all the different parts of a molecule during a simulation. It is calculated by taking the root-mean-square of all the pairwise correlation values from a dynamic cross-correlation matrix. This single value provides a global metric of the overall collectivity of the system&apos;s dynamics, with a higher value indicating that the molecule&apos;s motions are more concerted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">RMS average correlation</rdfs:label>
     </owl:Class>
@@ -35088,7 +35276,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001973">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AMBER-GS (Garcia-Sanbonmatsu) is a variant of the AMBER protein force field designed to improve the simulation of protein secondary structure equilibrium. It specifically modifies the backbone torsion potentials of the earlier ff94 parameter set to reduce the artificial over-stabilization of alpha-helices. For experts, this modification typically involves setting the N=3 term of the Fourier series for phi and psi dihedrals to zero to correct the helical propensity bias. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERGS</rdfs:label>
     </owl:Class>
     
@@ -35375,9 +35563,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001515"/>
-        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the 
-C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 
-1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A numerical coefficient in a force field that defines the stiffness of the short-range repulsive barrier between two atoms. In the Lennard-Jones potential, this is the C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents atomic overlap. For experts, while physically approximating an exponential repulsion, the 1/r ^12 form is chosen primarily for computational efficiency as the square of the dispersion term. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">repulsion interaction parameter</rdfs:label>
     </owl:Class>
     
@@ -35868,7 +36054,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -35878,7 +36064,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -35889,7 +36075,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.  (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -35969,7 +36155,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.(UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -37063,7 +37249,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_1000010"/>
-        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second.</obo:IAO_0000115>
+        <obo:IAO_0000115>An SI unit of time equal to 10^-15 seconds or one quadrillionth of a second. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>fs</oboInOwl:hasExactSynonym>
         <rdfs:label>femtosecond</rdfs:label>
     </owl:Class>
@@ -37074,7 +37260,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000109"/>
-        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of pressure defined as 101,325 pascals (Pa) or 1.01325 bar, approximately equal to the average atmospheric pressure at sea level on Earth. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>atm</oboInOwl:hasExactSynonym>
         <rdfs:label>atmosphere</rdfs:label>
     </owl:Class>
@@ -37085,7 +37271,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000060"/>
-        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of velocity, representing one angstrom (10^-10 meters) of distance traveled per nanosecond (10^-9 seconds) of time. It is commonly used in molecular dynamics simulations and studies of atomic-scale processes. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>Å/ns|angstrom/nanosecond</oboInOwl:hasExactSynonym>
         <rdfs:label>angstrom per nanosecond</rdfs:label>
     </owl:Class>
@@ -37096,7 +37282,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010004">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance, defined as one kilocalorie of energy (1000 thermochemical gram calories) per one mole of substance. It is commonly used in chemistry and biology for thermodynamic quantities. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol|kilocalorie/mole</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole</rdfs:label>
     </owl:Class>
@@ -37107,7 +37293,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000111"/>
-        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of energy per amount of substance per area, commonly used in molecular dynamics simulations for expressing force constants and restraint weights. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>kcal/mol/Å^2|kilocalorie/mole/angstrom^2</oboInOwl:hasExactSynonym>
         <rdfs:label>kilocalorie per mole per square angstrom</rdfs:label>
     </owl:Class>
@@ -37118,7 +37304,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000219"/>
-        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit of electric charge defined as the charge carried by a single proton. It is a fundamental physical constant, with a value of exactly 1.602176634 × 10^-19 coulombs. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>e</oboInOwl:hasExactSynonym>
         <rdfs:label>elementary charge</rdfs:label>
     </owl:Class>
@@ -37129,7 +37315,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures a fluid&apos;s resistance to flow under the influence of gravity. It is the ratio of the fluid&apos;s dynamic viscosity to its density. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>kinematic viscosity unit</rdfs:label>
     </owl:Class>
     
@@ -37139,7 +37325,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010007"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St).</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of kinematic viscosity, defined as the kinematic viscosity of a fluid that passes one square centimeter in one second. It is equivalent to the unit Stokes (St). (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>cm^2/s|stokes|St</oboInOwl:hasExactSynonym>
         <rdfs:label>square centimeter per second</rdfs:label>
     </owl:Class>
@@ -37150,7 +37336,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UO_0000000"/>
-        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity.</obo:IAO_0000115>
+        <obo:IAO_0000115>A unit that measures the separation of positive and negative electrical charges within a system, indicating the system&apos;s overall polarity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label>electric dipole moment unit</rdfs:label>
     </owl:Class>
     
@@ -37160,7 +37346,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010010">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010009"/>
-        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters.</obo:IAO_0000115>
+        <obo:IAO_0000115>A centimeter-gram-second (CGS) unit of electric dipole moment, defined as 10^-18 statcoulomb-centimeters. One Debye is approximately equal to 3.33564 × 10^-30 coulomb-meters. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>D</oboInOwl:hasExactSynonym>
         <rdfs:label>debye</rdfs:label>
     </owl:Class>
@@ -37171,7 +37357,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -37181,7 +37367,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein.</obo:IAO_0000115>
+        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -37201,7 +37387,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -37211,7 +37397,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy.</obo:IAO_0000115>
+        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -37221,7 +37407,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces.</obo:IAO_0000115>
+        <obo:IAO_0000115>The Schrake-Rupley algorithm is a classic method for calculating the solvent accessible surface area (SASA) of a molecule by &quot;rolling&quot; a probe sphere over the atoms&apos; van der Waals surfaces. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Shrake-Rupley algorithm</rdfs:label>
     </owl:Class>
     
@@ -37932,6 +38118,166 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
         <owl:annotatedTarget>A subsection of sequence with biological interest that is conserved in different proteins. They may or may not have functional or structural significance within the proteins in which they are found.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
     </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000037">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000112 xml:lang="en">http://stats.stackexchange.com/questions/50623/r-calculating-mean-and-standard-error-of-mean-for-factors-with-lm-vs-direct</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The standard error of the mean (SEM) is data item denoting the standard deviation of the sample-mean&apos;s estimate of a population mean.
+It is calculated by dividing the sample standard deviation (i.e., the sample-based estimate of the standard deviation of the population) by the square root of n , the size (number of observations) of the sample.
+
+A measure of dispersion applied to means across hypothetical repeated random samples.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Brian S. Alper, Harold Lehmann, Muhammad Afzal, Xing Song, Kenneth Wilkins, Joanne Dehnbostel</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">SEM</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">adapted from wikipedia (https://en.wikipedia.org/wiki/Standard_error)</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en">SEM</obo:STATO_0000032>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.sem(a, axis=0, ddof=1)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sem.html#scipy.stats.sem
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L1928</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">standard error of the mean</rdfs:label>
+        <rdfs:seeAlso>https://fevir.net/resources/CodeSystem/27270#STATO:0000037</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000142">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The correlation coefficient of two variables in a data sample is their covariance divided by the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">STATO</obo:IAO_0000119>
+        <obo:STATO_0000032>r</obo:STATO_0000032>
+        <obo:STATO_0000032 xml:lang="en">r statistic</obo:STATO_0000032>
+        <rdfs:label xml:lang="en">correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000201 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">Spearman&apos;s rank correlation coefficient is a correlation coefficient which is a nonparametric measure of statistical dependence between two ranked variables. It assesses how well the relationship between two variables can be described using a monotonic function. If there are no repeated data values, a perfect Spearman correlation of +1 or −1 occurs when each of the variables is a perfect monotone function of the other.
+Spearman&apos;s coefficient may be used when the conditions for computing Pearson&apos;s correlation are not met (e.g linearity, normality of the 2 continuous variables) but may require a ranking transformation of the variables</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">Spearman&apos;s rho</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">http://en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">cor(x, y = NULL, use = &quot;everything&quot;,method = c(&quot;spearman&quot;))</obo:STATO_0000041>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.spearmanr(a, b=None, axis=0)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.spearmanr.html#scipy.stats.spearmanr
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2643</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">Spearman&apos;s rank correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000237 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The standard deviation of a random variable, statistical population, data set, or probability distribution is a measure of variation which correspond to the average distance from the mean of the data set to any given point of that dataset. It also corresponds to the square root of its variance.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">σ</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">http://en.wikipedia.org/wiki/Standard_deviation</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">sd(x, na.rm = FALSE)
+
+http://stat.ethz.ch/R-manual/R-patched/library/stats/html/sd.html</obo:STATO_0000041>
+        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000280">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/STATO_0000142"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The Pearson&apos;s correlation coefficient is a correlation coefficient which evaluates two continuous variables for association strength in a data sample. It assumes that both variables are normally distributed and linearity exists. 
+The coefficient is calculated by dividing their covariance with the product of their individual standard deviations. It is a normalized measurement of how the two are linearly related.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Orlaith Burke</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">Pearson product-moment correlation coefficient</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">Pearson&apos;s r</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">r statistics</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">STATO, adapted from
+http://www.r-tutor.com/elementary-statistics/numerical-measures/correlation-coefficient
+and from:
+http://stamash.org/pearsons-correlation-coefficient/
+http://stamash.org/kendalls-tau-correlation/</obo:IAO_0000119>
+        <obo:STATO_0000032 xml:lang="en"></obo:STATO_0000032>
+        <obo:STATO_0000041 xml:lang="en">cor(x, y = NULL, use = &quot;everything&quot;,method = c(&quot;pearson&quot;))</obo:STATO_0000041>
+        <obo:STATO_0000041 xml:lang="en">http://stat.ethz.ch/R-manual/R-patched/library/stats/html/cor.html</obo:STATO_0000041>
+        <obo:STATO_0000391 xml:lang="en">scipy.stats.pearsonr(x, y)
+
+http://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.pearsonr.html#scipy.stats.pearsonr
+
+source:
+https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/stats.py#L2427</obo:STATO_0000391>
+        <rdfs:label xml:lang="en">Pearson&apos;s correlation coefficient</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000564 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000564">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The coefficient of determination is a data item measuring the proportion of the variance in the dependent variable that is predictable from the independent variable(s).
+In the case of a linear regression mode, the coefficient of determination r2 is the quotient of the variances of the fitted values and observed values of the dependent variable.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">r2</obo:IAO_0000118>
+        <obo:STATO_0000041 xml:lang="en">&gt; eruption.lm = lm(eruptions ~ waiting, data=faithful)
+&gt; summary(eruption.lm)$r.squared 
+
+
+from:
+http://www.r-tutor.com/elementary-statistics/simple-linear-regression/coefficient-determination</obo:STATO_0000041>
+        <rdfs:label xml:lang="en">coefficient of determination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/STATO_0000700 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/STATO_0000700">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001403"/>
+        <obo:IAO_0000115 xml:lang="en">A hypothesis testing measure that represents the probability of obtaining a result at least as far from the value actually obtained as the value expected, assuming the null hypothesis is true.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Within the frequentist framework, a p-value is typically a p-value for two-sided test and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting divided by 2. In some cases, the p-value is a p-value for one-sided test, and the criterion for rejecting the null hypothesis is typically expressed as a p-value that is less than an alpha setting. A p-value is preferably coded more precisely as a p-value for two-sided test or a p-value for one-sided test rather than using the code for p-value without specification. The code for p-value (without specification) may be used in contexts where the p-value reported is ambiguous.
+
+Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_0000116>
+        <obo:IAO_0000118 xml:lang="en">P value</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">P-value</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">PValue</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">p value</obo:IAO_0000118>
+        <obo:IAO_0000119 xml:lang="en">SEVCO group</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">p-value</rdfs:label>
+    </owl:Class>
     
 
 
@@ -38949,7 +39295,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000922">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000697"/>
-        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The NCBI Reference Sequence (RefSeq) collection for nucleotide data, providing a comprehensive, integrated, non-redundant, and well-annotated set of sequences for chromosomes, genomic regions, transcripts, and RNAs. RefSeq aims to provide stable reference sequences for various organisms. It is a critical resource for genomics and gene annotation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NCBI RefSeq Nucleotide</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39029,7 +39375,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000957">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000707"/>
-        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A manually curated, large-scale database of bioactive drug-like small molecules and their quantitative bioactivity data against drug targets (primarily proteins). It brings together chemical, bioactivity, and genomic data to aid the translation of genomic information into effective new drugs. ChEMBL is a critical resource for drug discovery, pharmacology, and medicinal chemistry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ChEMBL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39119,7 +39465,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000967">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000704"/>
-        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI -  A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Conserved Domain Database by NCBI - A database maintained by NCBI containing manually curated models of ancient domains and full-length proteins, as well as models imported from other sources like Pfam and SMART. CDD is used to identify conserved domains within protein sequences, providing insights into their function. It is a key tool for protein sequence analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">CDD</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39169,7 +39515,7 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000972">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000706"/>
-        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free, open-source, curated, and peer-reviewed pathway database that provides detailed information on human biological pathways and processes. Reactome uses a hierarchical organization to describe molecular events, from individual reactions to complex pathways, linking genes, proteins, and small molecules. It is a key resource for systems biology and pathway analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Reactome</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39300,6 +39646,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001001">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000710"/>
         <obo:IAO_0000115 xml:lang="en">A database and web server that provides a collection of pre-equilibrated molecular dynamics simulations of proteins, particularly focusing on pharmaceutically relevant targets. MoDEL aims to offer ready-to-use starting points for further simulation studies, such as ligand binding or conformational analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">MoDEL database</oboInOwl:hasExactSynonym>
+        <rdfs:comment xml:lang="en">Distinct from the class &apos;model&apos; (MOLSIM:000006), which it resembles only in spelling: this is a named simulation data repository, that is a general kind of representation. Case-insensitive lexical matching conflates the two, so prefer the synonym &apos;MoDEL database&apos; when matching.</rdfs:comment>
         <rdfs:label xml:lang="en">MoDEL</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39449,6 +39797,8 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001945 -->
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001945">
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A redundant untyped individual that duplicated the class &apos;omni-path&apos; (MOLSIM:001949). It should not be used; use that class instead.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001949"/>
         <rdfs:comment xml:lang="en">Obsoleted: redundant untyped individual duplicating the class &apos;omni-path&apos; (MOLSIM_001949), which is the concept to use instead.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete Omni-Path</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -39716,7 +40066,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000895"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000896"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000897"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000906"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000907"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921"/>
@@ -39724,8 +40073,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001044"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001059"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001094"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001095"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001096"/>
@@ -39823,7 +40170,6 @@ C12 term (4ϵσ^12), approximating the Pauli exclusion principle that prevents a
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001700"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001728"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001740"/>
-            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001747"/>
             <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001986"/>
         </owl:members>
     </rdf:Description>


### PR DESCRIPTION
Regenerates the nine release assets. The previous cut was 2026-07-24 and predated 11 commits to `molsim-edit.owl`.

**Includes since the last release:**

- STATO statistics reuse : 8 MOLSIM terms retired with `IAO:0100001` redirects, 7 STATO classes imported via bounded MIREOT
- `MOLSIM:001484` relabelled `statistical model` → `statistical mechanics model`, with the old label kept as an exact synonym
- SSSOM mappings 24 → 38 (PSI-MI 18, KiSAO 8, GO 3, STATO 3, SO 2, EDAM 1, OBI 1, PR 1, SWO 1)
- Marker and deprecation normalisation, plus the two CI verification checks

**Build:** `make prepare_release_fast` (`IMP=false PAT=false MIR=false`) : existing import modules reused, not regenerated. Version `2026-07-24` → `2026-07-29`. All three RDF/XML files pass the `LightRDF` check.

**Contents check:** 2,067 classes declared (14 retired → 2,053 live) plus 10 unit classes merged from the units component = 2,077 MOLSIM classes in the release; 15 `deprecated=true` assertions (14 classes + 1 named individual); external classes CHEBI 189, UO 45, SO 23, IAO 20, STATO 7, GO 1.

Only the nine release assets are in this diff. The regenerated `src/ontology/reports/` files were reverted :  they are build by-products, not release assets.
