### PR TITLE
Apply Adam Hospital's verified definitions

### DIFF
--- a/src/ontology/molsim-edit.owl
+++ b/src/ontology/molsim-edit.owl
@@ -2965,8 +2965,9 @@ DataPropertyDomain(owl:topDataProperty obo:MOLSIM_001887)
 
 # Class: obo:MOLSIM_000000 (molecular dynamics process)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000000 "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000000 "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000000 "molecular dynamics process"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000000 orcid:0000-0002-8291-8071)
 
 # Class: obo:MOLSIM_000001 (software)
 
@@ -3087,8 +3088,9 @@ SubClassOf(obo:MOLSIM_000019 obo:MOLSIM_000008)
 
 # Class: obo:MOLSIM_000020 (lipid17)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000020 "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000020 "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000020 "lipid17"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000020 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000020 obo:MOLSIM_000008)
 
 # Class: obo:MOLSIM_000021 (amber ff14SB)
@@ -3517,8 +3519,9 @@ SubClassOf(obo:MOLSIM_000087 obo:MOLSIM_000037)
 
 # Class: obo:MOLSIM_000088 (Kruskal's algorithm)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000088 "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000088 "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000088 "Kruskal's algorithm"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000088 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000088 obo:MOLSIM_000087)
 
 # Class: obo:MOLSIM_000089 (Prim's algorithm)
@@ -3957,8 +3960,9 @@ SubClassOf(obo:MOLSIM_000155 obo:MOLSIM_000143)
 
 # Class: obo:MOLSIM_000156 (GROMACS mdp format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000156 "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000156 "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000156 "GROMACS mdp format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000156 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000156 obo:MOLSIM_002065)
 
 # Class: obo:MOLSIM_000157 (framework)
@@ -3984,8 +3988,9 @@ SubClassOf(obo:MOLSIM_000159 obo:MOLSIM_001090)
 
 # Class: obo:MOLSIM_000160 (molecular dynamics engine)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000160 "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000160 "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000160 "molecular dynamics engine"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000160 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000160 obo:MOLSIM_001851)
 
 # Class: obo:MOLSIM_000161 (quantum chemistry engine)
@@ -3996,8 +4001,9 @@ SubClassOf(obo:MOLSIM_000161 obo:MOLSIM_001851)
 
 # Class: obo:MOLSIM_000162 (docking tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000162 "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000162 "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000162 "docking tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000162 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000162 obo:MOLSIM_001850)
 
 # Class: obo:MOLSIM_000163 (visualization tool)
@@ -4008,20 +4014,23 @@ SubClassOf(obo:MOLSIM_000163 obo:MOLSIM_000001)
 
 # Class: obo:MOLSIM_000164 (analysis tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000164 "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000164 "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000164 "analysis tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000164 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000164 obo:MOLSIM_000001)
 
 # Class: obo:MOLSIM_000165 (data processing tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000165 "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000165 "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000165 "data processing tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000165 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000165 obo:MOLSIM_000001)
 
 # Class: obo:MOLSIM_000166 (file conversion tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000166 "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000166 "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000166 "file conversion tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000166 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000166 obo:MOLSIM_000165)
 
 # Class: obo:MOLSIM_000167 (automation script)
@@ -4301,8 +4310,9 @@ SubClassOf(obo:MOLSIM_000208 obo:MOLSIM_000002)
 
 # Class: obo:MOLSIM_000209 (equilibration)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000209 "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000209 "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000209 "equilibration"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000209 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000209 obo:MOLSIM_000002)
 
 # Class: obo:MOLSIM_000210 (umbrella sampling)
@@ -4379,20 +4389,23 @@ SubClassOf(obo:MOLSIM_000220 obo:MOLSIM_000490)
 
 # Class: obo:MOLSIM_000221 (PDB2PQR)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000221 "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000221 "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000221 "PDB2PQR"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000221 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000221 obo:MOLSIM_000223)
 
 # Class: obo:MOLSIM_000222 (ligand protonation tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000222 "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000222 "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000222 "ligand protonation tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000222 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000222 obo:MOLSIM_000220)
 
 # Class: obo:MOLSIM_000223 (generic protonation tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000223 "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000223 "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000223 "generic protonation tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000223 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000223 obo:MOLSIM_000220)
 
 # Class: obo:MOLSIM_000224 (Epik)
@@ -4415,14 +4428,16 @@ SubClassOf(obo:MOLSIM_000226 obo:MOLSIM_000225)
 
 # Class: obo:MOLSIM_000227 (membrane protein orientation tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000227 "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000227 "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000227 "membrane protein orientation tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000227 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000227 obo:MOLSIM_001850)
 
 # Class: obo:MOLSIM_000228 (memembed)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000228 "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000228 "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000228 "memembed"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000228 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000228 obo:MOLSIM_000227)
 
 # Class: obo:MOLSIM_000229 (resolution-based simulation method)
@@ -4500,8 +4515,9 @@ SubClassOf(obo:MOLSIM_000239 obo:MOLSIM_000238)
 
 # Class: obo:MOLSIM_000240 (pKa tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000240 "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000240 "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000240 "pKa tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000240 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000240 obo:MOLSIM_000490)
 
 # Class: obo:MOLSIM_000241 (PROPKA)
@@ -4518,8 +4534,9 @@ SubClassOf(obo:MOLSIM_000242 obo:MOLSIM_000460)
 
 # Class: obo:MOLSIM_000243 (in-silico mutagenesis tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000243 "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000243 "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000243 "in-silico mutagenesis tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000243 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000243 obo:MOLSIM_001850)
 
 # Class: obo:MOLSIM_000244 (FoldX)
@@ -4916,8 +4933,9 @@ SubClassOf(obo:MOLSIM_000304 obo:MOLSIM_000109)
 
 # Class: obo:MOLSIM_000305 (modeling method)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000305 "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000305 "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000305 "modeling method"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000305 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000305 obo:MOLSIM_000140)
 
 # Class: obo:MOLSIM_000306 (statistical package)
@@ -5962,9 +5980,10 @@ SubClassOf(obo:MOLSIM_000465 obo:MOLSIM_000462)
 
 # Class: obo:MOLSIM_000466 (orientations of proteins in membranes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000466 "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000466 "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000466 "OPM"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000466 "orientations of proteins in membranes"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000466 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000466 obo:MOLSIM_000227)
 SubClassOf(obo:MOLSIM_000466 obo:MOLSIM_001119)
 
@@ -5984,8 +6003,9 @@ SubClassOf(obo:MOLSIM_000468 obo:MOLSIM_000909)
 
 # Class: obo:MOLSIM_000469 (AMBER mdin format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000469 "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000469 "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000469 "AMBER mdin format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000469 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000469 obo:MOLSIM_002065)
 
 # Class: obo:MOLSIM_000470 (mdout format)
@@ -5998,8 +6018,9 @@ SubClassOf(obo:MOLSIM_000470 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_000471 (AMBER restart format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000471 "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000471 "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000471 "AMBER restart format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000471 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000471 obo:MOLSIM_000441)
 
 # Class: obo:MOLSIM_000472 (AMBER topology format)
@@ -6049,8 +6070,9 @@ SubClassOf(obo:MOLSIM_000478 obo:MOLSIM_000917)
 
 # Class: obo:MOLSIM_000479 (Connolly surface analysis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000479 "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000479 "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000479 "Connolly surface analysis"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000479 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000479 obo:MOLSIM_000478)
 
 # Class: obo:MOLSIM_000480 (covariance matrix analysis)
@@ -6743,9 +6765,10 @@ SubClassOf(obo:MOLSIM_000595 obo:MOLSIM_000590)
 
 # Class: obo:MOLSIM_000596 (grid format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000596 "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000596 "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000596 ".grid"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000596 "grid format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000596 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000596 obo:MOLSIM_000590)
 
 # Class: obo:MOLSIM_000597 (dx format)
@@ -7225,8 +7248,9 @@ SubClassOf(obo:MOLSIM_000669 obo:MOLSIM_000917)
 
 # Class: obo:MOLSIM_000670 (coordinate centering analysis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000670 "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000670 "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000670 "coordinate centering analysis"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000670 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000670 obo:MOLSIM_000917)
 
 # Class: obo:MOLSIM_000671 (closest solvent analysis)
@@ -7459,8 +7483,9 @@ SubClassOf(obo:MOLSIM_000705 obo:MOLSIM_000703)
 
 # Class: obo:MOLSIM_000706 (pathway database)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000706 "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000706 "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000706 "pathway database"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000706 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000706 obo:MOLSIM_000703)
 
 # Class: obo:MOLSIM_000707 (bioactivity database)
@@ -7611,8 +7636,9 @@ SubClassOf(obo:MOLSIM_000740 obo:MOLSIM_000015)
 
 # Class: obo:MOLSIM_000741 (amber ff02)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000741 "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000741 "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000741 "amber ff02"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000741 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000741 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_000742 (amber ff10)
@@ -7678,8 +7704,9 @@ SubClassOf(obo:MOLSIM_000751 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_000752 (CHARMM 19)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000752 "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000752 "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000752 "CHARMM 19"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000752 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000752 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_000753 (CHARMM 27)
@@ -7810,8 +7837,9 @@ SubClassOf(obo:MOLSIM_000773 obo:MOLSIM_000161)
 
 # Class: obo:MOLSIM_000774 (Abalone)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000774 "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000774 "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000774 "Abalone"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000774 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000774 obo:MOLSIM_001664)
 
 # Class: obo:MOLSIM_000775 (CP2K)
@@ -7828,8 +7856,9 @@ SubClassOf(obo:MOLSIM_000776 obo:MOLSIM_000161)
 
 # Class: obo:MOLSIM_000777 (Desmond)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000777 "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000777 "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000777 "Desmond"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000777 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000777 obo:MOLSIM_000160)
 
 # Class: obo:MOLSIM_000778 (Firefly)
@@ -7882,8 +7911,9 @@ SubClassOf(obo:MOLSIM_000785 obo:MOLSIM_000161)
 
 # Class: obo:MOLSIM_000786 (NAMD)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000786 "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000786 "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000786 "NAMD"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000786 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000786 obo:MOLSIM_000160)
 
 # Class: obo:MOLSIM_000787 (SIESTA)
@@ -8235,9 +8265,10 @@ SubClassOf(obo:MOLSIM_000842 obo:MOLSIM_000841)
 
 # Class: obo:MOLSIM_000843 (molecular dynamics)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000843 "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000843 "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000843 "MD"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000843 "molecular dynamics"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000843 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000843 obo:MOLSIM_000308)
 
 # Class: obo:MOLSIM_000844 (NetCDF format)
@@ -8402,8 +8433,9 @@ SubClassOf(obo:MOLSIM_000866 obo:MOLSIM_000437)
 
 # Class: obo:MOLSIM_000867 (CHARMM input format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000867 "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000867 "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000867 "CHARMM input format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000867 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000867 obo:MOLSIM_000438)
 
 # Class: obo:MOLSIM_000868 (GAMESS input format)
@@ -8428,8 +8460,9 @@ SubClassOf(obo:MOLSIM_000870 obo:MOLSIM_000437)
 
 # Class: obo:MOLSIM_000871 (GROMACS input  format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000871 "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_000871 "GROMACS input  format"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000871 "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_000871 "GROMACS input format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000871 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000871 obo:MOLSIM_002065)
 
 # Class: obo:MOLSIM_000872 (HyperChem hin format)
@@ -8458,14 +8491,16 @@ SubClassOf(obo:MOLSIM_000875 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_000876 (NAMD configuration format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000876 "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000876 "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000876 "NAMD configuration format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000876 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000876 obo:MOLSIM_002065)
 
 # Class: obo:MOLSIM_000877 (NWChem input format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000877 "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000877 "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000877 "NWChem input format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000877 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000877 obo:MOLSIM_000437)
 
 # Class: obo:MOLSIM_000878 (Q-Chem input format)
@@ -8490,8 +8525,9 @@ SubClassOf(obo:MOLSIM_000880 obo:MOLSIM_000441)
 
 # Class: obo:MOLSIM_000881 (CHARMM output format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000881 "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000881 "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000881 "CHARMM output format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000881 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000881 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_000882 (GAMESS output format)
@@ -8514,8 +8550,9 @@ SubClassOf(obo:MOLSIM_000884 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_000885 (GROMACS output format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000885 "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000885 "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000885 "GROMACS output format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000885 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000885 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_000886 (Jaguar output format)
@@ -8562,8 +8599,9 @@ SubClassOf(obo:MOLSIM_000892 obo:MOLSIM_000441)
 
 # Class: obo:MOLSIM_000893 (NWChem restart format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000893 "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000893 "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000893 "NWChem restart format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000893 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000893 obo:MOLSIM_000441)
 
 # Class: obo:MOLSIM_000894 (mdfrc format)
@@ -8595,10 +8633,11 @@ SubClassOf(obo:MOLSIM_000897 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_000898 (itp format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000898 "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000898 "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000898 "GROMACS include topology format"@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_000898 "GROMACS itp format"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000898 "itp format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000898 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000898 obo:MOLSIM_001091)
 
 # Class: obo:MOLSIM_000899 (top format)
@@ -8624,8 +8663,9 @@ SubClassOf(obo:MOLSIM_000901 obo:MOLSIM_001091)
 
 # Class: obo:MOLSIM_000902 (dcd format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000902 "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000902 "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000902 "dcd format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000902 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000902 obo:MOLSIM_001090)
 
 # Class: obo:MOLSIM_000903 (GROMACS trajectory format)
@@ -8736,8 +8776,9 @@ SubClassOf(obo:MOLSIM_000918 obo:MOLSIM_000917)
 
 # Class: obo:MOLSIM_000921 (crd format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000921 "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000921 "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000921 "crd format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000921 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000921 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_000923 (local structure analysis)
@@ -8814,8 +8855,9 @@ SubClassOf(obo:MOLSIM_000940 obo:MOLSIM_002066)
 
 # Class: obo:MOLSIM_000941 (coordinate rotation modeling)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000941 "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_000941 "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_000941 "coordinate rotation modeling"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_000941 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_000941 obo:MOLSIM_000305)
 
 # Class: obo:MOLSIM_000942 (time cross correlation analysis)
@@ -9178,7 +9220,7 @@ SubClassOf(obo:MOLSIM_001039 obo:MOLSIM_001090)
 
 # Class: obo:MOLSIM_001040 (distance matrix format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001040 "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001040 "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule."@en)
 AnnotationAssertion(rdfs:comment obo:MOLSIM_001040 "Common examples include:
 
 - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.
@@ -9187,6 +9229,7 @@ AnnotationAssertion(rdfs:comment obo:MOLSIM_001040 "Common examples include:
 
 - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001040 "distance matrix format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001040 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001040 obo:MOLSIM_010020)
 
 # Class: obo:MOLSIM_001041 (xpm  format)
@@ -9349,16 +9392,18 @@ SubClassOf(obo:MOLSIM_001061 obo:MOLSIM_001090)
 
 # Class: obo:MOLSIM_001062 (pqr format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001062 "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001062 "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_001062 ".pqr")
 AnnotationAssertion(rdfs:label obo:MOLSIM_001062 "pqr format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001062 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001062 obo:MOLSIM_001088)
 
 # Class: obo:MOLSIM_001063 (MOE)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001063 "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001063 "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_001063 "Molecular Operating Environment"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001063 "MOE"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001063 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001063 obo:MOLSIM_000490)
 SubClassOf(obo:MOLSIM_001063 obo:MOLSIM_002041)
 
@@ -9426,8 +9471,9 @@ AnnotationAssertion(rdfs:label obo:MOLSIM_001072 "information content entity"@en
 
 # Class: obo:MOLSIM_001073 (molecular system specification)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001073 "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001073 "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001073 "molecular system specification"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001073 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001073 obo:MOLSIM_001072)
 
 # Class: obo:MOLSIM_001074 (process specification)
@@ -9718,15 +9764,17 @@ SubClassOf(obo:MOLSIM_001117 obo:MOLSIM_010022)
 
 # Class: obo:MOLSIM_001118 (mdinfo format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001118 "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001118 "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_001118 "AMBER mdinfo format"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001118 "mdinfo format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001118 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001118 obo:MOLSIM_000439)
 
 # Class: obo:MOLSIM_001119 (database web server)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001119 "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001119 "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001119 "database web server"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001119 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001119 obo:MOLSIM_001671)
 
 # Class: obo:MOLSIM_001120 (nef format)
@@ -9968,8 +10016,9 @@ SubClassOf(obo:MOLSIM_001200 obo:MOLSIM_001199)
 
 # Class: obo:MOLSIM_001201 (constraint and restraint parameter)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001201 "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001201 "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001201 "constraint and restraint parameter"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001201 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001201 obo:MOLSIM_001164)
 
 # Class: obo:MOLSIM_001202 (constraint parameter)
@@ -10057,14 +10106,16 @@ SubClassOf(obo:MOLSIM_001214 obo:MOLSIM_001210)
 
 # Class: obo:MOLSIM_001215 (alchemical transformation state)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001215 "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001215 "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001215 "alchemical transformation state"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001215 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001215 obo:MOLSIM_001210)
 
 # Class: obo:MOLSIM_001216 (number of replicates)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001216 "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001216 "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001216 "number of replicates"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001216 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001216 obo:MOLSIM_001210)
 
 # Class: obo:MOLSIM_001217 (surface tension)
@@ -10832,8 +10883,9 @@ SubClassOf(obo:MOLSIM_001336 obo:MOLSIM_001333)
 
 # Class: obo:MOLSIM_001337 (hydrogen mass repartitioning analysis)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001337 "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001337 "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001337 "hydrogen mass repartitioning analysis"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001337 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001337 obo:MOLSIM_000328)
 
 # Class: obo:MOLSIM_001338 (ion-oxygen distance)
@@ -10850,8 +10902,9 @@ SubClassOf(obo:MOLSIM_001339 obo:MOLSIM_001333)
 
 # Class: obo:MOLSIM_001340 (dihedral angle)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001340 "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001340 "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001340 "dihedral angle"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001340 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001340 obo:MOLSIM_001333)
 
 # Class: obo:MOLSIM_001341 (protein backbone torsion angle)
@@ -11040,8 +11093,9 @@ SubClassOf(obo:MOLSIM_001365 obo:MOLSIM_001359)
 
 # Class: obo:MOLSIM_001366 (base pair step parameter)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001366 "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001366 "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001366 "base pair step parameter"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001366 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001366 obo:MOLSIM_001358)
 
 # Class: obo:MOLSIM_001367 (shift)
@@ -11475,8 +11529,9 @@ SubClassOf(obo:MOLSIM_001431 obo:MOLSIM_001427)
 
 # Class: obo:MOLSIM_001432 (adaptive string method)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001432 "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001432 "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001432 "adaptive string method"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001432 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001432 obo:MOLSIM_000860)
 
 # Class: obo:MOLSIM_001433 (ensemble trajectory analysis)
@@ -11538,14 +11593,16 @@ SubClassOf(obo:MOLSIM_001441 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_001442 (amber ff03)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001442 "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001442 "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001442 "amber ff03"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001442 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001442 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_001443 (amber ff03ua)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001443 "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001443 "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001443 "amber ff03ua"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001443 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001443 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_001444 (amber OL15)
@@ -11860,8 +11917,9 @@ SubClassOf(obo:MOLSIM_001493 obo:MOLSIM_000014)
 
 # Class: obo:MOLSIM_001494 (crystallographic model component)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001494 "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001494 "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001494 "crystallographic model component"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001494 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001494 obo:MOLSIM_000006)
 
 # Class: obo:MOLSIM_001495 (asymmetric unit)
@@ -12080,8 +12138,9 @@ SubClassOf(obo:MOLSIM_001529 obo:MOLSIM_000204)
 
 # Class: obo:MOLSIM_001530 (amber fb15)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001530 "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001530 "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001530 "amber fb15"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001530 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001530 obo:MOLSIM_000009)
 
 # Class: obo:MOLSIM_001531 (united-atom force field)
@@ -12246,8 +12305,9 @@ SubClassOf(obo:MOLSIM_001557 obo:MOLSIM_001956)
 
 # Class: obo:MOLSIM_001558 (electrostatics analysis tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001558 "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001558 "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001558 "electrostatics analysis tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001558 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001558 obo:MOLSIM_000164)
 
 # Class: obo:MOLSIM_001559 (adaptive Poisson-Boltzmann solver)
@@ -12330,14 +12390,16 @@ SubClassOf(obo:MOLSIM_001571 obo:MOLSIM_000272)
 
 # Class: obo:MOLSIM_001572 (ndfes)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001572 "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001572 "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001572 "ndfes"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001572 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001572 obo:MOLSIM_001969)
 
 # Class: obo:MOLSIM_001573 (ParmEd)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001573 "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001573 "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001573 "ParmEd"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001573 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001573 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001574 (pdb4amber)
@@ -12423,20 +12485,23 @@ SubClassOf(obo:MOLSIM_001586 obo:MOLSIM_001585)
 
 # Class: obo:MOLSIM_001587 (Intel Math Kernel Library)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001587 "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)"@en)
-AnnotationAssertion(rdfs:label obo:MOLSIM_001587 "Intel Math Kernel Library"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001587 "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms."@en)
+AnnotationAssertion(rdfs:label obo:MOLSIM_001587 "Intel oneAPI Math Kernel Library"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001587 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001587 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001588 (package manager)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001588 "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001588 "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001588 "package manager"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001588 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001588 obo:MOLSIM_000171)
 
 # Class: obo:MOLSIM_001589 (Miniconda)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001589 "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001589 "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001589 "Miniconda"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001589 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001589 obo:MOLSIM_001588)
 
 # Class: obo:MOLSIM_001590 (update_amber)
@@ -12698,8 +12763,9 @@ SubClassOf(obo:MOLSIM_001630 obo:MOLSIM_001569)
 
 # Class: obo:MOLSIM_001631 (ambpdb)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001631 "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001631 "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001631 "ambpdb"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001631 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001631 obo:MOLSIM_001569)
 
 # Class: obo:MOLSIM_001632 (ante-MMPBSA.py)
@@ -12824,14 +12890,16 @@ SubClassOf(obo:MOLSIM_001651 obo:MOLSIM_001569)
 
 # Class: obo:MOLSIM_001652 (chamber)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001652 "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001652 "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001652 "chamber"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001652 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001652 obo:MOLSIM_001569)
 
 # Class: obo:MOLSIM_001653 (match_atomname)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001653 "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001653 "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001653 "match_atomname"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001653 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001653 obo:MOLSIM_001569)
 
 # Class: obo:MOLSIM_001654 (MPI library)
@@ -12872,14 +12940,16 @@ SubClassOf(obo:MOLSIM_001659 obo:MOLSIM_000001)
 
 # Class: obo:MOLSIM_001660 (NAB)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001660 "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001660 "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001660 "NAB"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001660 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001660 obo:MOLSIM_001659)
 
 # Class: obo:MOLSIM_001661 (FE-ToolKit)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001661 "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001661 "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001661 "FE-ToolKit"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001661 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001661 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001662 (saxs_rism)
@@ -12944,14 +13014,16 @@ SubClassOf(obo:MOLSIM_001671 obo:MOLSIM_000001)
 
 # Class: obo:MOLSIM_001672 (GLYCAM-Web)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001672 "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001672 "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001672 "GLYCAM-Web"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001672 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001672 obo:MOLSIM_000714)
 
 # Class: obo:MOLSIM_001673 (Glycoprotein Builder)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001673 "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001673 "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001673 "Glycoprotein Builder"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001673 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001673 obo:MOLSIM_001119)
 
 # Class: obo:MOLSIM_001674 (RDKit)
@@ -12994,8 +13066,9 @@ SubClassOf(obo:MOLSIM_001679 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001680 (DL-Find)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001680 "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001680 "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001680 "DL-Find"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001680 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001680 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001681 (sff)
@@ -13020,8 +13093,9 @@ SubClassOf(obo:MOLSIM_001683 obo:MOLSIM_000160)
 
 # Class: obo:MOLSIM_001684 (match analysis tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001684 "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001684 "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001684 "match analysis tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001684 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001684 obo:MOLSIM_000164)
 
 # Class: obo:MOLSIM_001685 (WAMM)
@@ -13386,8 +13460,9 @@ SubClassOf(obo:MOLSIM_001742 obo:MOLSIM_000447)
 
 # Class: obo:MOLSIM_001743 (ICOSA algorithm)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001743 "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001743 "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001743 "ICOSA algorithm"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001743 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001743 obo:MOLSIM_001715)
 
 # Class: obo:MOLSIM_001744 (steepest descent algorithm)
@@ -13404,8 +13479,9 @@ SubClassOf(obo:MOLSIM_001745 obo:MOLSIM_001696)
 
 # Class: obo:MOLSIM_001746 (DSSP algorithm)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001746 "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001746 "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001746 "DSSP algorithm"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001746 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001746 obo:MOLSIM_001745)
 
 # Class: obo:MOLSIM_001747 (trajectory analysis algorithm (deprecated))
@@ -13463,6 +13539,7 @@ SubClassOf(obo:MOLSIM_001754 obo:MOLSIM_001753)
 AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001755 "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001755 orcid:0000-0003-4177-3619)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001755 "atom name"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001755 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001755 obo:MOLSIM_000447)
 
 # Class: obo:MOLSIM_001756 (residue connection atom)
@@ -13636,26 +13713,30 @@ SubClassOf(obo:MOLSIM_001782 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001783 (parallel beta sheet)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001783 "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001783 "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001783 "parallel beta sheet"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001783 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001783 obo:MOLSIM_001782)
 
 # Class: obo:MOLSIM_001784 (anti-parallel beta sheet)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001784 "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001784 "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001784 "anti-parallel beta sheet"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001784 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001784 obo:MOLSIM_001782)
 
 # Class: obo:MOLSIM_001785 (helix)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001785 "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001785 "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001785 "helix"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001785 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001785 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001786 (3-10 helix)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001786 "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001786 "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001786 "3-10 helix"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001786 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001786 obo:MOLSIM_001785)
 
 # Class: obo:MOLSIM_001787 (alpha helix)
@@ -13666,8 +13747,9 @@ SubClassOf(obo:MOLSIM_001787 obo:MOLSIM_001785)
 
 # Class: obo:MOLSIM_001788 (pi helix)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001788 "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001788 "The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001788 "pi helix"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001788 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001788 obo:MOLSIM_001785)
 
 # Class: obo:MOLSIM_001789 (turn)
@@ -13678,8 +13760,9 @@ SubClassOf(obo:MOLSIM_001789 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001790 (bend)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001790 "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001790 "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001790 "bend"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001790 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001790 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001791 (extended beta conformation)
@@ -13690,8 +13773,9 @@ SubClassOf(obo:MOLSIM_001791 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001792 (beta bridge)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001792 "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001792 "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001792 "beta bridge"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001792 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001792 obo:MOLSIM_001781)
 
 # Class: obo:MOLSIM_001793 (conformational transition)
@@ -13710,8 +13794,9 @@ SubClassOf(obo:MOLSIM_001794 obo:MOLSIM_001793)
 
 # Class: obo:MOLSIM_001795 (MDL solvent model format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001795 "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001795 "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001795 "MDL solvent model format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001795 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001795 obo:MOLSIM_001091)
 
 # Class: obo:MOLSIM_001796 (mean solvation force)
@@ -14065,8 +14150,9 @@ SubClassOf(obo:MOLSIM_001849 obo:MOLSIM_000004)
 
 # Class: obo:MOLSIM_001850 (modeling and setup tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001850 "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001850 "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001850 "modeling and setup tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001850 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001850 obo:MOLSIM_000158)
 
 # Class: obo:MOLSIM_001851 (simulation engine)
@@ -14165,8 +14251,9 @@ SubClassOf(obo:MOLSIM_001865 obo:MOLSIM_001403)
 
 # Class: obo:MOLSIM_001866 (backbone DH fluctuations)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001866 "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001866 "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001866 "backbone DH fluctuations"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001866 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001866 obo:MOLSIM_001333)
 
 # Class: obo:MOLSIM_001867 (membrane analysis)
@@ -14326,8 +14413,9 @@ SubClassOf(obo:MOLSIM_001888 obo:MOLSIM_001887)
 
 # Class: obo:MOLSIM_001889 (complex system)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001889 "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001889 "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001889 "complex system"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001889 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001889 obo:MOLSIM_001887)
 
 # Class: obo:MOLSIM_001890 (ligand complex system)
@@ -14359,8 +14447,9 @@ SubClassOf(obo:MOLSIM_001893 obo:MOLSIM_001890)
 
 # Class: obo:MOLSIM_001894 (hybrid complex system)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001894 "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001894 "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001894 "hybrid complex system"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001894 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001894 obo:MOLSIM_001889)
 
 # Class: obo:MOLSIM_001895 (nucleic acid complex system)
@@ -14547,22 +14636,25 @@ SubClassOf(obo:MOLSIM_001921 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_001922 (3DMol.js)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001922 "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001922 "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001922 "3DMol.js"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001922 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001922 obo:MOLSIM_001566)
 SubClassOf(obo:MOLSIM_001922 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_001923 (NGL)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001923 "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001923 "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001923 "NGL"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001923 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001923 obo:MOLSIM_001566)
 SubClassOf(obo:MOLSIM_001923 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_001924 (Open Babel)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001924 "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001924 "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001924 "Open Babel"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001924 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001924 obo:MOLSIM_000166)
 
 # Class: obo:MOLSIM_001925 (editconf)
@@ -14579,15 +14671,17 @@ SubClassOf(obo:MOLSIM_001926 obo:MOLSIM_000251)
 
 # Class: obo:MOLSIM_001927 (CHARMM-GUI)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001927 "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001927 "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001927 "CHARMM-GUI"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001927 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001927 obo:MOLSIM_000225)
 SubClassOf(obo:MOLSIM_001927 obo:MOLSIM_000714)
 
 # Class: obo:MOLSIM_001928 (Modeller)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001928 "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001928 "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001928 "Modeller"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001928 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001928 obo:MOLSIM_001958)
 
 # Class: obo:MOLSIM_001929 (ACEMD)
@@ -14611,15 +14705,17 @@ SubClassOf(obo:MOLSIM_001931 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_001932 (Jmol)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001932 "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001932 "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001932 "Jmol"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001932 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001932 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_001933 (MolStar)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001933 "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001933 "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_001933 "Mol*"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001933 "MolStar"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001933 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001933 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_001934 (UCSF Chimera)
@@ -14753,8 +14849,9 @@ SubClassOf(obo:MOLSIM_001954 obo:MOLSIM_000225)
 
 # Class: obo:MOLSIM_001955 (crystallographic build tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001955 "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001955 "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001955 "crystallographic build tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001955 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001955 obo:MOLSIM_001556)
 
 # Class: obo:MOLSIM_001956 (system packing and solvation tool)
@@ -14771,14 +14868,16 @@ SubClassOf(obo:MOLSIM_001957 obo:MOLSIM_000490)
 
 # Class: obo:MOLSIM_001958 (homology modeling tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001958 "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001958 "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001958 "homology modeling tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001958 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001958 obo:MOLSIM_001850)
 
 # Class: obo:MOLSIM_001959 (AutoDock Vina)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001959 "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001959 "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001959 "AutoDock Vina"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001959 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001959 obo:MOLSIM_000162)
 
 # Class: obo:MOLSIM_001960 (nucleic acid analysis tool)
@@ -14814,14 +14913,16 @@ SubClassOf(obo:MOLSIM_001964 obo:MOLSIM_001684)
 
 # Class: obo:MOLSIM_001965 (DALI)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001965 "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001965 "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001965 "DALI"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001965 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001965 obo:MOLSIM_001684)
 
 # Class: obo:MOLSIM_001966 (LS-align)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001966 "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001966 "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001966 "LS-align"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001966 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001966 obo:MOLSIM_001684)
 
 # Class: obo:MOLSIM_001967 (replica exchange algorithm)
@@ -14839,8 +14940,9 @@ SubClassOf(obo:MOLSIM_001968 obo:MOLSIM_001564)
 
 # Class: obo:MOLSIM_001969 (free energy surface analysis tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001969 "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001969 "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001969 "free energy surface analysis tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001969 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001969 obo:MOLSIM_001564)
 
 # Class: obo:MOLSIM_001970 (parameter assignment tool)
@@ -15000,8 +15102,9 @@ SubClassOf(obo:MOLSIM_001994 obo:MOLSIM_001827)
 
 # Class: obo:MOLSIM_001995 (position restraints)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001995 "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_001995 "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_001995 "position restraints"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_001995 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_001995 obo:MOLSIM_001552)
 
 # Class: obo:MOLSIM_001996 (Urey-Bradley potential)
@@ -15108,8 +15211,9 @@ SubClassOf(obo:MOLSIM_002011 obo:MOLSIM_001333)
 
 # Class: obo:MOLSIM_002012 (continuation state)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002012 "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002012 "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002012 "continuation state"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002012 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002012 obo:MOLSIM_001164)
 
 # Class: obo:MOLSIM_002013 (test particle insertion)
@@ -15274,28 +15378,32 @@ SubClassOf(obo:MOLSIM_002038 obo:MOLSIM_000441)
 
 # Class: obo:MOLSIM_002039 (atom ID)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002039 "An atom ID is usually a number, that uniquely defines a given atom in structure."@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002039 "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system."@en)
 AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002039 orcid:0000-0003-4177-3619)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002039 "atom ID"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002039 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002039 obo:MOLSIM_000447)
 
 # Class: obo:MOLSIM_002040 (JSmol)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002040 "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002040 "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002040 "JSmol"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002040 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002040 obo:MOLSIM_002041)
 
 # Class: obo:MOLSIM_002041 (molecular structure visualization tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002041 "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002041 "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002041 "molecular structure visualization tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002041 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002041 obo:MOLSIM_000163)
 
 # Class: obo:MOLSIM_002042 (data plotting tool)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002042 "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002042 "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_002042 "data visualization tool"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002042 "data plotting tool"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002042 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002042 obo:MOLSIM_000163)
 
 # Class: obo:MOLSIM_002043 (CAMPARI)
@@ -15337,22 +15445,25 @@ SubClassOf(obo:MOLSIM_002048 obo:MOLSIM_001566)
 
 # Class: obo:MOLSIM_002049 (AutoDock)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002049 "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002049 "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002049 "AutoDock"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002049 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002049 obo:MOLSIM_000162)
 
 # Class: obo:MOLSIM_002050 (GOLD)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002050 "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002050 "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_002050 "Genetic Optimisation for Ligand Docking"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002050 "GOLD"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002050 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002050 obo:MOLSIM_000162)
 
 # Class: obo:MOLSIM_002051 (Glide)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002051 "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002051 "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_002051 "Grid-based Ligand Docking with Energetics"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002051 "Glide"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002051 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002051 obo:MOLSIM_000162)
 
 # Class: obo:MOLSIM_002052 (rDock)
@@ -15401,8 +15512,9 @@ SubClassOf(obo:MOLSIM_002057 obo:MOLSIM_000852)
 
 # Class: obo:MOLSIM_002058 (PDBQT format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002058 "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002058 "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002058 "PDBQT format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002058 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002058 obo:MOLSIM_000715)
 SubClassOf(obo:MOLSIM_002058 obo:MOLSIM_001088)
 
@@ -15415,8 +15527,9 @@ SubClassOf(obo:MOLSIM_002059 obo:MOLSIM_000715)
 
 # Class: obo:MOLSIM_002060 (docking log format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002060 "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002060 "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files."@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002060 "docking log format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002060 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002060 obo:MOLSIM_000715)
 
 # Class: obo:MOLSIM_002061 (PAE matrix format)
@@ -15428,10 +15541,11 @@ SubClassOf(obo:MOLSIM_002061 obo:MOLSIM_000715)
 
 # Class: obo:MOLSIM_002062 (Maestro format)
 
-AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002062 "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:MOLSIM_002062 "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties."@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_002062 "mae format"@en)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:MOLSIM_002062 "maegz format"@en)
 AnnotationAssertion(rdfs:label obo:MOLSIM_002062 "Maestro format"@en)
+AnnotationAssertion(obo:IAO_0000117 obo:MOLSIM_002062 orcid:0000-0002-8291-8071)
 SubClassOf(obo:MOLSIM_002062 obo:MOLSIM_000715)
 SubClassOf(obo:MOLSIM_002062 obo:MOLSIM_001088)
 


### PR DESCRIPTION
Apply Adam Hospital's verified definitions for 114 terms

Adds IAO:0000117 (orcid:0000-0002-8291-8071) to 114 terms and clears 112 (UNVERIFIED) markers. Verified 419 to 531; unverified 1,832 to 1,720, which takes the unverified share from 80.8% to 75.9%.

Two label fixes: GROMACS input format had a double space, and Intel Math Kernel Library becomes Intel oneAPI Math Kernel Library.

No hierarchy or synonym changes, so this batch is annotation-only.

Two characters normalised to ASCII for tooling robustness: U+22C5 dot operator to * in the position restraints unit, and U+2011 non-breaking hyphen to - in match_atomname. Scientifically meaningful non-ASCII is retained, including the i to i+3 arrows in the helix definitions and the phi and psi torsions in amber ff03.