### PR TITLE
Cut the 2026-08-07 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The primary goal of this ontology is to standardize the representation of molecu
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
 | **Prefix**               | `MOLSIM`                                                                                                           |
 | **Namespace**            | `http://purl.obolibrary.org/obo/MOLSIM_`                                                                           |
-| **Size**                 | 2,047 live classes · 113 data properties · 17 object properties · 70 live named individuals (2,269 terms declared, 22 retired) |
+| **Size**                 | 2,046 live classes · 113 data properties · 17 object properties · 70 live named individuals (2,269 terms declared, 23 retired) |
 | **Hierarchy**            | Domain-oriented (no upper ontology yet; see [Ontology Alignment](#ontology-alignment-reuse-now-abstraction-later)) |
 | **Management**           | ODK (Ontology Development Kit) + ROBOT, reasoned with ELK                                                          |
 | **Source serialization** | OWL Functional Syntax: [`src/ontology/molsim-edit.owl`](src/ontology/molsim-edit.owl)                              |

--- a/molsim-base.json
+++ b/molsim-base.json
@@ -13,6 +13,21 @@
         "val" : "https://orcid.org/0000-0002-0476-9699"
       }, {
         "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-2294-5393"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-4303-9349"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-7544-0938"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-8291-8071"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0003-4177-3619"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
         "val" : "https://orcid.org/0009-0007-1391-4986"
       }, {
         "pred" : "http://purl.org/dc/terms/creator",
@@ -42,13 +57,16 @@
         "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
         "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-29"
+        "val" : "2026-08-07"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-base.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim-base.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000000",
@@ -56,8 +74,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)"
-        }
+          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000001",
@@ -70,30 +92,46 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
-      "lbl" : "preparation",
+      "lbl" : "simulation preparation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "preparation"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
-      "lbl" : "execution",
+      "lbl" : "simulation execution",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)"
-        }
+          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "execution"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
-      "lbl" : "analysis",
+      "lbl" : "simulation analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "analysis"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
@@ -129,7 +167,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000008",
-      "lbl" : "lipid  force field",
+      "lbl" : "lipid force field",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -253,8 +291,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)"
-        }
+          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000021",
@@ -840,7 +882,11 @@
       "meta" : {
         "definition" : {
           "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
-        }
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1."
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000077",
@@ -947,8 +993,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
-        }
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000089",
@@ -1247,12 +1297,12 @@
         "definition" : {
           "val" : "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms."
         },
+        "xrefs" : [ {
+          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0009-0007-1391-4986"
-        }, {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource",
-          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
         } ]
       }
     }, {
@@ -1678,8 +1728,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000157",
@@ -1726,8 +1780,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)"
-        }
+          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000161",
@@ -1744,8 +1802,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)"
-        }
+          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000163",
@@ -1762,8 +1824,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)"
-        }
+          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000165",
@@ -1771,8 +1837,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)"
-        }
+          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000166",
@@ -1780,8 +1850,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)"
-        }
+          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000167",
@@ -2238,7 +2312,11 @@
       "meta" : {
         "definition" : {
           "val" : "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "heating"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000209",
@@ -2246,8 +2324,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)"
-        }
+          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000210",
@@ -2378,8 +2460,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)"
-        }
+          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000222",
@@ -2387,8 +2473,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000223",
@@ -2396,8 +2486,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000224",
@@ -2432,8 +2526,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)"
-        }
+          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000228",
@@ -2441,8 +2539,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)"
-        }
+          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000229",
@@ -2573,8 +2675,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000241",
@@ -2600,8 +2706,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000244",
@@ -3259,8 +3369,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)"
-        }
+          "val" : "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000306",
@@ -3306,7 +3420,7 @@
         "definition" : {
           "val" : "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)"
         },
-        "comments" : [ "TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)" ]
+        "comments" : [ "Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
@@ -3314,7 +3428,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms."
+          "val" : "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -4803,16 +4917,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "lbl" : "protein database ID",
+      "lbl" : "obsolete protein database ID",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
+          "val" : "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
         },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0003-4177-3619"
-        } ]
+        "comments" : [ "Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review." ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
@@ -5009,11 +5121,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)"
+          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "OPM"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -5048,8 +5164,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000470",
@@ -5073,8 +5193,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)"
-        }
+          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000472",
@@ -5157,8 +5281,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)"
-        }
+          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
@@ -5171,16 +5299,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "lbl" : "2D RMSD analysis",
+      "lbl" : "obsolete 2D RMSD analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
+          "val" : "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
         },
+        "comments" : [ "Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45." ],
         "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0002-2294-5393"
-        } ]
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000311"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
@@ -6212,11 +6342,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)"
+          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".grid"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -7014,8 +7148,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)"
-        }
+          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000671",
@@ -7101,6 +7239,11 @@
         "definition" : {
           "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
         },
+        "comments" : [ "Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -7392,8 +7535,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)"
-        }
+          "val" : "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000707",
@@ -7635,8 +7782,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)"
-        }
+          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000742",
@@ -7738,8 +7889,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)"
-        }
+          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000753",
@@ -7936,8 +8091,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)"
-        }
+          "val" : "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000775",
@@ -7963,8 +8122,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)"
-        }
+          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000778",
@@ -8044,8 +8207,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)"
-        }
+          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000787",
@@ -8599,11 +8766,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)"
+          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "MD"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -8907,8 +9078,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)"
-        }
+          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000868",
@@ -8946,12 +9121,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000871",
-      "lbl" : "GROMACS input  format",
+      "lbl" : "GROMACS input format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)"
-        }
+          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000872",
@@ -8995,8 +9174,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000877",
@@ -9004,8 +9187,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)"
-        }
+          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000878",
@@ -9047,8 +9234,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)"
-        }
+          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000882",
@@ -9083,8 +9274,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000886",
@@ -9155,8 +9350,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)"
-        }
+          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000894",
@@ -9212,7 +9411,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)"
+          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -9220,6 +9419,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "GROMACS itp format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -9265,8 +9468,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)"
-        }
+          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000903",
@@ -9298,6 +9505,7 @@
         "definition" : {
           "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -9447,8 +9655,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)"
-        }
+          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000923",
@@ -9575,8 +9787,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)"
-        }
+          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000942",
@@ -9737,7 +9953,7 @@
         "definition" : {
           "val" : "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information."
         },
-        "comments" : [ "Amber's standard ASCII coordinate trajectory file format.\n\nThe \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
+        "comments" : [ "Amber's standard ASCII coordinate trajectory file format. The \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER inpcrd format"
@@ -10125,7 +10341,7 @@
         "definition" : {
           "val" : "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited."
         },
-        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
+        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER trj format"
@@ -10141,13 +10357,17 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)"
+          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule."
         },
-        "comments" : [ "Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ]
+        "comments" : [ "Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001041",
-      "lbl" : "xpm  format",
+      "lbl" : "xpm format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -10158,7 +10378,7 @@
           "val" : ".xpm"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "GROMACS xpm  format"
+          "val" : "GROMACS xpm format"
         } ]
       }
     }, {
@@ -10171,27 +10391,42 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
+          "val" : "AMBER PARM7 format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "AMBER parm7 format"
+        }, {
+          "pred" : "hasExactSynonym",
           "val" : "AMBER parmtop format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER prmtop format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "parm7 format"
         } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "lbl" : "parm7 format",
+      "lbl" : "obsolete parm7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)"
+          "val" : "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format."
         },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER PARM7 format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER parm7 format"
-        } ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001042"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
@@ -10275,17 +10510,30 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)"
-        }
+          "val" : "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "restrt format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "rst7 format"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
-      "lbl" : "rst7 format",
+      "lbl" : "obsolete rst7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection."
+        },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001049"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001051",
@@ -10391,7 +10639,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001059",
-      "lbl" : "conflib  format",
+      "lbl" : "conflib format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -10402,7 +10650,7 @@
           "val" : ".conflib"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "LMOD conflib  format"
+          "val" : "LMOD conflib format"
         } ]
       }
     }, {
@@ -10438,11 +10686,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)"
+          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".pqr"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -10451,11 +10703,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)"
+          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Molecular Operating Environment"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -10557,10 +10813,7 @@
       "meta" : {
         "definition" : {
           "val" : "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)"
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001073",
@@ -10568,8 +10821,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001074",
@@ -10736,6 +10993,7 @@
         "definition" : {
           "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -10759,6 +11017,7 @@
         "definition" : {
           "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
         },
+        "comments" : [ "Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -10867,7 +11126,7 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "skf  format"
+          "val" : "skf format"
         } ]
       }
     }, {
@@ -11054,11 +11313,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)"
+          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER mdinfo format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -11067,8 +11330,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)"
-        }
+          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001120",
@@ -11435,8 +11702,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)"
-        }
+          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001202",
@@ -11581,8 +11852,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)"
-        }
+          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001216",
@@ -11590,8 +11865,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)"
-        }
+          "val" : "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001217",
@@ -12855,8 +13134,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)"
-        }
+          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001338",
@@ -12882,8 +13165,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)"
-        }
+          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001341",
@@ -13240,8 +13527,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)"
-        }
+          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001367",
@@ -13972,8 +14263,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)"
-        }
+          "val" : "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001433",
@@ -14074,8 +14369,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)"
-        }
+          "val" : "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001443",
@@ -14083,8 +14382,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)"
-        }
+          "val" : "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001444",
@@ -14579,8 +14882,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001495",
@@ -14919,8 +15226,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)"
-        }
+          "val" : "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001531",
@@ -15178,8 +15489,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)"
-        }
+          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001559",
@@ -15246,12 +15561,20 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001566",
-      "lbl" : "library",
+      "lbl" : "software library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)"
-        }
+          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "library"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001567",
@@ -15304,8 +15627,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)"
-        }
+          "val" : "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001573",
@@ -15313,8 +15640,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)"
-        }
+          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001574",
@@ -15443,12 +15774,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001587",
-      "lbl" : "Intel Math Kernel Library",
+      "lbl" : "Intel oneAPI Math Kernel Library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)"
-        }
+          "val" : "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001588",
@@ -15456,8 +15791,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)"
-        }
+          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001589",
@@ -15465,8 +15804,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)"
-        }
+          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001590",
@@ -15656,7 +15999,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
+          "val" : "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -15883,8 +16226,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)"
-        }
+          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001632",
@@ -16072,8 +16419,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)"
-        }
+          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001653",
@@ -16081,8 +16432,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)"
-        }
+          "val" : "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001654",
@@ -16144,8 +16499,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)"
-        }
+          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001661",
@@ -16153,8 +16512,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)"
-        }
+          "val" : "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001662",
@@ -16252,8 +16615,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)"
-        }
+          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001673",
@@ -16261,8 +16628,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)"
-        }
+          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001674",
@@ -16328,8 +16699,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)"
-        }
+          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001681",
@@ -16348,6 +16723,10 @@
         "definition" : {
           "val" : "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures."
         },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "x3DNA"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0002-4303-9349"
@@ -16371,8 +16750,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001685",
@@ -16948,8 +17331,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)"
-        }
+          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001744",
@@ -16975,8 +17362,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)"
-        }
+          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
@@ -17065,6 +17456,9 @@
           "val" : "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -17340,8 +17734,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)"
-        }
+          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
@@ -17349,44 +17747,72 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)"
-        }
+          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "lbl" : "helix",
+      "lbl" : "obsolete helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001114"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "lbl" : "3-10 helix",
+      "lbl" : "obsolete 3-10 helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001119"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "lbl" : "alpha helix",
+      "lbl" : "obsolete alpha helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001117"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "lbl" : "pi helix",
+      "lbl" : "obsolete pi helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001118"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
@@ -17403,8 +17829,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)"
-        }
+          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001791",
@@ -17421,8 +17851,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)"
-        }
+          "val" : "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001793",
@@ -17456,8 +17890,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)"
-        }
+          "val" : "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001796",
@@ -18055,8 +18493,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)"
-        }
+          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001851",
@@ -18211,8 +18653,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)"
-        }
+          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001867",
@@ -18510,8 +18956,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)"
-        }
+          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001890",
@@ -18567,8 +19017,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)"
-        }
+          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001895",
@@ -18891,8 +19345,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)"
-        }
+          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001923",
@@ -18900,8 +19358,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)"
-        }
+          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001924",
@@ -18909,8 +19371,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)"
-        }
+          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001925",
@@ -18936,8 +19402,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)"
-        }
+          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001928",
@@ -18945,8 +19415,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)"
-        }
+          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001929",
@@ -18985,8 +19459,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)"
-        }
+          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001933",
@@ -18994,11 +19472,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)"
+          "val" : "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Mol*"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -19215,8 +19697,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001956",
@@ -19242,8 +19728,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)"
-        }
+          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001959",
@@ -19251,8 +19741,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001960",
@@ -19309,8 +19803,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)"
-        }
+          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001966",
@@ -19318,8 +19816,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)"
-        }
+          "val" : "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001967",
@@ -19349,8 +19851,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)"
-        }
+          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001970",
@@ -19600,8 +20106,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)"
-        }
+          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001996",
@@ -19771,8 +20281,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)"
-        }
+          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002013",
@@ -20030,9 +20544,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An atom ID is usually a number, that uniquely defines a given atom in structure."
+          "val" : "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -20043,8 +20560,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)"
-        }
+          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002041",
@@ -20052,8 +20573,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)"
-        }
+          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002042",
@@ -20061,11 +20586,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)"
+          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "data visualization tool"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20132,8 +20661,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
-        }
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002050",
@@ -20141,11 +20674,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Genetic Optimisation for Ligand Docking"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20154,11 +20691,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Grid-based Ligand Docking with Energetics"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20253,8 +20794,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
-        }
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002059",
@@ -20275,8 +20820,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)"
-        }
+          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002061",
@@ -20297,7 +20846,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)"
+          "val" : "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -20305,6 +20854,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "maegz format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20691,7 +21244,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)"
         }
       }
     }, {
@@ -20700,7 +21253,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -20709,7 +21262,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)"
         }
       }
     }, {
@@ -20718,7 +21271,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)"
         }
       }
     }, {
@@ -20727,7 +21280,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)"
         }
       }
     }, {
@@ -20736,7 +21289,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)"
         }
       }
     }, {
@@ -20745,7 +21298,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)"
         }
       }
     }, {
@@ -20754,7 +21307,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)"
         }
       }
     }, {
@@ -20763,7 +21316,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)"
         }
       }
     }, {
@@ -20772,7 +21325,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -20781,7 +21334,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)"
         }
       }
     }, {
@@ -20790,7 +21343,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)"
         }
       }
     }, {
@@ -20799,7 +21352,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)"
         }
       }
     }, {
@@ -20808,7 +21361,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)"
         }
       }
     }, {
@@ -20817,7 +21370,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -20826,7 +21379,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)"
         }
       }
     }, {
@@ -20835,7 +21388,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)"
         }
       }
     }, {
@@ -20844,7 +21397,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)"
         }
       }
     }, {
@@ -20853,7 +21406,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)"
         }
       }
     }, {
@@ -20862,7 +21415,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)"
         }
       }
     }, {
@@ -20871,7 +21424,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)"
         }
       }
     }, {
@@ -20880,7 +21433,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -20889,7 +21442,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -20898,7 +21451,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)"
         }
       }
     }, {
@@ -20907,7 +21460,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -20916,7 +21469,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -20925,7 +21478,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)"
         }
       }
     }, {
@@ -20934,7 +21487,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)"
         }
       }
     }, {
@@ -20943,7 +21496,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)"
         }
       }
     }, {
@@ -20952,7 +21505,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)"
         }
       }
     }, {
@@ -20961,7 +21514,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)"
         }
       }
     }, {
@@ -20970,7 +21523,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -20979,7 +21532,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -20988,7 +21541,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -20997,7 +21550,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)"
         }
       }
     }, {
@@ -21006,7 +21559,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)"
         }
       }
     }, {
@@ -21015,7 +21568,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)"
         }
       }
     }, {
@@ -21024,7 +21577,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)"
         }
       }
     }, {
@@ -21033,7 +21586,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)"
         }
       }
     }, {
@@ -21042,7 +21595,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)"
         }
       }
     }, {
@@ -21051,7 +21604,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)"
+          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -21064,7 +21617,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)"
+          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -21077,7 +21630,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)"
+          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -21090,7 +21643,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)"
         }
       }
     }, {
@@ -21099,7 +21652,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -21108,7 +21661,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)"
         }
       }
     }, {
@@ -21117,7 +21670,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)"
         }
       }
     }, {
@@ -21126,7 +21679,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)"
         }
       }
     }, {
@@ -21135,7 +21688,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)"
         }
       }
     }, {
@@ -21144,7 +21697,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)"
         }
       }
     }, {
@@ -21153,7 +21706,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)"
         }
       }
     }, {
@@ -21162,7 +21715,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)"
         }
       }
     }, {
@@ -21171,7 +21724,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)"
         }
       }
     }, {
@@ -21180,7 +21733,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)"
         }
       }
     }, {
@@ -21189,7 +21742,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)"
         }
       }
     }, {
@@ -21198,7 +21751,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)"
         }
       }
     }, {
@@ -21207,7 +21760,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -21216,7 +21769,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)"
         }
       }
     }, {
@@ -21225,7 +21778,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)"
         }
       }
     }, {
@@ -21234,7 +21787,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -21243,7 +21796,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -21252,7 +21805,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -21261,7 +21814,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -21270,7 +21823,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -21279,7 +21832,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -21288,7 +21841,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)"
         }
       }
     }, {
@@ -21297,8 +21850,21 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)"
         }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "lbl" : "DSSR",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "Dissecting the Spatial Structure of RNA"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
@@ -21596,6 +22162,9 @@
       "id" : "http://purl.obolibrary.org/obo/SO_0000417",
       "type" : "CLASS"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001078",
+      "type" : "CLASS"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/STATO_0000142",
       "type" : "CLASS"
     }, {
@@ -21710,7 +22279,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -21720,7 +22289,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)"
         }
       }
     }, {
@@ -21730,7 +22299,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -21740,7 +22309,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)"
         }
       }
     }, {
@@ -21750,7 +22319,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)"
         }
       }
     }, {
@@ -21760,7 +22329,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)"
         }
       }
     }, {
@@ -21770,7 +22339,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)"
         }
       }
     }, {
@@ -21780,7 +22349,17 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)"
+        }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "lbl" : "follows protocol",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "definition" : {
+          "val" : "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -22241,7 +22820,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)"
         }
       }
     }, {
@@ -22251,7 +22830,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)"
         }
       }
     }, {
@@ -22261,7 +22840,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)"
         }
       }
     }, {
@@ -22271,7 +22850,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)"
         },
         "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
@@ -22282,7 +22861,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -22292,7 +22871,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -22302,7 +22881,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)"
         }
       }
     }, {
@@ -22312,7 +22891,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)"
         }
       }
     }, {
@@ -22322,7 +22901,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)"
         }
       }
     }, {
@@ -22332,7 +22911,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)"
         }
       }
     }, {
@@ -22342,7 +22921,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)"
         }
       }
     }, {
@@ -22352,7 +22931,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)"
         }
       }
     }, {
@@ -22362,7 +22941,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)"
         }
       }
     }, {
@@ -22372,7 +22951,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -22382,7 +22961,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)"
         }
       }
     }, {
@@ -22392,7 +22971,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -22402,7 +22981,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -22412,7 +22991,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -22422,7 +23001,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)"
         }
       }
     }, {
@@ -22432,7 +23011,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -22442,7 +23021,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -22452,7 +23031,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -22462,7 +23041,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -22472,7 +23051,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)"
         }
       }
     }, {
@@ -22482,7 +23061,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -22492,7 +23071,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)"
         }
       }
     }, {
@@ -22502,7 +23081,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -22512,7 +23091,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)"
         }
       }
     }, {
@@ -22522,7 +23101,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -22532,7 +23111,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -22542,7 +23121,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -22552,7 +23131,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)"
         }
       }
     }, {
@@ -22562,7 +23141,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)"
         }
       }
     }, {
@@ -22572,7 +23151,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -22582,7 +23161,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)"
         }
       }
     }, {
@@ -22592,7 +23171,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)"
         }
       }
     }, {
@@ -22602,7 +23181,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)"
         }
       }
     }, {
@@ -22612,7 +23191,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -22622,7 +23201,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)"
         }
       }
     }, {
@@ -22632,7 +23211,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -22642,7 +23221,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -22652,7 +23231,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -22662,7 +23241,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)"
         }
       }
     }, {
@@ -22672,7 +23251,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)"
         }
       }
     }, {
@@ -22682,7 +23261,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)"
         }
       }
     }, {
@@ -22692,7 +23271,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)"
         }
       }
     }, {
@@ -22702,7 +23281,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)"
         }
       }
     }, {
@@ -22712,7 +23291,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)"
         }
       }
     }, {
@@ -22722,7 +23301,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -22732,7 +23311,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)"
         }
       }
     }, {
@@ -22742,7 +23321,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -22752,7 +23331,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -22762,7 +23341,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -22772,7 +23351,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -22782,7 +23361,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)"
         }
       }
     }, {
@@ -22792,7 +23371,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)"
         }
       }
     }, {
@@ -22802,7 +23381,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)"
         }
       }
     }, {
@@ -22812,7 +23391,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)"
         }
       }
     }, {
@@ -22822,7 +23401,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -22832,7 +23411,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -22842,7 +23421,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)"
         }
       }
     }, {
@@ -22852,7 +23431,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)"
         }
       }
     }, {
@@ -22862,7 +23441,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)"
         }
       }
     }, {
@@ -22872,7 +23451,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)"
         }
       }
     }, {
@@ -22882,7 +23461,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)"
         }
       }
     }, {
@@ -22892,7 +23471,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)"
         }
       }
     }, {
@@ -22902,7 +23481,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)"
         }
       }
     }, {
@@ -22912,7 +23491,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)"
         }
       }
     }, {
@@ -22922,7 +23501,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)"
         }
       }
     }, {
@@ -22932,7 +23511,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)"
         }
       }
     }, {
@@ -22942,7 +23521,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)"
         }
       }
     }, {
@@ -23532,9 +24111,8 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)"
-        },
-        "comments" : [ "The Cambridge Structural Database (CSD) is the world's primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)" ]
+          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)"
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001945",
@@ -23557,7 +24135,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)"
         }
       }
     }, {
@@ -23566,7 +24144,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)"
         }
       }
     }, {
@@ -23575,7 +24153,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -23584,7 +24162,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -23593,7 +24171,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -23602,6 +24180,10 @@
       "propertyType" : "ANNOTATION"
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000116",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -23614,10 +24196,6 @@
       "propertyType" : "ANNOTATION"
     }, {
       "id" : "http://purl.org/dc/elements/1.1/type",
-      "type" : "PROPERTY",
-      "propertyType" : "ANNOTATION"
-    }, {
-      "id" : "http://purl.org/dc/terms/BibliographicResource",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -23653,6 +24231,10 @@
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+      "type" : "PROPERTY",
+      "propertyType" : "ANNOTATION"
+    }, {
       "id" : "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
@@ -23664,15 +24246,15 @@
     "edges" : [ {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
       "pred" : "is_a",
@@ -24894,6 +25476,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000610"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000310",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001072"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
@@ -25438,10 +26024,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001090"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000430"
@@ -25573,10 +26155,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000939"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
       "pred" : "is_a",
@@ -26384,11 +26962,11 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000686",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000687",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
       "pred" : "is_a",
@@ -27542,10 +28120,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -27567,10 +28141,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
     }, {
@@ -30288,7 +30858,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001781",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001333"
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001078"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001782",
       "pred" : "is_a",
@@ -30301,22 +30871,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001782"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001781"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
       "pred" : "is_a",
@@ -31846,6 +32400,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002162"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001960"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/UO_1000010"
@@ -32301,6 +32859,10 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002202",
       "pred" : "subPropertyOf",
       "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "pred" : "subPropertyOf",
+      "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
     } ],
     "domainRangeAxioms" : [ {
       "predicateId" : "http://purl.obolibrary.org/obo/IAO_0000039",
@@ -32343,7 +32905,7 @@
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001994" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002167",
-      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ],
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002156" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002168",
@@ -32373,6 +32935,10 @@
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002202",
       "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001164" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
+      "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ]
     } ]
   } ]
 }

--- a/molsim-base.obo
+++ b/molsim-base.obo
@@ -1,7 +1,7 @@
 format-version: 1.2
-data-version: molsim/releases/2026-07-29/molsim-base.owl
+data-version: molsim/releases/2026-08-07/molsim-base.owl
 default-namespace: molsim
-idspace: dce http://purl.org/dc/elements/1.1/ 
+idspace: dc http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: foaf http://xmlns.com/foaf/0.1/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
@@ -9,9 +9,15 @@ idspace: orcid https://orcid.org/
 idspace: protege http://protege.stanford.edu/plugins/owl/protege# 
 remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
 remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
+remark: Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.
 ontology: molsim/molsim-base
-property_value: dce:type IAO:8000001
+property_value: dc:type IAO:8000001
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
+property_value: dcterms:contributor orcid:0000-0002-2294-5393
+property_value: dcterms:contributor orcid:0000-0002-4303-9349
+property_value: dcterms:contributor orcid:0000-0002-7544-0938
+property_value: dcterms:contributor orcid:0000-0002-8291-8071
+property_value: dcterms:contributor orcid:0000-0003-4177-3619
 property_value: dcterms:contributor orcid:0009-0007-1391-4986
 property_value: dcterms:creator orcid:0000-0001-8613-1447
 property_value: dcterms:creator orcid:0000-0003-4846-8051
@@ -20,13 +26,14 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-29" xsd:string
+property_value: owl:versionInfo "2026-08-07" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
 id: MOLSIM:000000
 name: molecular dynamics process
-def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)" []
+def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation." []
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000001
@@ -35,27 +42,31 @@ def: "Software refers to the set of instructions, data, or programs used to oper
 
 [Term]
 id: MOLSIM:000002
-name: preparation
+name: simulation preparation
 def: "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "preparation" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000003
-name: execution
-def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+name: simulation execution
+def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies." []
+synonym: "execution" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000004
-name: analysis
+name: simulation analysis
 def: "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "analysis" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000005
 name: protonation
 def: "A specific step within the preparation process where the ionization states (presence or absence of protons) of ionizable residues (like acids, bases, histidines) and ligands are determined and assigned based on estimated pKa values relevant to the target pH of the simulation. Correct protonation is critical for accurately modeling electrostatic interactions and pH-dependent phenomena. Specialized tools are often used for this task. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 disjoint_from: MOLSIM:000208 ! thermalization
 
 [Term]
@@ -73,7 +84,7 @@ is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:000008
-name: lipid  force field
+name: lipid force field
 def: "A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)" []
 is_a: MOLSIM:000772 ! chemical entity-based force field
 disjoint_from: MOLSIM:000009 ! protein force field
@@ -140,20 +151,21 @@ disjoint_from: MOLSIM:000485 ! split-valence
 id: MOLSIM:000018
 name: lipid21
 def: "A specific version of a lipid force field, part of the AMBER family, providing parameters optimized for simulating lipids. Released around 2021, it incorporates updates and refinements based on contemporary data and methodologies to improve accuracy in membrane simulations. Its name indicates the originating group (AMBER) and year of major update. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 disjoint_from: MOLSIM:000019 ! lipid14
 
 [Term]
 id: MOLSIM:000019
 name: lipid14
 def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2014. It provides parameters optimized for simulating a range of common lipid types found in biological membranes. This version aimed to improve upon previous lipid models within the AMBER family. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:000020
 name: lipid17
-def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails." []
+is_a: MOLSIM:000008 ! lipid force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000021
@@ -532,6 +544,7 @@ id: MOLSIM:000076
 name: Tversky index algorithm
 def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
+property_value: IAO:0000116 "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1." xsd:string
 
 [Term]
 id: MOLSIM:000077
@@ -603,9 +616,10 @@ is_a: MOLSIM:000037 ! algorithm
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected." []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000089
@@ -782,8 +796,8 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000114
 name: HOLE
 def: "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms." []
+xref: https://doi.org/10.1016/S0263-7855(97)00009-X
 is_a: MOLSIM:000245 ! tunnel predictor tool
-property_value: dcterms:BibliographicResource "https://doi.org/10.1016/S0263-7855(97)00009-X" xsd:string
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -1049,9 +1063,10 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000156
 name: GROMACS mdp format
-def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)" []
+def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
 disjoint_from: MOLSIM:000469 ! AMBER mdin format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000157
@@ -1077,8 +1092,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000160
 name: molecular dynamics engine
-def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)" []
+def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS." []
 is_a: MOLSIM:001851 ! simulation engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000161
@@ -1089,8 +1105,9 @@ is_a: MOLSIM:001851 ! simulation engine
 [Term]
 id: MOLSIM:000162
 name: docking tool
-def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)" []
+def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000163
@@ -1101,20 +1118,23 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:000164
 name: analysis tool
-def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)" []
+def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000165
 name: data processing tool
-def: "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)" []
+def: "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000166
 name: file conversion tool
-def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)" []
+def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)." []
 is_a: MOLSIM:000165 ! data processing tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000167
@@ -1398,20 +1418,22 @@ is_a: MOLSIM:001802 ! script
 id: MOLSIM:000208
 name: thermalization
 def: "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+synonym: "heating" EXACT []
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000209
 name: equilibration
-def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration." []
+is_a: MOLSIM:000002 ! simulation preparation
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000210
 name: umbrella sampling
 def: "A specific simulation execution technique used to enhance sampling along a chosen reaction coordinate or order parameter, often for calculating the potential of mean force (PMF) or free energy profile associated with a process like ligand unbinding or a conformational change. It involves running multiple simulations, each confined ('biased') by a potential (the 'umbrella') to sample a specific window along the coordinate, with subsequent analysis required to unbias the results and reconstruct the overall profile. It falls under the category of enhanced sampling methods." []
 synonym: "US" EXACT []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 disjoint_from: MOLSIM:000211 ! production
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -1419,19 +1441,19 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000211
 name: production
 def: "The main data-gathering phase of a simulation execution, performed after the system has been properly prepared and equilibrated. During the production run, the system is simulated for a significant length of time under the desired conditions (ensemble, temperature, pressure) without strong restraints or equilibration protocols, and the resulting trajectory (positions and velocities over time) is saved for later analysis. The goal is to generate statistically meaningful data about the system's behavior. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000212
 name: free energy calculation
 def: "A type of simulation execution specifically designed to compute the free energy difference between two states (e.g., bound vs unbound, state A vs state B) or the free energy profile along a reaction coordinate. Common methods include Free Energy Perturbation (FEP), Thermodynamic Integration (TI), Umbrella Sampling (for PMFs), and sometimes methods based on endpoint analysis like MM/PBSA or MM/GBSA (though these are technically post-processing analyses estimating free energy). These calculations are computationally demanding but crucial for understanding binding affinities, reaction barriers, and relative stabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000213
 name: adaptive steered molecular dynamics
 def: "An enhanced sampling simulation technique that enhances traditional steered molecular dynamics (SMD) to calculate binding affinities, mechanical unfolding pathways, and free energy profiles (e.g., Potential of Mean Force) in biomolecules. It works by breaking long pulling processes into a series of stages or windows along a specific reaction coordinate." []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -1450,7 +1472,7 @@ is_a: MOLSIM:000017 ! minimal
 id: MOLSIM:000216
 name: visualization
 def: "The process of creating graphical representations of molecular structures, trajectories, and simulation data using specialized software. Visualization is essential for inspecting system setup, monitoring simulation progress, understanding molecular motion and interactions, identifying structural features, and communicating results effectively through images and animations. It is an integral part of both preparation and analysis stages. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:000217
@@ -1482,20 +1504,23 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:000221
 name: PDB2PQR
-def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)" []
+def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)." []
 is_a: MOLSIM:000223 ! generic protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000222
 name: ligand protonation tool
-def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)" []
+def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000223
 name: generic protonation tool
-def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)" []
+def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000224
@@ -1519,14 +1544,16 @@ disjoint_from: MOLSIM:001927 ! CHARMM-GUI
 [Term]
 id: MOLSIM:000227
 name: membrane protein orientation tool
-def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)" []
+def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000228
 name: memembed
-def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)" []
+def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential." []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000229
@@ -1605,8 +1632,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000240
 name: pKa tool
-def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)" []
+def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example." []
 is_a: MOLSIM:000490 ! structure preparation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000241
@@ -1623,8 +1651,9 @@ is_a: MOLSIM:000460 ! molecular mechanics Poisson-Boltzmann surface area tool
 [Term]
 id: MOLSIM:000243
 name: in-silico mutagenesis tool
-def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)" []
+def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000244
@@ -2026,8 +2055,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000305
 name: modeling method
-def: "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)" []
+def: "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy." []
 is_a: MOLSIM:000140 ! computational method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000306
@@ -2059,12 +2089,13 @@ is_a: MOLSIM:000610 ! thermodynamics analysis
 id: MOLSIM:000310
 name: plan specification
 def: "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)" []
-comment: TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)
+comment: Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.
+is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:000311
 name: RMSD analysis
-def: "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms." []
+def: "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms." []
 is_a: MOLSIM:000917 ! structural analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -2963,10 +2994,10 @@ def: "An identifier is a unique name, code, or label assigned to a specific enti
 
 [Term]
 id: MOLSIM:000448
-name: protein database ID
-def: "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
-is_a: MOLSIM:000447 ! identifier
-property_value: IAO:0000117 orcid:0000-0003-4177-3619
+name: obsolete protein database ID
+def: "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
+comment: Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000449
@@ -3083,10 +3114,11 @@ is_a: MOLSIM:000462 ! molecular mechanics generalized Born surface area tool
 [Term]
 id: MOLSIM:000466
 name: orientations of proteins in membranes
-def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)" []
+def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations." []
 synonym: "OPM" EXACT []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000467
@@ -3105,8 +3137,9 @@ is_a: MOLSIM:000909 ! volumetric data format
 [Term]
 id: MOLSIM:000469
 name: AMBER mdin format
-def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)" []
+def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000470
@@ -3122,10 +3155,11 @@ disjoint_from: MOLSIM:000879 ! ADF output format
 [Term]
 id: MOLSIM:000471
 name: AMBER restart format
-def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)" []
+def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)." []
 is_a: MOLSIM:000441 ! simulation state format
 disjoint_from: MOLSIM:000880 ! rkf format
 disjoint_from: MOLSIM:000890 ! GAUSSIAN chk format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000472
@@ -3176,8 +3210,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000479
 name: Connolly surface analysis
-def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)" []
+def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent." []
 is_a: MOLSIM:000478 ! molecular surface analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000480
@@ -3187,10 +3222,11 @@ is_a: MOLSIM:000939 ! dynamics analysis
 
 [Term]
 id: MOLSIM:000481
-name: 2D RMSD analysis
-def: "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
-is_a: MOLSIM:000917 ! structural analysis
-property_value: IAO:0000117 orcid:0000-0002-2294-5393
+name: obsolete 2D RMSD analysis
+def: "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
+comment: Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45.
+is_obsolete: true
+replaced_by: MOLSIM:000311
 
 [Term]
 id: MOLSIM:000482
@@ -3272,7 +3308,7 @@ is_a: MOLSIM:002041 ! molecular structure visualization tool
 id: MOLSIM:000494
 name: minimization
 def: "Minimization is a computational step that relaxes a molecular structure to remove any bad clashes between atoms. As a stage of the preparation process, energy minimization is a procedure that adjusts the atomic coordinates to find a nearby local minimum on the potential energy surface, thereby removing steric strain from the initial model. This is achieved by using algorithms like steepest descent or conjugate gradient to iteratively reduce the net forces on the atoms until a convergence criterion, such as grms_tol, is met. This process is referred to in log files and inputs with terms like \"MINIMIZATION,\" \"ntmin=1,\" \"emtol,\" and \"ncyc.\" (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000495
@@ -3284,7 +3320,7 @@ is_a: MOLSIM:000272 ! radii set
 id: MOLSIM:000496
 name: pyMBAR
 def: "pyMBAR refers to a specific Python software library implementation of the Multistate Bennett Acceptance Ratio (MBAR) method. MBAR itself is a statistical technique for optimally combining data from multiple simulations to calculate free energies and expectation values. Therefore, pyMBAR is a tool used for the analysis stage of free energy calculations, particularly for processing data generated by methods like umbrella sampling or replica exchange simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:000497
@@ -3871,9 +3907,10 @@ is_a: MOLSIM:000590 ! plot data format
 [Term]
 id: MOLSIM:000596
 name: grid format
-def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)" []
+def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule." []
 synonym: ".grid" EXACT []
 is_a: MOLSIM:000590 ! plot data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000597
@@ -4355,8 +4392,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000670
 name: coordinate centering analysis
-def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)" []
+def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization." []
 is_a: MOLSIM:000917 ! structural analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000671
@@ -4412,7 +4450,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 id: MOLSIM:000679
 name: obsolete image bond fixing analysis
 def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+comment: Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45.
 is_obsolete: true
+replaced_by: MOLSIM:000659
 
 [Term]
 id: MOLSIM:000680
@@ -4457,13 +4497,13 @@ is_a: MOLSIM:000141 ! theoretical approach
 id: MOLSIM:000686
 name: PDB ID
 def: "A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., '1TIM', '6M0J') serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000687
 name: Uniprot ID
 def: "A UniProt ID, more formally known as a UniProt Accession Number (e.g., 'P00761', 'Q8WZ42'), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000688
@@ -4591,8 +4631,9 @@ is_a: MOLSIM:000703 ! secondary database
 [Term]
 id: MOLSIM:000706
 name: pathway database
-def: "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)" []
+def: "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples." []
 is_a: MOLSIM:000703 ! secondary database
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000707
@@ -4745,8 +4786,9 @@ disjoint_from: MOLSIM:001472 ! bonded metal model
 [Term]
 id: MOLSIM:000741
 name: amber ff02
-def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)" []
+def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000742
@@ -4812,8 +4854,9 @@ is_a: MOLSIM:000009 ! protein force field
 [Term]
 id: MOLSIM:000752
 name: CHARMM 19
-def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)" []
+def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000753
@@ -4944,8 +4987,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000774
 name: Abalone
-def: "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)" []
+def: "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field." []
 is_a: MOLSIM:001664 ! software suite
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000775
@@ -4962,9 +5006,10 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000777
 name: Desmond
-def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)" []
+def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
 disjoint_from: MOLSIM:000784 ! LAMMPS
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000778
@@ -5017,8 +5062,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000786
 name: NAMD
-def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)" []
+def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000787
@@ -5375,9 +5421,10 @@ is_a: MOLSIM:000841 ! empirical method
 [Term]
 id: MOLSIM:000843
 name: molecular dynamics
-def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)" []
+def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems." []
 synonym: "MD" EXACT []
 is_a: MOLSIM:000308 ! simulation method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000844
@@ -5544,8 +5591,9 @@ disjoint_from: MOLSIM:000868 ! GAMESS input format
 [Term]
 id: MOLSIM:000867
 name: CHARMM input format
-def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)" []
+def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results." []
 is_a: MOLSIM:000438 ! script format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000868
@@ -5569,9 +5617,10 @@ is_a: MOLSIM:000437 ! simulation input format
 
 [Term]
 id: MOLSIM:000871
-name: GROMACS input  format
-def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)" []
+name: GROMACS input format
+def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000872
@@ -5600,14 +5649,16 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000876
 name: NAMD configuration format
-def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)" []
+def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000877
 name: NWChem input format
-def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)" []
+def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system." []
 is_a: MOLSIM:000437 ! simulation input format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000878
@@ -5632,8 +5683,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000881
 name: CHARMM output format
-def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)" []
+def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000882
@@ -5656,8 +5708,9 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000885
 name: GROMACS output format
-def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)" []
+def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000886
@@ -5704,8 +5757,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000893
 name: NWChem restart format
-def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)" []
+def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)." []
 is_a: MOLSIM:000441 ! simulation state format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000894
@@ -5737,10 +5791,11 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000898
 name: itp format
-def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)" []
+def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive." []
 synonym: "GROMACS include topology format" EXACT []
 synonym: "GROMACS itp format" EXACT []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000899
@@ -5766,8 +5821,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000902
 name: dcd format
-def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)" []
+def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability." []
 is_a: MOLSIM:001090 ! molecular trajectory format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000903
@@ -5786,6 +5842,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:000905
 name: obsolete small molecule structure
 def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -5877,8 +5934,9 @@ is_a: MOLSIM:000917 ! structural analysis
 [Term]
 id: MOLSIM:000921
 name: crd format
-def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)" []
+def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used." []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000923
@@ -5943,7 +6001,7 @@ is_a: MOLSIM:000937 ! structure clustering analysis
 id: MOLSIM:000939
 name: dynamics analysis
 def: "Dynamics analysis involves processing the time-series data generated from molecular dynamics simulations, primarily the trajectory files, to extract quantitative information and insights about the system's behavior. This encompasses a wide range of techniques aimed at understanding molecular motions, conformational changes, interactions, and kinetic or thermodynamic properties. The goal is to translate raw simulation output into meaningful physical or biological understanding." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 is_a: MOLSIM:000026 ! analysis method
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -5958,8 +6016,9 @@ disjoint_from: MOLSIM:001079 ! frcmod format
 [Term]
 id: MOLSIM:000941
 name: coordinate rotation modeling
-def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)" []
+def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure." []
 is_a: MOLSIM:000305 ! modeling method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000942
@@ -6061,7 +6120,7 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 id: MOLSIM:000963
 name: AMBER crd format
 def: "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information." []
-comment: Amber's standard ASCII coordinate trajectory file format.\n\nThe "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
+comment: Amber's standard ASCII coordinate trajectory file format. The "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
 synonym: "AMBER inpcrd format" EXACT []
 synonym: "AMBER prmcrd format" EXACT []
 is_a: MOLSIM:000921 ! crd format
@@ -6302,7 +6361,7 @@ is_a: MOLSIM:000921 ! crd format
 id: MOLSIM:001039
 name: trj format
 def: "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited." []
-comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
+comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
 synonym: "AMBER trj format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
@@ -6310,33 +6369,39 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001040
 name: distance matrix format
-def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)" []
-comment: Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
+def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule." []
+comment: Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
 is_a: MOLSIM:010020 ! molecular trajectory analysis format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001041
-name: xpm  format
+name: xpm format
 def: "The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)" []
 synonym: ".xpm" EXACT []
-synonym: "GROMACS xpm  format" EXACT []
+synonym: "GROMACS xpm format" EXACT []
 is_a: MOLSIM:001040 ! distance matrix format
 
 [Term]
 id: MOLSIM:001042
 name: prmtop format
 def: "The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)" []
+synonym: "AMBER PARM7 format" EXACT []
+synonym: "AMBER parm7 format" EXACT []
 synonym: "AMBER parmtop format" EXACT []
 synonym: "AMBER prmtop format" EXACT []
+synonym: "parm7 format" EXACT []
 is_a: MOLSIM:000472 ! AMBER topology format
 
 [Term]
 id: MOLSIM:001043
-name: parm7 format
-def: "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)" []
+name: obsolete parm7 format
+def: "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.
 synonym: "AMBER PARM7 format" EXACT []
 synonym: "AMBER parm7 format" EXACT []
-is_a: MOLSIM:000472 ! AMBER topology format
+is_obsolete: true
+replaced_by: MOLSIM:001042
 
 [Term]
 id: MOLSIM:001044
@@ -6382,15 +6447,19 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001049
 name: rst format
-def: "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)" []
+def: "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)" []
+synonym: "restrt format" EXACT []
+synonym: "rst7 format" EXACT []
 is_a: MOLSIM:000471 ! AMBER restart format
-disjoint_from: MOLSIM:001050 ! rst7 format
+disjoint_from: MOLSIM:001050 ! obsolete rst7 format
 
 [Term]
 id: MOLSIM:001050
-name: rst7 format
-def: "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)" []
-is_a: MOLSIM:000471 ! AMBER restart format
+name: obsolete rst7 format
+def: "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.
+is_obsolete: true
+replaced_by: MOLSIM:001049
 
 [Term]
 id: MOLSIM:001051
@@ -6453,10 +6522,10 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 
 [Term]
 id: MOLSIM:001059
-name: conflib  format
+name: conflib format
 def: "The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)" []
 synonym: ".conflib" EXACT []
-synonym: "LMOD conflib  format" EXACT []
+synonym: "LMOD conflib format" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
 
 [Term]
@@ -6477,17 +6546,19 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:001062
 name: pqr format
-def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)" []
+def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field." []
 synonym: ".pqr" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001063
 name: MOE
-def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)" []
+def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface." []
 synonym: "Molecular Operating Environment" EXACT []
 is_a: MOLSIM:000490 ! structure preparation tool
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001064
@@ -6549,14 +6620,14 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 id: MOLSIM:001072
 name: information content entity
 def: "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)" []
-property_value: dcterms:BibliographicResource "" xsd:string
 
 [Term]
 id: MOLSIM:001073
 name: molecular system specification
-def: "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)" []
+def: "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed." []
 is_a: MOLSIM:001072 ! information content entity
 disjoint_from: MOLSIM:001074 ! process specification
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001074
@@ -6651,6 +6722,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 id: MOLSIM:001087
 name: obsolete macromolecular structure format
 def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -6664,6 +6736,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:001089
 name: obsolete software-specific coordinate format
 def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+comment: Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -6728,7 +6801,7 @@ is_a: MOLSIM:002066 ! force field parameter format
 id: MOLSIM:001099
 name: DFTB parameter format
 def: "The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)" []
-synonym: "skf  format" EXACT []
+synonym: "skf format" EXACT []
 is_a: MOLSIM:002066 ! force field parameter format
 
 [Term]
@@ -6847,15 +6920,17 @@ is_a: MOLSIM:010022 ! quantum chemistry format
 [Term]
 id: MOLSIM:001118
 name: mdinfo format
-def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)" []
+def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file." []
 synonym: "AMBER mdinfo format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001119
 name: database web server
-def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)" []
+def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system." []
 is_a: MOLSIM:001671 ! web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001120
@@ -7096,8 +7171,9 @@ is_a: MOLSIM:001199 ! external field parameter
 [Term]
 id: MOLSIM:001201
 name: constraint and restraint parameter
-def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)" []
+def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001202
@@ -7185,14 +7261,16 @@ is_a: MOLSIM:001210 ! system setup parameter
 [Term]
 id: MOLSIM:001215
 name: alchemical transformation state
-def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)" []
+def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001216
 name: number of replicates
-def: "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)" []
+def: "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001217
@@ -7960,8 +8038,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001337
 name: hydrogen mass repartitioning analysis
-def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)" []
+def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics." []
 is_a: MOLSIM:000328 ! system setup modeling
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001338
@@ -7978,8 +8057,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:001340
 name: dihedral angle
-def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)" []
+def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001341
@@ -8168,8 +8248,9 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 [Term]
 id: MOLSIM:001366
 name: base pair step parameter
-def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)" []
+def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist." []
 is_a: MOLSIM:001358 ! nucleic acid parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001367
@@ -8603,8 +8684,9 @@ is_a: MOLSIM:001427 ! miscellaneous descriptor
 [Term]
 id: MOLSIM:001432
 name: adaptive string method
-def: "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)" []
+def: "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path." []
 is_a: MOLSIM:000860 ! string method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001433
@@ -8666,14 +8748,16 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001442
 name: amber ff03
-def: "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)" []
+def: "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001443
 name: amber ff03ua
-def: "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)" []
+def: "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001444
@@ -8711,13 +8795,13 @@ is_a: MOLSIM:000010 ! DNA force field
 id: MOLSIM:001449
 name: lipid11
 def: "Lipid11 is a specific version of the AMBER lipid force field, released around 2011, that provided an updated set of parameters for simulating common phospholipid molecules. It served as an improvement over earlier lipid models within the AMBER family for modeling biological membranes. It has since been superseded by more recent versions like LIPID14 and LIPID17, but represents an important step in the development of AMBER's membrane simulation capabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001450
 name: GAFFLipid
 def: "GAFFLipid is a force field for simulating a wide variety of lipid molecules, built upon the principles of the General Amber Force Field (GAFF). It uses the GAFF atom typing and parameterization strategy to automatically generate parameters for lipids that are not covered by specialized lipid force fields like LIPID17. This makes it a versatile tool for modeling novel or unusual lipid species in membrane simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001451
@@ -8991,8 +9075,9 @@ is_a: MOLSIM:000014 ! water model force field
 [Term]
 id: MOLSIM:001494
 name: crystallographic model component
-def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)" []
+def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid." []
 is_a: MOLSIM:000006 ! model
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001495
@@ -9213,8 +9298,9 @@ is_a: MOLSIM:000204 ! ligand charge model
 [Term]
 id: MOLSIM:001530
 name: amber fb15
-def: "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)" []
+def: "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001531
@@ -9380,8 +9466,9 @@ is_a: MOLSIM:001956 ! system packing and solvation tool
 [Term]
 id: MOLSIM:001558
 name: electrostatics analysis tool
-def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)" []
+def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001559
@@ -9427,15 +9514,17 @@ is_a: MOLSIM:001968 ! alchemical analysis tool
 
 [Term]
 id: MOLSIM:001566
-name: library
-def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)" []
+name: software library
+def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing." []
+synonym: "library" EXACT []
 is_a: MOLSIM:000170 ! software component
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001567
 name: FFTW
 def: "FFTW is a highly optimized software library for computing the discrete Fourier transform, a fundamental mathematical operation used in many scientific applications. In biomolecular simulations, it is most commonly used to perform the Fast Fourier Transform (FFT) required for the Particle Mesh Ewald (PME) method of calculating long-range electrostatic forces. For simulation engines, using the FFTW library is essential for achieving high performance in the most computationally demanding part of the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001568
@@ -9464,14 +9553,16 @@ is_a: MOLSIM:000272 ! radii set
 [Term]
 id: MOLSIM:001572
 name: ndfes
-def: "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)" []
+def: "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods." []
 is_a: MOLSIM:001969 ! free energy surface analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001573
 name: ParmEd
-def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001574
@@ -9509,7 +9600,7 @@ id: MOLSIM:001579
 name: pytraj
 def: "Pytraj is a Python library that provides a programmable interface to the powerful trajectory analysis capabilities of the cpptraj engine from the AmberTools suite. It allows users to write Python scripts to perform a wide range of analyses, such as calculating RMSD, distances, and hydrogen bonds, directly on simulation trajectories. Pytraj enables the creation of complex, automated, and reproducible analysis workflows that integrate seamlessly with other Python data science tools." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -9528,7 +9619,7 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 id: MOLSIM:001582
 name: torch PBSA runtime
 def: "The torch PBSA runtime is a software library that leverages the PyTorch deep learning framework to perform Poisson-Boltzmann Surface Area (PBSA) calculations. By using PyTorch, it can take advantage of GPU acceleration to significantly speed up the computationally intensive process of solving the Poisson-Boltzmann equation. For researchers, this library offers a high-performance tool for estimating solvation free energies as part of binding free energy calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001583
@@ -9556,21 +9647,24 @@ is_a: MOLSIM:001585 ! build system tool
 
 [Term]
 id: MOLSIM:001587
-name: Intel Math Kernel Library
-def: "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+name: Intel oneAPI Math Kernel Library
+def: "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001588
 name: package manager
-def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)" []
+def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments." []
 is_a: MOLSIM:000171 ! software development and management tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001589
 name: Miniconda
-def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)" []
+def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software." []
 is_a: MOLSIM:001588 ! package manager
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001590
@@ -9624,7 +9718,7 @@ is_a: MOLSIM:000157 ! framework
 id: MOLSIM:001598
 name: TCPB-cpp
 def: "TCPB-cpp is a software tool that acts as a bridge, allowing a classical simulation program to communicate with the TeraChem quantum chemistry program. It is a C++ library that provides an Application Programming Interface (API), enabling a molecular dynamics engine to send a small, quantum mechanical (QM) part of the system to TeraChem for a high-performance, GPU-accelerated energy and force calculation. This allows for the creation of powerful and efficient QM/MM simulations, where the speed of a classical simulation is combined with the accuracy of TeraChem's quantum calculations for studying chemical reactions. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001599
@@ -9690,7 +9784,7 @@ is_a: MOLSIM:001970 ! parameter assignment tool
 [Term]
 id: MOLSIM:001608
 name: parmcal
-def: "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
+def: "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
 is_a: MOLSIM:001970 ! parameter assignment tool
 
 [Term]
@@ -9833,8 +9927,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001631
 name: ambpdb
-def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)" []
+def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001632
@@ -9959,20 +10054,22 @@ is_a: MOLSIM:001569 ! utility script
 [Term]
 id: MOLSIM:001652
 name: chamber
-def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)" []
+def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001653
 name: match_atomname
-def: "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)" []
+def: "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001654
 name: MPI library
 def: "An MPI library is a software library that implements the Message Passing Interface (MPI) standard for parallel programming. It provides functions that allow multiple independent processes, typically running on different computers in a cluster, to communicate and exchange data with each other. For high-performance biomolecular simulations, an MPI library is essential for parallelizing the calculations and distributing the workload across many processors to simulate large systems efficiently. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001655
@@ -9984,7 +10081,7 @@ is_a: MOLSIM:001654 ! MPI library
 id: MOLSIM:001656
 name: ARPACK
 def: "ARPACK is a software library for solving large-scale eigenvalue problems, which involve finding the characteristic modes and values of a large matrix. It is particularly efficient at finding a subset of eigenvalues and their corresponding eigenvectors, which is often what is needed in scientific computing. In biomolecular simulation, ARPACK is used in analysis methods like Normal Mode Analysis or Principal Component Analysis to calculate the dominant modes of molecular motion. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001657
@@ -10007,14 +10104,16 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001660
 name: NAB
-def: "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)" []
+def: "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository." []
 is_a: MOLSIM:001659 ! programming language
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001661
 name: FE-ToolKit
-def: "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001662
@@ -10079,27 +10178,29 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001672
 name: GLYCAM-Web
-def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)" []
+def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages." []
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001673
 name: Glycoprotein Builder
-def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)" []
+def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein." []
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001674
 name: RDKit
 def: "RDKit is an open-source software library for cheminformatics, providing a wide range of tools for working with chemical structures. It allows users to read and write molecular file formats, generate 2D and 3D coordinates, calculate molecular descriptors, and perform substructure searching. In the context of biomolecular simulation, RDKit is frequently used in preparatory workflows to process, analyze, and prepare small molecule ligands for subsequent modeling and simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001675
 name: OpenMM
 def: "OpenMM is a high-performance software library that provides a toolkit for running molecular dynamics simulations, with a strong emphasis on GPU acceleration. It is not a monolithic application but rather a flexible library that allows developers to easily add simulation capabilities to their own programs. For the simulation community, OpenMM provides a powerful, hardware-accelerated, and easily customizable platform for developing new simulation methods and applications. (UNVERIFIED)" []
 is_a: MOLSIM:000160 ! molecular dynamics engine
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001676
@@ -10118,30 +10219,32 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:001678
 name: BLAS
 def: "BLAS, or Basic Linear Algebra Subprograms, is a specification that defines a set of low-level routines for performing common linear algebra operations such as vector and matrix multiplication. Highly optimized libraries that implement the BLAS standard are available and provide a foundation for more complex numerical software. For simulation and quantum chemistry programs, using an optimized BLAS library is critical for achieving high performance in matrix-intensive calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001679
 name: LAPACK
 def: "LAPACK, or the Linear Algebra Package, is a standard software library that provides routines for solving more advanced numerical linear algebra problems. It includes functions for solving systems of linear equations, finding eigenvalues and eigenvectors, and performing matrix factorizations. For computational chemistry and simulation analysis tools, LAPACK is an essential component for tasks like matrix diagonalization in Principal Component Analysis or solving equations in quantum mechanical calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001680
 name: DL-Find
-def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001681
 name: sff
 def: "The sff library is a software component, often used with the OpenMM simulation toolkit, for parsing and interpreting force field definition files. It is designed to read standard force field file formats, such as those from AMBER, and make the parameters available to a simulation engine. This library provides the essential function of translating the human-readable force field files into the internal representation needed to calculate forces during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001682
 name: 3DNA
 def: "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures." []
+synonym: "x3DNA" EXACT []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 property_value: IAO:0000117 orcid:0000-0002-4303-9349
 property_value: IAO:0000117 orcid:0000-0002-7544-0938
@@ -10155,8 +10258,9 @@ is_a: MOLSIM:000160 ! molecular dynamics engine
 [Term]
 id: MOLSIM:001684
 name: match analysis tool
-def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)" []
+def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001685
@@ -10530,8 +10634,9 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001743
 name: ICOSA algorithm
-def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)" []
+def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment." []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001744
@@ -10548,9 +10653,10 @@ is_a: MOLSIM:001696 ! analysis algorithm
 [Term]
 id: MOLSIM:001746
 name: DSSP algorithm
-def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)" []
+def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation." []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 disjoint_from: MOLSIM:010012 ! STRIDE algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001747
@@ -10608,6 +10714,7 @@ id: MOLSIM:001755
 name: atom name
 def: "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
@@ -10685,20 +10792,20 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001767
 name: trajectory post-processing
 def: "Trajectory post-processing is the general process of cleaning and preparing raw simulation trajectory files before performing detailed scientific analysis. This typically involves essential steps like removing the overall rotation and translation of a target molecule to keep it centered, and fixing any molecules that appear \"broken\" by the periodic boundary conditions. These routine procedures are necessary to create a clean trajectory that is suitable for correct visualization and accurate calculation of structural properties." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001768
 name: match list preparation
 def: "This is a setup step in some advanced simulation or analysis workflows where a list is created to define a correspondence between atoms in two different molecules or structures. This \"match list\" is essential for methods like alchemical free energy calculations, where it specifies which atom in one molecule transforms into which atom in another. The correct preparation of this list is a critical and often manual step that defines the mapping for the entire transformation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001769
 name: topology and coordinate file preparation
 def: "This is the fundamental setup process in preparing a molecular simulation, where two distinct but essential files are created. The first is the topology file, which defines the molecule's chemical identity, including its atoms, bonds, and force field parameters. The second is the coordinate file, which provides the initial three-dimensional positions of all the atoms, serving as the starting snapshot for the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001770
@@ -10723,13 +10830,13 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001773
 name: LEaP preparation
 def: "LEaP preparation is the process of using the LEaP program from the AmberTools software suite to build a complete molecular system that is ready for simulation. This involves loading a molecular structure file, applying a specific force field to assign parameters, adding a box of solvent molecules, and introducing ions to neutralize the system's charge. This step is the standard and essential procedure for assembling all the necessary components into the final topology and coordinate files needed to run an AMBER simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001774
 name: momentum removal
 def: "Momentum removal is a procedure applied periodically during a molecular dynamics simulation to prevent the entire system from drifting or spinning over time. It works by resetting the total linear and angular momentum of the system to zero at regular intervals, which can otherwise accumulate due to numerical inaccuracies in the integration algorithm. This is a standard housekeeping procedure that ensures the molecule of interest remains centered in the simulation box for easier analysis. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001775
@@ -10771,7 +10878,7 @@ is_a: MOLSIM:001778 ! wavefunction model
 id: MOLSIM:001781
 name: secondary structure
 def: "Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein's overall architecture and how its shape changes during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001333 ! structural property
+is_a: SO:0001078
 
 [Term]
 id: MOLSIM:001782
@@ -10782,38 +10889,48 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001783
 name: parallel beta sheet
-def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)" []
+def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001784
 name: anti-parallel beta sheet
-def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)" []
+def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001785
-name: helix
-def: "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)" []
-is_a: MOLSIM:001781 ! secondary structure
+name: obsolete helix
+def: "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001114
 
 [Term]
 id: MOLSIM:001786
-name: 3-10 helix
-def: "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete 3-10 helix
+def: "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001119
 
 [Term]
 id: MOLSIM:001787
-name: alpha helix
-def: "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete alpha helix
+def: "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001117
 
 [Term]
 id: MOLSIM:001788
-name: pi helix
-def: "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete pi helix
+def: "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001118
 
 [Term]
 id: MOLSIM:001789
@@ -10824,8 +10941,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001790
 name: bend
-def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)" []
+def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001791
@@ -10836,8 +10954,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001792
 name: beta bridge
-def: "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)" []
+def: "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001793
@@ -10856,8 +10975,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001795
 name: MDL solvent model format
-def: "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)" []
+def: "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions." []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001796
@@ -11206,13 +11326,14 @@ is_a: MOLSIM:001463 ! QM/MM model component
 id: MOLSIM:001849
 name: convergence analysis
 def: "Convergence analysis is the process of checking whether a simulation has been run for a sufficient amount of time to provide a stable and reliable result. This is typically done by monitoring a key property, such as the system's energy or a structural measurement, to see if its average value stops changing and remains steady over the later parts of the simulation. Performing this analysis is a critical step to ensure that the calculated properties are statistically meaningful and not just an artifact of a short, unrepresentative trajectory. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001850
 name: modeling and setup tool
-def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)" []
+def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation." []
 is_a: MOLSIM:000158 ! simulation and modeling software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001851
@@ -11268,7 +11389,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001859
 name: network analysis
 def: "Network analysis is a method that represents a molecule as a graph of nodes (atoms or residues) connected by edges (interactions or correlations) to analyze how information is communicated through its structure. By applying graph theory, this approach can identify critical residues that act as communication hubs and map the pathways of correlated motion that connect distant parts of the molecule. This is a powerful tool for understanding allosteric regulation and the long-range effects of mutations. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001860
@@ -11280,7 +11401,7 @@ is_a: MOLSIM:000917 ! structural analysis
 id: MOLSIM:001861
 name: ligand analysis
 def: "Ligand analysis is a broad category of methods focused on characterizing the behavior of a small molecule, or ligand, during a simulation of its complex with a larger receptor. This includes analyzing the stability of its binding pose, its internal flexibility and conformational changes, and its specific interactions with the protein or nucleic acid. These analyses are fundamental to structure-based drug design for understanding the determinants of binding affinity and specificity. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001862
@@ -11312,21 +11433,22 @@ is_a: MOLSIM:001403 ! statistical property
 [Term]
 id: MOLSIM:001866
 name: backbone DH fluctuations
-def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)" []
+def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001867
 name: membrane analysis
 def: "Membrane analysis is a category of analysis methods specifically focused on characterizing the properties of lipid bilayer simulations. These methods are used to quantify the structural and dynamic behavior of the membrane itself and its interactions with other molecules, like embedded proteins. This includes calculating key properties such as the area per lipid, membrane thickness, and lipid order parameters to validate the simulation and understand membrane function." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
 id: MOLSIM:001868
 name: area per lipid
 def: "The area per lipid is a fundamental biophysical metric representing the average cross-sectional surface area occupied by a single lipid molecule within a lipid bilayer. It is calculated by dividing the total area of the simulation box in the membrane plane by the number of lipids in one leaflet." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -11447,7 +11569,7 @@ is_a: MOLSIM:000342 ! correlation analysis
 id: MOLSIM:001885
 name: trajectory meta analysis
 def: "Trajectory meta-analysis refers to a higher level of analysis that involves comparing, contrasting, or combining the results from multiple, independent simulation trajectories. This can be used to improve statistical certainty, assess the convergence of a simulation, or identify the differences in dynamics between a wild-type protein and a mutant. This approach is essential for drawing robust conclusions that are not dependent on a single simulation run." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -11473,8 +11595,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001889
 name: complex system
-def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)" []
+def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together." []
 is_a: MOLSIM:001887 ! molecular simulation system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001890
@@ -11506,8 +11629,9 @@ is_a: MOLSIM:001890 ! ligand complex system
 [Term]
 id: MOLSIM:001894
 name: hybrid complex system
-def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)" []
+def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair." []
 is_a: MOLSIM:001889 ! complex system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001895
@@ -11668,7 +11792,7 @@ id: MOLSIM:001918
 name: MDAnalysis
 def: "MDAnalysis is an open-source Python library used for the analysis of molecular dynamics simulation trajectories. It provides a flexible and object-oriented framework that allows users to read, write, and manipulate atomic coordinate data from a wide variety of simulation packages. MDAnalysis is a powerful tool for writing custom, complex, and reproducible analysis scripts in a familiar Python environment." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -11676,41 +11800,44 @@ id: MOLSIM:001919
 name: MDTraj
 def: "MDTraj is a modern, open-source Python library designed for the fast and efficient analysis of molecular dynamics trajectories. It excels at reading and writing a very broad range of trajectory and topology file formats, making it highly interoperable. MDTraj provides a fast and powerful toolkit for performing common structural and time-series analyses on simulation data." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001920
 name: ProDy
 def: "ProDy is a free and open-source Python package for analyzing protein structural dynamics. It provides a comprehensive set of tools for tasks such as parsing structure files, analyzing conformational ensembles, and calculating collective modes of motion using methods like Normal Mode Analysis. For researchers studying protein function, ProDy offers a powerful environment for exploring the link between a protein's structure and its dynamic behavior. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001921
 name: BioBB
 def: "BioBB, or BioExcel Building Blocks, is a library of Python wrappers that create a standardized interface for many common biomolecular simulation programs like GROMACS and AmberTools. Each building block performs a specific task, such as running an energy minimization or calculating an RMSD, using a consistent input and output format. For computational biologists, BioBB provides an interoperable toolkit for constructing complex, reproducible, and portable simulation workflows." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001922
 name: 3DMol.js
-def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001923
 name: NGL
-def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001924
 name: Open Babel
-def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)" []
+def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files." []
 is_a: MOLSIM:000166 ! file conversion tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001925
@@ -11727,15 +11854,17 @@ is_a: MOLSIM:000251 ! trajectory processing tool
 [Term]
 id: MOLSIM:001927
 name: CHARMM-GUI
-def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)" []
+def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations." []
 is_a: MOLSIM:000225 ! membrane packing tool
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001928
 name: Modeller
-def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)" []
+def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation." []
 is_a: MOLSIM:001958 ! homology modeling tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001929
@@ -11759,15 +11888,17 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001932
 name: Jmol
-def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)" []
+def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001933
 name: MolStar
-def: "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)" []
+def: "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies." []
 synonym: "Mol*" EXACT []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001934
@@ -11904,8 +12035,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001955
 name: crystallographic build tool
-def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)" []
+def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment." []
 is_a: MOLSIM:001556 ! system setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001956
@@ -11922,14 +12054,16 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:001958
 name: homology modeling tool
-def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)" []
+def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001959
 name: AutoDock Vina
-def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)" []
+def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001960
@@ -11965,14 +12099,16 @@ is_a: MOLSIM:001684 ! match analysis tool
 [Term]
 id: MOLSIM:001965
 name: DALI
-def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)" []
+def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001966
 name: LS-align
-def: "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)" []
+def: "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001967
@@ -11990,8 +12126,9 @@ is_a: MOLSIM:001564 ! free energy analysis tool
 [Term]
 id: MOLSIM:001969
 name: free energy surface analysis tool
-def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)" []
+def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates." []
 is_a: MOLSIM:001564 ! free energy analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001970
@@ -12046,7 +12183,7 @@ is_a: MOLSIM:001531 ! united-atom force field
 id: MOLSIM:001978
 name: PLUMED
 def: "PLUMED is an open-source software library designed to analyze molecular dynamics simulations and perform enhanced sampling of free energy landscapes. It functions as middleware that interfaces with various simulation engines to calculate collective variables and apply biasing potentials in real-time." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -12152,8 +12289,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001995
 name: position restraints
-def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)" []
+def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol." []
 is_a: MOLSIM:001552 ! restraint potential
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001996
@@ -12249,7 +12387,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:002010
 name: solvation
 def: "Solvation is the computational process of immersing a solute molecule, such as a protein, into a box containing solvent molecules, typically water. This step involves placing the solute coordinates into a pre-equilibrated solvent box, removing solvent molecules that overlap with the solute atoms, and updating the system topology. For experts, this process defines the simulation box dimensions, density, and total number of atoms, which are critical for the efficiency and validity of periodic boundary condition simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:002011
@@ -12260,8 +12398,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:002012
 name: continuation state
-def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)" []
+def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002013
@@ -12427,28 +12566,32 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:002039
 name: atom ID
-def: "An atom ID is usually a number, that uniquely defines a given atom in structure." []
+def: "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
 id: MOLSIM:002040
 name: JSmol
-def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)" []
+def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002041
 name: molecular structure visualization tool
-def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)" []
+def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships." []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002042
 name: data plotting tool
-def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)" []
+def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files." []
 synonym: "data visualization tool" EXACT []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002043
@@ -12479,33 +12622,36 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:002047
 name: OpenMPI
 def: "Open MPI is an open-source, freely available implementation of the Message Passing Interface (MPI) standard. It is widely used in high-performance computing to facilitate communication between distributed processes. In biomolecular simulation, it is a standard library used to compile and run parallel simulation engines, such as GROMACS, LAMMPS, and NAMD, across multiple nodes of a computer cluster to ensure efficient scaling and data exchange. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002048
 name: MPICH
 def: "MPICH is a highly efficient, open-source implementation of the Message Passing Interface (MPI) standard. It serves as both a widely used standalone MPI library for high-performance computing and as the foundational framework for many other vendor-specific or derivative MPI implementations (such as Intel MPI and MVAPICH). For biomolecular simulations on distributed-memory supercomputers, MPICH provides the essential message-passing infrastructure required for large-scale parallelization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement." []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations." []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002052
@@ -12554,10 +12700,11 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms." []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002059
@@ -12569,8 +12716,9 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002060
 name: docking log format
-def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)" []
+def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files." []
 is_a: MOLSIM:000715 ! prediction data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002061
@@ -12582,11 +12730,12 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002062
 name: Maestro format
-def: "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)" []
+def: "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties." []
 synonym: "mae format" EXACT []
 synonym: "maegz format" EXACT []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002063
@@ -12816,411 +12965,418 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:002098
 name: restart simulation process
-def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)" []
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:002099
 name: metadata extraction tool
-def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000165 ! data processing tool
 
 [Term]
 id: MOLSIM:002100
 name: PMEMD.cuda
-def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)" []
 is_a: MOLSIM:001669 ! PMEMD
 
 [Term]
 id: MOLSIM:002101
 name: metadata validation process
-def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002102
 name: coordinate wrapping process
-def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)" []
 is_a: MOLSIM:001767 ! trajectory post-processing
 
 [Term]
 id: MOLSIM:002103
 name: NMR restrained simulation
-def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)" []
 is_a: MOLSIM:000364 ! restrained simulation method
 
 [Term]
 id: MOLSIM:002104
 name: belly dynamics
-def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)" []
 is_a: MOLSIM:000335 ! restrained subset dynamics
 
 [Term]
 id: MOLSIM:002105
 name: replica exchange attempt frequency
-def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)" []
 is_a: MOLSIM:001219 ! enhanced sampling parameter
 
 [Term]
 id: MOLSIM:002106
 name: center of mass removal interval
-def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002107
 name: multi-timestep inner loop count
-def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002108
 name: output control parameter
-def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002109
 name: energy output interval
-def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002110
 name: restart output interval
-def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002111
 name: log output interval
-def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002112
 name: simulation state time
-def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:001083 ! simulation state
 
 [Term]
 id: MOLSIM:002113
 name: final density
-def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002114
 name: computational performance metric
-def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)" []
 is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:002115
 name: total wallclock time
-def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 disjoint_from: MOLSIM:002116 ! total cpu time
 
 [Term]
 id: MOLSIM:002116
 name: total cpu time
-def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002117
 name: setup wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002118
 name: production wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002119
 name: average integration step time
-def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002120
 name: simulation throughput
-def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002155
 name: simulation protocol
-def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002156
 name: simulation stage
-def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)" []
 is_a: MOLSIM:000000 ! molecular dynamics process
 
 [Term]
 id: MOLSIM:002157
 name: simulation parameter schedule
-def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002158
 name: simulation continuity check
-def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002159
 name: cross-source validation
-def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002160
 name: file parsing error
-def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002161
 name: file format convention
-def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)" []
 is_a: MOLSIM:000436 ! data format
 
 [Term]
 id: MOLSIM:002162
 name: system classification label
-def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002163
 name: atom selection mask
-def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002164
 name: trajectory frame interval
-def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 disjoint_from: MOLSIM:002165 ! inter-stage time gap
 
 [Term]
 id: MOLSIM:002165
 name: inter-stage time gap
-def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 
 [Term]
 id: MOLSIM:002166
 name: hydrogen detection strategy
-def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)" []
 is_a: MOLSIM:001696 ! analysis algorithm
 
 [Term]
 id: MOLSIM:002192
 name: initial density
-def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002196
 name: atom count consistency check
-def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 disjoint_from: MOLSIM:002197 ! box consistency check
 
 [Term]
 id: MOLSIM:002197
 name: box consistency check
-def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002198
 name: timing consistency check
-def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002199
 name: sampling consistency check
-def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002203
 name: protein domain
-def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)" []
+def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains." []
 is_a: SO:0000417
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002204
 name: receptor-binding domain
-def: "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)" []
+def: "A protein domain whose function is to attach to a matching partner molecule called a receptor." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002205
 name: catalytic domain
-def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)" []
+def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002206
 name: protein functional class label
-def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002207
 name: enzyme classification label
-def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002208
 name: transport protein classification label
-def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002209
 name: structural protein classification label
-def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002210
 name: regulatory protein classification label
-def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002211
 name: signaling protein classification label
-def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002212
 name: motor protein classification label
-def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002213
 name: immune protein classification label
-def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002214
 name: storage protein classification label
-def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002226
 name: periodic box angles
-def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)" []
 is_a: MOLSIM:001210 ! system setup parameter
 
 [Term]
 id: MOLSIM:002230
 name: SMILES code
-def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)" []
 is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:002232
 name: compiler
-def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)" []
 is_a: MOLSIM:000171 ! software development and management tool
 
 [Term]
 id: MOLSIM:002233
 name: atom index group
-def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002234
 name: classical molecular dynamics
-def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000843 ! molecular dynamics
 
 [Term]
 id: MOLSIM:002235
 name: source structure residue mapping
-def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002236
 name: oligomeric state
-def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)" []
 is_a: MOLSIM:001333 ! structural property
 
 [Term]
 id: MOLSIM:002237
 name: monomeric state
-def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 disjoint_from: MOLSIM:002238 ! dimeric state
 
 [Term]
 id: MOLSIM:002238
 name: dimeric state
-def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002239
 name: trimeric state
-def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002240
 name: tetrameric state
-def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002241
 name: higher-order oligomeric state
-def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002246
 name: spike opening conformational state
-def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)" []
 is_a: MOLSIM:000105 ! conformational state
 
 [Term]
 id: MOLSIM:002247
 name: biological strain classification label
-def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002248
 name: histone variant classification label
-def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
+
+[Term]
+id: MOLSIM:002249
+name: DSSR
+def: "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)" []
+synonym: "Dissecting the Spatial Structure of RNA" EXACT []
+is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
 id: MOLSIM:010001
@@ -13419,7 +13575,7 @@ range: MOLSIM:000001 ! software
 id: MOLSIM:000507
 name: alignment tool
 def: "In molecular dynamics, alignment tool provides spatial re-orientation of membrane proteins with respect to the hydrocarbon core of the lipid bilayer. It connects a structural alignment procedure or analysis step to the specific software program or tool used to perform the alignment of molecular structures. Structural alignment is used to superimpose molecular structures (e.g., proteins, nucleic acids) to compare their conformations or identify conserved regions. This property identifies the computational tool responsible for generating the alignment. (UNVERIFIED)" []
-domain: MOLSIM:000004 ! analysis
+domain: MOLSIM:000004 ! simulation analysis
 range: MOLSIM:000001 ! software
 
 [Typedef]
@@ -13460,14 +13616,14 @@ range: MOLSIM:001994 ! reaction coordinate
 [Typedef]
 id: MOLSIM:002167
 name: has simulation stage
-def: "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)" []
-domain: MOLSIM:002155 ! simulation protocol
+def: "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002156 ! simulation stage
 
 [Typedef]
 id: MOLSIM:002168
 name: has parameter schedule
-def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002157 ! simulation parameter schedule
 is_a: MOLSIM:002202 ! has simulation parameter
@@ -13475,42 +13631,49 @@ is_a: MOLSIM:002202 ! has simulation parameter
 [Typedef]
 id: MOLSIM:002169
 name: has continuity check
-def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002158 ! simulation continuity check
 
 [Typedef]
 id: MOLSIM:002170
 name: has parsing error
-def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002160 ! file parsing error
 
 [Typedef]
 id: MOLSIM:002171
 name: has system classification
-def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)" []
 domain: MOLSIM:001887 ! molecular simulation system
 range: MOLSIM:002162 ! system classification label
 
 [Typedef]
 id: MOLSIM:002172
 name: has format convention
-def: "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)" []
 domain: MOLSIM:000436 ! data format
 range: MOLSIM:002161 ! file format convention
 
 [Typedef]
 id: MOLSIM:002173
 name: has restraint mask
-def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002163 ! atom selection mask
 
 [Typedef]
 id: MOLSIM:002202
 name: has simulation parameter
-def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:001164 ! simulation parameter
+
+[Typedef]
+id: MOLSIM:002250
+name: follows protocol
+def: "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
+range: MOLSIM:002155 ! simulation protocol
 

--- a/molsim-base.owl
+++ b/molsim-base.owl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/molsim/molsim-base.owl#"
      xml:base="http://purl.obolibrary.org/obo/molsim/molsim-base.owl"
-     xmlns:dce="http://purl.org/dc/elements/1.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -14,10 +14,15 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim/molsim-base.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-base.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim-base.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
-        <dce:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
+        <dc:type rdf:resource="http://purl.obolibrary.org/obo/IAO_8000001"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0001-8613-1447"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0003-4846-8051"/>
@@ -28,7 +33,8 @@
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
         <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
         <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
-        <owl:versionInfo>2026-07-29</owl:versionInfo>
+        <rdfs:comment xml:lang="en">Scope note: MOLSIM&apos;s boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.</rdfs:comment>
+        <owl:versionInfo>2026-08-07</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -57,6 +63,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117"/>
@@ -72,12 +84,6 @@
     <!-- http://purl.org/dc/elements/1.1/type -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/type"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/BibliographicResource -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/BibliographicResource"/>
     
 
 
@@ -126,6 +132,12 @@
     <!-- http://www.geneontology.org/formats/oboInOwl#default-namespace -->
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#default-namespace"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
     
 
 
@@ -258,9 +270,9 @@
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002167">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation stage</rdfs:label>
     </owl:ObjectProperty>
     
@@ -272,7 +284,7 @@
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002202"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002157"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parameter schedule</rdfs:label>
     </owl:ObjectProperty>
     
@@ -284,7 +296,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002158"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has continuity check</rdfs:label>
     </owl:ObjectProperty>
     
@@ -296,7 +308,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002160"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parsing error</rdfs:label>
     </owl:ObjectProperty>
     
@@ -308,7 +320,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has system classification</rdfs:label>
     </owl:ObjectProperty>
     
@@ -320,7 +332,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has format convention</rdfs:label>
     </owl:ObjectProperty>
     
@@ -332,7 +344,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002163"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint mask</rdfs:label>
     </owl:ObjectProperty>
     
@@ -344,8 +356,20 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation parameter</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002250 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002250">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">follows protocol</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -866,7 +890,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002121">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">first solvent molecule index</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -877,7 +901,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002122">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of solvent molecules</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -888,7 +912,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002123">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of atoms per frame</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -899,7 +923,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
@@ -911,7 +935,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002125">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total angles</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -922,7 +946,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002126">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total dihedrals</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -933,7 +957,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002127">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001139"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of constraint failures</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -944,7 +968,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002128">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has completion status</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -955,7 +979,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002129">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">continuation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -966,7 +990,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002130">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -977,7 +1001,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002131">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QM/MM activation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -988,7 +1012,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002132">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">self-guided Langevin dynamics flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -999,7 +1023,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002133">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spherical cap flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1010,7 +1034,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002134">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has box dimensions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1021,7 +1045,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002135">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has velocities flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1032,7 +1056,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002136">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box type flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1042,7 +1066,7 @@
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002137">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory metadata descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1053,7 +1077,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002138">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of frames</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1064,7 +1088,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002139">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate format specifier</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1075,7 +1099,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002140">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural and dimensional arrays</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1086,7 +1110,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002141">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1097,7 +1121,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002142">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1108,7 +1132,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002143">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system nomenclature descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1119,7 +1143,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002144">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent residue name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1130,7 +1154,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002145">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue labels</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1141,7 +1165,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002146">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique residue names</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1152,7 +1176,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002147">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique atom types</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1163,7 +1187,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002148">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">born radii set name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1174,7 +1198,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002149">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log and validation descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1185,7 +1209,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002150">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has error message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1196,7 +1220,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002151">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has warning message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1207,7 +1231,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002152">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation warning</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1218,7 +1242,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002153">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation error</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1229,7 +1253,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002154">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">consistency check result</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1240,7 +1264,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002179">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has coordinates array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1251,7 +1275,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002180">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1262,7 +1286,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002181">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has time array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1273,7 +1297,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002182">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has NMR restraints active</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1284,7 +1308,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002183">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is degraded extraction mode</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1295,7 +1319,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002184">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has temperature schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1306,7 +1330,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002185">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1317,7 +1341,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002186">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has cutoff schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1328,7 +1352,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002187">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">force field feature</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1339,7 +1363,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002188">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue composition map</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1350,7 +1374,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002189">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">raw control parameters</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1361,7 +1385,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002190">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">REMD variant type</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1372,7 +1396,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002191">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart file path</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1383,7 +1407,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002193">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is charge neutral</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1394,7 +1418,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002194">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen mass summary</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1406,7 +1430,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001941"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">gpu model name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1417,7 +1441,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002200">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">HMR inferred from timestep flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1429,7 +1453,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total simulation steps</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1440,7 +1464,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002215">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1451,7 +1475,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002216">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1462,7 +1486,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002217">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1473,7 +1497,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002218">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ion atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1484,7 +1508,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002219">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1495,7 +1519,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002220">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">other atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1506,7 +1530,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002221">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1517,7 +1541,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002222">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1528,7 +1552,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002223">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1539,7 +1563,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002224">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleosomes</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1550,7 +1574,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002225">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleotides per DNA strand</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1561,7 +1585,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002227">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box angles array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1572,7 +1596,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002228">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has positions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1583,7 +1607,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002229">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1595,7 +1619,7 @@
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">software version</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1606,7 +1630,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002242">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains antibody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1617,7 +1641,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002243">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains nanobody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1628,7 +1652,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002244">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains linker histone</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1639,7 +1663,7 @@
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002245">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone tails present</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1659,7 +1683,8 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000000">
-        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics process</rdfs:label>
     </owl:Class>
     
@@ -1677,9 +1702,10 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">preparation</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">preparation</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation preparation</rdfs:label>
     </owl:Class>
     
 
@@ -1687,9 +1713,11 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">execution</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
+        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">execution</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation execution</rdfs:label>
     </owl:Class>
     
 
@@ -1697,9 +1725,10 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000004">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">analysis</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">analysis</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation analysis</rdfs:label>
     </owl:Class>
     
 
@@ -1740,7 +1769,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000772"/>
         <obo:IAO_0000115 xml:lang="en">A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">lipid  force field</rdfs:label>
+        <rdfs:label xml:lang="en">lipid force field</rdfs:label>
     </owl:Class>
     
 
@@ -1862,7 +1891,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000008"/>
-        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It&apos;s designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">lipid17</rdfs:label>
     </owl:Class>
     
@@ -2445,6 +2475,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
         <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1.</obo:IAO_0000116>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -2564,7 +2595,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -2844,7 +2876,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000245"/>
         <obo:IAO_0000115 xml:lang="en">HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
-        <dcterms:BibliographicResource>https://doi.org/10.1016/S0263-7855(97)00009-X</dcterms:BibliographicResource>
+        <oboInOwl:hasDbXref>https://doi.org/10.1016/S0263-7855(97)00009-X</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">HOLE</rdfs:label>
     </owl:Class>
     
@@ -3276,7 +3308,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS mdp format</rdfs:label>
     </owl:Class>
     
@@ -3319,7 +3352,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001851"/>
-        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics engine</rdfs:label>
     </owl:Class>
     
@@ -3339,7 +3373,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking tool</rdfs:label>
     </owl:Class>
     
@@ -3359,7 +3394,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">analysis tool</rdfs:label>
     </owl:Class>
     
@@ -3369,7 +3405,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">data processing tool</rdfs:label>
     </owl:Class>
     
@@ -3379,7 +3416,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">file conversion tool</rdfs:label>
     </owl:Class>
     
@@ -3823,6 +3861,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
         <obo:IAO_0000115 xml:lang="en">A step within the preparation or equilibration phase where the system&apos;s temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">heating</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">thermalization</rdfs:label>
     </owl:Class>
     
@@ -3832,7 +3871,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
-        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">equilibration</rdfs:label>
     </owl:Class>
     
@@ -3958,7 +3998,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000221">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000223"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDB2PQR</rdfs:label>
     </owl:Class>
     
@@ -3968,7 +4009,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000222">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ligand protonation tool</rdfs:label>
     </owl:Class>
     
@@ -3978,7 +4020,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000223">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">generic protonation tool</rdfs:label>
     </owl:Class>
     
@@ -4018,7 +4061,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000227">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">membrane protein orientation tool</rdfs:label>
     </owl:Class>
     
@@ -4028,7 +4072,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000228">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
-        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein&apos;s position and orientation to minimize the calculated free energy of transferring the protein&apos;s amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">memembed</rdfs:label>
     </owl:Class>
     
@@ -4155,7 +4200,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pKa tool</rdfs:label>
     </owl:Class>
     
@@ -4185,7 +4231,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000243">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">in-silico mutagenesis tool</rdfs:label>
     </owl:Class>
     
@@ -4827,7 +4874,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000305">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000140"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include &quot;molecular docking,&quot; &quot;homology modeling,&quot; &quot;scoring function,&quot; and &quot;binding pose prediction.&quot; (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling method</rdfs:label>
     </owl:Class>
     
@@ -4878,8 +4926,9 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
         <obo:IAO_0000115 xml:lang="en">A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled &quot;Experimental Design,&quot; &quot;Study Protocol,&quot; &quot;Selection Criteria,&quot; or &quot;Computational Strategy.&quot; (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)</rdfs:comment>
+        <rdfs:comment xml:lang="en">Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.</rdfs:comment>
         <rdfs:label xml:lang="en">plan specification</rdfs:label>
     </owl:Class>
     
@@ -4889,7 +4938,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000311">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">RMSD analysis is a calculation that measures how much a molecule&apos;s shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A calculation that measures how much a molecule&apos;s shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">RMSD analysis</rdfs:label>
     </owl:Class>
@@ -6326,10 +6375,10 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000448 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000448">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
-        <rdfs:label xml:lang="en">protein database ID</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete protein database ID</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -6518,7 +6567,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">OPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">orientations of proteins in membranes</rdfs:label>
     </owl:Class>
@@ -6551,7 +6601,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER mdin format</rdfs:label>
     </owl:Class>
     
@@ -6573,7 +6624,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER restart format</rdfs:label>
     </owl:Class>
     
@@ -6656,7 +6708,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000478"/>
-        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Connolly surface analysis</rdfs:label>
     </owl:Class>
     
@@ -6675,10 +6728,11 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000481 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000481">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
-        <rdfs:label xml:lang="en">2D RMSD analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000311"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with &apos;RMSD analysis&apos; (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term&apos;s definition. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 2D RMSD analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -7805,7 +7859,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000596">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000590"/>
-        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">.grid</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">grid format</rdfs:label>
     </owl:Class>
@@ -8583,7 +8638,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000670">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate centering analysis</rdfs:label>
     </owl:Class>
     
@@ -8674,6 +8730,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with its former parent &apos;periodic boundary imaging&apos; (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term&apos;s definition now states so. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -8746,7 +8804,7 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000686 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000686">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., &apos;1TIM&apos;, &apos;6M0J&apos;) serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDB ID</rdfs:label>
     </owl:Class>
@@ -8756,7 +8814,7 @@
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000687 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000687">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A UniProt ID, more formally known as a UniProt Accession Number (e.g., &apos;P00761&apos;, &apos;Q8WZ42&apos;), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Uniprot ID</rdfs:label>
     </owl:Class>
@@ -8959,7 +9017,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000706">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000703"/>
-        <obo:IAO_0000115 xml:lang="en">A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pathway database</rdfs:label>
     </owl:Class>
     
@@ -9203,7 +9262,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000741">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff02</rdfs:label>
     </owl:Class>
     
@@ -9314,7 +9374,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000752">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM 19</rdfs:label>
     </owl:Class>
     
@@ -9534,7 +9595,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000774">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001664"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Abalone</rdfs:label>
     </owl:Class>
     
@@ -9564,7 +9626,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000777">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Desmond</rdfs:label>
     </owl:Class>
     
@@ -9654,7 +9717,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000786">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD</rdfs:label>
     </owl:Class>
     
@@ -10231,7 +10295,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000843">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000308"/>
-        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">MD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">molecular dynamics</rdfs:label>
     </owl:Class>
@@ -10494,7 +10559,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000867">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000438"/>
-        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM input format</rdfs:label>
     </owl:Class>
     
@@ -10536,8 +10602,9 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000871">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">GROMACS input  format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">GROMACS input format</rdfs:label>
     </owl:Class>
     
 
@@ -10586,7 +10653,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000876">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD configuration format</rdfs:label>
     </owl:Class>
     
@@ -10596,7 +10664,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000877">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000437"/>
-        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem input format</rdfs:label>
     </owl:Class>
     
@@ -10638,7 +10707,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000881">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM output format</rdfs:label>
     </owl:Class>
     
@@ -10678,7 +10748,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000885">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS output format</rdfs:label>
     </owl:Class>
     
@@ -10758,7 +10829,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000893">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem restart format</rdfs:label>
     </owl:Class>
     
@@ -10811,7 +10883,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000898">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS include topology format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS itp format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">itp format</rdfs:label>
@@ -10856,7 +10929,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000902">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dcd format</rdfs:label>
     </owl:Class>
     
@@ -10887,6 +10961,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -11035,7 +11110,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crd format</rdfs:label>
     </owl:Class>
     
@@ -11161,7 +11237,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000941">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000305"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate rotation modeling</rdfs:label>
     </owl:Class>
     
@@ -11330,15 +11407,7 @@
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER inpcrd format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmcrd format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format.
-
-The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. 
-
-Users can interact with it using file-based commands:
-
-Loading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.
-
-Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
+        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format. The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
         <rdfs:label xml:lang="en">AMBER crd format</rdfs:label>
     </owl:Class>
     
@@ -11725,13 +11794,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
         <obo:IAO_0000115 xml:lang="en">The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential &quot;frames&quot; where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER trj format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:
-
-vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.
-
-vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.
-
-vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
         <rdfs:label xml:lang="en">trj format</rdfs:label>
     </owl:Class>
     
@@ -11741,14 +11804,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010020"/>
-        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">Common examples include:
-
-- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.
-
-- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.
-
-- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:comment xml:lang="en">Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
         <rdfs:label xml:lang="en">distance matrix format</rdfs:label>
     </owl:Class>
     
@@ -11760,8 +11818,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001040"/>
         <obo:IAO_0000115 xml:lang="en">The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.xpm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">xpm  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">xpm format</rdfs:label>
     </owl:Class>
     
 
@@ -11771,8 +11829,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
         <obo:IAO_0000115 xml:lang="en">The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parmtop format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmtop format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">parm7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">prmtop format</rdfs:label>
     </owl:Class>
     
@@ -11781,11 +11842,13 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001042"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">parm7 format</rdfs:label>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete parm7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11855,7 +11918,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">restrt format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">rst7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">rst format</rdfs:label>
     </owl:Class>
     
@@ -11864,9 +11929,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">rst7 format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001049"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete rst7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -11967,8 +12034,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
         <obo:IAO_0000115 xml:lang="en">The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.conflib</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">conflib  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">conflib format</rdfs:label>
     </owl:Class>
     
 
@@ -12000,7 +12067,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym>.pqr</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">pqr format</rdfs:label>
     </owl:Class>
@@ -12012,7 +12080,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001063">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Molecular Operating Environment</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MOE</rdfs:label>
     </owl:Class>
@@ -12110,8 +12179,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001072 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001072">
-        <obo:IAO_0000115>An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
-        <dcterms:BibliographicResource></dcterms:BibliographicResource>
+        <obo:IAO_0000115 xml:lang="en">An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">information content entity</rdfs:label>
     </owl:Class>
     
@@ -12121,7 +12189,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001073">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular system specification</rdfs:label>
     </owl:Class>
     
@@ -12271,6 +12340,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -12292,6 +12362,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Related discussion in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -12397,7 +12468,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002066"/>
         <obo:IAO_0000115 xml:lang="en">The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)</obo:IAO_0000115>
-        <oboInOwl:hasExactSynonym xml:lang="en">skf  format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">skf format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">DFTB parameter format</rdfs:label>
     </owl:Class>
     
@@ -12591,7 +12662,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER mdinfo format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">mdinfo format</rdfs:label>
     </owl:Class>
@@ -12602,7 +12674,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001671"/>
-        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">database web server</rdfs:label>
     </owl:Class>
     
@@ -13015,7 +13088,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">constraint and restraint parameter</rdfs:label>
     </owl:Class>
     
@@ -13160,7 +13234,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001215">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">alchemical transformation state</rdfs:label>
     </owl:Class>
     
@@ -13170,7 +13245,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001216">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">number of replicates</rdfs:label>
     </owl:Class>
     
@@ -14423,7 +14499,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000328"/>
-        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hydrogen mass repartitioning analysis</rdfs:label>
     </owl:Class>
     
@@ -14453,7 +14530,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dihedral angle</rdfs:label>
     </owl:Class>
     
@@ -14747,7 +14825,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001358"/>
-        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">base pair step parameter</rdfs:label>
     </owl:Class>
     
@@ -15446,7 +15525,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000860"/>
-        <obo:IAO_0000115 xml:lang="en">The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (&quot;images&quot;) along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">adaptive string method</rdfs:label>
     </owl:Class>
     
@@ -15549,7 +15629,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03</rdfs:label>
     </owl:Class>
     
@@ -15559,7 +15640,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03ua</rdfs:label>
     </owl:Class>
     
@@ -16079,7 +16161,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic model component</rdfs:label>
     </owl:Class>
     
@@ -16443,7 +16526,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber fb15 is a specific &quot;recipe&quot; or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber fb15</rdfs:label>
     </owl:Class>
     
@@ -16717,7 +16801,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001558">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">electrostatics analysis tool</rdfs:label>
     </owl:Class>
     
@@ -16797,8 +16882,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001566">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000170"/>
-        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">library</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">software library</rdfs:label>
     </owl:Class>
     
 
@@ -16857,7 +16944,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001572">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001969"/>
-        <obo:IAO_0000115 xml:lang="en">ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ndfes</rdfs:label>
     </owl:Class>
     
@@ -16867,7 +16955,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001573">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ParmEd</rdfs:label>
     </owl:Class>
     
@@ -17010,8 +17099,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001587">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Intel Math Kernel Library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">Intel oneAPI Math Kernel Library</rdfs:label>
     </owl:Class>
     
 
@@ -17020,7 +17110,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001588">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">package manager</rdfs:label>
     </owl:Class>
     
@@ -17030,7 +17121,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001589">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001588"/>
-        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Miniconda</rdfs:label>
     </owl:Class>
     
@@ -17226,7 +17318,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001608">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001970"/>
-        <obo:IAO_0000115 xml:lang="en">an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parmcal</rdfs:label>
     </owl:Class>
     
@@ -17461,7 +17553,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001631">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ambpdb</rdfs:label>
     </owl:Class>
     
@@ -17671,7 +17764,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001652">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">chamber</rdfs:label>
     </owl:Class>
     
@@ -17681,7 +17775,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001653">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match_atomname</rdfs:label>
     </owl:Class>
     
@@ -17751,7 +17846,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001660">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001659"/>
-        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAB</rdfs:label>
     </owl:Class>
     
@@ -17761,7 +17857,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001661">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">FE-ToolKit</rdfs:label>
     </owl:Class>
     
@@ -17871,7 +17968,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001672">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GLYCAM-Web</rdfs:label>
     </owl:Class>
     
@@ -17881,7 +17979,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001673">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Glycoprotein Builder</rdfs:label>
     </owl:Class>
     
@@ -17953,7 +18052,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001680">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DL-Find</rdfs:label>
     </owl:Class>
     
@@ -17976,6 +18076,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <obo:IAO_0000115 xml:lang="en">x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">x3DNA</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">3DNA</rdfs:label>
     </owl:Class>
     
@@ -17995,7 +18096,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001684">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match analysis tool</rdfs:label>
     </owl:Class>
     
@@ -18598,7 +18700,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001743">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ICOSA algorithm</rdfs:label>
     </owl:Class>
     
@@ -18629,7 +18732,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001746">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010012"/>
-        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DSSP algorithm</rdfs:label>
     </owl:Class>
     
@@ -18722,6 +18826,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001755">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names &apos;CA&apos; and &apos;CB&apos; are used to differentiate the alpha-carbon from the beta-carbon.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom name</rdfs:label>
     </owl:Class>
@@ -18988,7 +19093,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001781 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001781">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
         <obo:IAO_0000115 xml:lang="en">Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein&apos;s overall architecture and how its shape changes during a simulation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">secondary structure</rdfs:label>
     </owl:Class>
@@ -19009,7 +19114,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001783">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -19019,7 +19125,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001784">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">anti-parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -19028,9 +19135,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001785 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001785">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19038,9 +19147,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001786 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001786">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">3-10 helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 3-10 helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19048,9 +19159,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001787 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001787">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">alpha helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete alpha helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19058,9 +19171,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001788 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001788">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">pi helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete pi helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -19079,7 +19194,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001790">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein&apos;s compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">bend</rdfs:label>
     </owl:Class>
     
@@ -19099,7 +19215,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001792">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein&apos;s folded structure together. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">beta bridge</rdfs:label>
     </owl:Class>
     
@@ -19131,7 +19248,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent&apos;s bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">MDL solvent model format</rdfs:label>
     </owl:Class>
     
@@ -19706,7 +19824,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001850">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000158"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling and setup tool</rdfs:label>
     </owl:Class>
     
@@ -19870,7 +19989,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001866">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">backbone DH fluctuations</rdfs:label>
     </owl:Class>
     
@@ -20123,7 +20243,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001889">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
-        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">complex system</rdfs:label>
     </owl:Class>
     
@@ -20176,7 +20297,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001894">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001889"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hybrid complex system</rdfs:label>
     </owl:Class>
     
@@ -20477,7 +20599,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001922">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">3DMol.js</rdfs:label>
     </owl:Class>
     
@@ -20488,7 +20611,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001923">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NGL</rdfs:label>
     </owl:Class>
     
@@ -20498,7 +20622,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001924">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000166"/>
-        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Open Babel</rdfs:label>
     </owl:Class>
     
@@ -20529,7 +20654,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001927">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000225"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM-GUI</rdfs:label>
     </owl:Class>
     
@@ -20539,7 +20665,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001928">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001958"/>
-        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Modeller</rdfs:label>
     </owl:Class>
     
@@ -20580,7 +20707,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001932">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Jmol</rdfs:label>
     </owl:Class>
     
@@ -20590,7 +20718,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001933">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Mol*</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MolStar</rdfs:label>
     </owl:Class>
@@ -20810,7 +20939,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001955">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001556"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic build tool</rdfs:label>
     </owl:Class>
     
@@ -20840,7 +20970,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001958">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">homology modeling tool</rdfs:label>
     </owl:Class>
     
@@ -20850,7 +20981,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001959">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock Vina</rdfs:label>
     </owl:Class>
     
@@ -20911,7 +21043,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001965">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DALI</rdfs:label>
     </owl:Class>
     
@@ -20921,7 +21054,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001966">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">LS-align</rdfs:label>
     </owl:Class>
     
@@ -20952,7 +21086,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001969">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001564"/>
-        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">free energy surface analysis tool</rdfs:label>
     </owl:Class>
     
@@ -21217,7 +21352,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001995">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001552"/>
-        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">position restraints</rdfs:label>
     </owl:Class>
     
@@ -21393,7 +21529,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the &quot;flying ice cube&quot; effect). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">continuation state</rdfs:label>
     </owl:Class>
     
@@ -21667,7 +21804,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in structure.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom ID</rdfs:label>
     </owl:Class>
@@ -21678,7 +21816,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">JSmol</rdfs:label>
     </owl:Class>
     
@@ -21688,7 +21827,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular structure visualization tool</rdfs:label>
     </owl:Class>
     
@@ -21698,7 +21838,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">data visualization tool</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">data plotting tool</rdfs:label>
     </owl:Class>
@@ -21770,7 +21911,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -21780,7 +21922,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -21791,7 +21934,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -21871,7 +22015,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -21892,7 +22037,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
-        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking log format</rdfs:label>
     </owl:Class>
     
@@ -21914,7 +22060,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">mae format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">maegz format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Maestro format</rdfs:label>
@@ -22291,7 +22438,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002098">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000003"/>
-        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart simulation process</rdfs:label>
     </owl:Class>
     
@@ -22301,7 +22448,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata extraction tool</rdfs:label>
     </owl:Class>
     
@@ -22311,7 +22458,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001669"/>
-        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PMEMD.cuda</rdfs:label>
     </owl:Class>
     
@@ -22321,7 +22468,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata validation process</rdfs:label>
     </owl:Class>
     
@@ -22331,7 +22478,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002102">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001767"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping process</rdfs:label>
     </owl:Class>
     
@@ -22341,7 +22488,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002103">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000364"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NMR restrained simulation</rdfs:label>
     </owl:Class>
     
@@ -22351,7 +22498,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000335"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">belly dynamics</rdfs:label>
     </owl:Class>
     
@@ -22361,7 +22508,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001219"/>
-        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">replica exchange attempt frequency</rdfs:label>
     </owl:Class>
     
@@ -22371,7 +22518,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002106">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">center of mass removal interval</rdfs:label>
     </owl:Class>
     
@@ -22381,7 +22528,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002107">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-timestep inner loop count</rdfs:label>
     </owl:Class>
     
@@ -22391,7 +22538,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002108">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">output control parameter</rdfs:label>
     </owl:Class>
     
@@ -22401,7 +22548,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">energy output interval</rdfs:label>
     </owl:Class>
     
@@ -22411,7 +22558,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart output interval</rdfs:label>
     </owl:Class>
     
@@ -22421,7 +22568,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002111">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log output interval</rdfs:label>
     </owl:Class>
     
@@ -22431,7 +22578,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002112">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001083"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation state time</rdfs:label>
     </owl:Class>
     
@@ -22441,7 +22588,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002113">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">final density</rdfs:label>
     </owl:Class>
     
@@ -22451,7 +22598,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002114">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001292"/>
-        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computational performance metric</rdfs:label>
     </owl:Class>
     
@@ -22461,7 +22608,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002115">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total wallclock time</rdfs:label>
     </owl:Class>
     
@@ -22471,7 +22618,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002116">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total cpu time</rdfs:label>
     </owl:Class>
     
@@ -22481,7 +22628,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">setup wallclock time</rdfs:label>
     </owl:Class>
     
@@ -22491,7 +22638,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">production wallclock time</rdfs:label>
     </owl:Class>
     
@@ -22501,7 +22648,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">average integration step time</rdfs:label>
     </owl:Class>
     
@@ -22511,7 +22658,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation throughput</rdfs:label>
     </owl:Class>
     
@@ -22521,7 +22668,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002155">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation protocol</rdfs:label>
     </owl:Class>
     
@@ -22531,7 +22678,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation stage</rdfs:label>
     </owl:Class>
     
@@ -22541,7 +22688,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002157">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation parameter schedule</rdfs:label>
     </owl:Class>
     
@@ -22551,7 +22698,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002158">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation continuity check</rdfs:label>
     </owl:Class>
     
@@ -22561,7 +22708,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002159">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">cross-source validation</rdfs:label>
     </owl:Class>
     
@@ -22571,7 +22718,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file parsing error</rdfs:label>
     </owl:Class>
     
@@ -22581,7 +22728,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002161">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
-        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file format convention</rdfs:label>
     </owl:Class>
     
@@ -22591,7 +22738,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system classification label</rdfs:label>
     </owl:Class>
     
@@ -22601,7 +22748,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002163">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom selection mask</rdfs:label>
     </owl:Class>
     
@@ -22612,7 +22759,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002165"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory frame interval</rdfs:label>
     </owl:Class>
     
@@ -22622,7 +22769,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">inter-stage time gap</rdfs:label>
     </owl:Class>
     
@@ -22632,7 +22779,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001696"/>
-        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen detection strategy</rdfs:label>
     </owl:Class>
     
@@ -22642,7 +22789,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002192">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial density</rdfs:label>
     </owl:Class>
     
@@ -22652,7 +22799,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002196">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom count consistency check</rdfs:label>
     </owl:Class>
     
@@ -22662,7 +22809,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002197">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box consistency check</rdfs:label>
     </owl:Class>
     
@@ -22672,7 +22819,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002198">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">timing consistency check</rdfs:label>
     </owl:Class>
     
@@ -22682,7 +22829,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002199">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">sampling consistency check</rdfs:label>
     </owl:Class>
     
@@ -22692,7 +22839,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
-        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">protein domain</rdfs:label>
     </owl:Class>
@@ -22703,7 +22850,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">receptor-binding domain</rdfs:label>
     </owl:Class>
@@ -22714,7 +22861,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002205">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">catalytic domain</rdfs:label>
     </owl:Class>
@@ -22725,7 +22872,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002206">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein functional class label</rdfs:label>
     </owl:Class>
     
@@ -22735,7 +22882,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002207">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">enzyme classification label</rdfs:label>
     </owl:Class>
     
@@ -22745,7 +22892,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">transport protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22755,7 +22902,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22765,7 +22912,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002210">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">regulatory protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22775,7 +22922,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002211">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">signaling protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22785,7 +22932,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002212">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">motor protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22795,7 +22942,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002213">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">immune protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22805,7 +22952,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002214">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">storage protein classification label</rdfs:label>
     </owl:Class>
     
@@ -22815,7 +22962,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002226">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">periodic box angles</rdfs:label>
     </owl:Class>
     
@@ -22825,7 +22972,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002230">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SMILES code</rdfs:label>
     </owl:Class>
     
@@ -22835,7 +22982,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002232">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">compiler</rdfs:label>
     </owl:Class>
     
@@ -22845,7 +22992,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002233">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom index group</rdfs:label>
     </owl:Class>
     
@@ -22855,7 +23002,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000843"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">classical molecular dynamics</rdfs:label>
     </owl:Class>
     
@@ -22865,7 +23012,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002235">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">source structure residue mapping</rdfs:label>
     </owl:Class>
     
@@ -22875,7 +23022,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002236">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -22885,7 +23032,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002237">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">monomeric state</rdfs:label>
     </owl:Class>
     
@@ -22895,7 +23042,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002238">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">dimeric state</rdfs:label>
     </owl:Class>
     
@@ -22905,7 +23052,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trimeric state</rdfs:label>
     </owl:Class>
     
@@ -22915,7 +23062,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">tetrameric state</rdfs:label>
     </owl:Class>
     
@@ -22925,7 +23072,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002241">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">higher-order oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -22935,7 +23082,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002246">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000105"/>
-        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spike opening conformational state</rdfs:label>
     </owl:Class>
     
@@ -22945,7 +23092,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002247">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">biological strain classification label</rdfs:label>
     </owl:Class>
     
@@ -22955,8 +23102,19 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002248">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone variant classification label</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002249">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
+        <obo:IAO_0000115 xml:lang="en">A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">Dissecting the Spatial Structure of RNA</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">DSSR</rdfs:label>
     </owl:Class>
     
 
@@ -23073,7 +23231,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -23083,7 +23241,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -23103,7 +23261,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -23113,7 +23271,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -23254,6 +23412,12 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/SO_0000417 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000417"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001078"/>
     
 
 
@@ -23962,8 +24126,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001532">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001522"/>
-        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">The Cambridge Structural Database (CSD) is the world&apos;s primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Cambridge Structural Database</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23985,7 +24148,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002174">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERRESTART NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -23995,7 +24158,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002175">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBER trajectory NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -24005,7 +24168,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002176">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Protein / Ligand in Explicit Water</rdfs:label>
     </owl:NamedIndividual>
     
@@ -24015,7 +24178,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002177">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atomic number HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     
@@ -24025,7 +24188,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002178">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom name HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     

--- a/molsim-full.json
+++ b/molsim-full.json
@@ -10,6 +10,21 @@
         "val" : "https://orcid.org/0000-0002-0476-9699"
       }, {
         "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-2294-5393"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-4303-9349"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-7544-0938"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-8291-8071"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0003-4177-3619"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
         "val" : "https://orcid.org/0009-0007-1391-4986"
       }, {
         "pred" : "http://purl.org/dc/terms/creator",
@@ -39,13 +54,16 @@
         "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
         "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-29"
+        "val" : "2026-08-07"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-full.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim-full.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/APOLLO_SV_00000008",
@@ -13307,8 +13325,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)"
-        }
+          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000001",
@@ -13321,30 +13343,46 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
-      "lbl" : "preparation",
+      "lbl" : "simulation preparation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "preparation"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
-      "lbl" : "execution",
+      "lbl" : "simulation execution",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)"
-        }
+          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "execution"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
-      "lbl" : "analysis",
+      "lbl" : "simulation analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "analysis"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
@@ -13380,7 +13418,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000008",
-      "lbl" : "lipid  force field",
+      "lbl" : "lipid force field",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -13504,8 +13542,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)"
-        }
+          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000021",
@@ -14091,7 +14133,11 @@
       "meta" : {
         "definition" : {
           "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
-        }
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1."
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000077",
@@ -14198,8 +14244,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
-        }
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000089",
@@ -14498,12 +14548,12 @@
         "definition" : {
           "val" : "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms."
         },
+        "xrefs" : [ {
+          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0009-0007-1391-4986"
-        }, {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource",
-          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
         } ]
       }
     }, {
@@ -14929,8 +14979,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000157",
@@ -14977,8 +15031,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)"
-        }
+          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000161",
@@ -14995,8 +15053,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)"
-        }
+          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000163",
@@ -15013,8 +15075,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)"
-        }
+          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000165",
@@ -15022,8 +15088,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)"
-        }
+          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000166",
@@ -15031,8 +15101,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)"
-        }
+          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000167",
@@ -15489,7 +15563,11 @@
       "meta" : {
         "definition" : {
           "val" : "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "heating"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000209",
@@ -15497,8 +15575,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)"
-        }
+          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000210",
@@ -15629,8 +15711,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)"
-        }
+          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000222",
@@ -15638,8 +15724,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000223",
@@ -15647,8 +15737,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000224",
@@ -15683,8 +15777,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)"
-        }
+          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000228",
@@ -15692,8 +15790,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)"
-        }
+          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000229",
@@ -15824,8 +15926,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000241",
@@ -15851,8 +15957,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000244",
@@ -16510,8 +16620,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)"
-        }
+          "val" : "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000306",
@@ -16557,7 +16671,7 @@
         "definition" : {
           "val" : "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)"
         },
-        "comments" : [ "TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)" ]
+        "comments" : [ "Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
@@ -16565,7 +16679,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms."
+          "val" : "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -18054,16 +18168,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "lbl" : "protein database ID",
+      "lbl" : "obsolete protein database ID",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
+          "val" : "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
         },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0003-4177-3619"
-        } ]
+        "comments" : [ "Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review." ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
@@ -18260,11 +18372,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)"
+          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "OPM"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -18299,8 +18415,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000470",
@@ -18324,8 +18444,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)"
-        }
+          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000472",
@@ -18408,8 +18532,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)"
-        }
+          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
@@ -18422,16 +18550,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "lbl" : "2D RMSD analysis",
+      "lbl" : "obsolete 2D RMSD analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
+          "val" : "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
         },
+        "comments" : [ "Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45." ],
         "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0002-2294-5393"
-        } ]
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000311"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
@@ -19463,11 +19593,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)"
+          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".grid"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20265,8 +20399,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)"
-        }
+          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000671",
@@ -20352,6 +20490,11 @@
         "definition" : {
           "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
         },
+        "comments" : [ "Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -20643,8 +20786,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)"
-        }
+          "val" : "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000707",
@@ -20886,8 +21033,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)"
-        }
+          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000742",
@@ -20989,8 +21140,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)"
-        }
+          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000753",
@@ -21187,8 +21342,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)"
-        }
+          "val" : "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000775",
@@ -21214,8 +21373,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)"
-        }
+          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000778",
@@ -21295,8 +21458,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)"
-        }
+          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000787",
@@ -21850,11 +22017,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)"
+          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "MD"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -22158,8 +22329,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)"
-        }
+          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000868",
@@ -22197,12 +22372,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000871",
-      "lbl" : "GROMACS input  format",
+      "lbl" : "GROMACS input format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)"
-        }
+          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000872",
@@ -22246,8 +22425,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000877",
@@ -22255,8 +22438,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)"
-        }
+          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000878",
@@ -22298,8 +22485,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)"
-        }
+          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000882",
@@ -22334,8 +22525,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000886",
@@ -22406,8 +22601,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)"
-        }
+          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000894",
@@ -22463,7 +22662,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)"
+          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -22471,6 +22670,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "GROMACS itp format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -22516,8 +22719,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)"
-        }
+          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000903",
@@ -22549,6 +22756,7 @@
         "definition" : {
           "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -22698,8 +22906,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)"
-        }
+          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000923",
@@ -22826,8 +23038,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)"
-        }
+          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000942",
@@ -22988,7 +23204,7 @@
         "definition" : {
           "val" : "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information."
         },
-        "comments" : [ "Amber's standard ASCII coordinate trajectory file format.\n\nThe \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
+        "comments" : [ "Amber's standard ASCII coordinate trajectory file format. The \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER inpcrd format"
@@ -23376,7 +23592,7 @@
         "definition" : {
           "val" : "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited."
         },
-        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
+        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER trj format"
@@ -23392,13 +23608,17 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)"
+          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule."
         },
-        "comments" : [ "Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ]
+        "comments" : [ "Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001041",
-      "lbl" : "xpm  format",
+      "lbl" : "xpm format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -23409,7 +23629,7 @@
           "val" : ".xpm"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "GROMACS xpm  format"
+          "val" : "GROMACS xpm format"
         } ]
       }
     }, {
@@ -23422,27 +23642,42 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
+          "val" : "AMBER PARM7 format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "AMBER parm7 format"
+        }, {
+          "pred" : "hasExactSynonym",
           "val" : "AMBER parmtop format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER prmtop format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "parm7 format"
         } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "lbl" : "parm7 format",
+      "lbl" : "obsolete parm7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)"
+          "val" : "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format."
         },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER PARM7 format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER parm7 format"
-        } ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001042"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
@@ -23526,17 +23761,30 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)"
-        }
+          "val" : "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "restrt format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "rst7 format"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
-      "lbl" : "rst7 format",
+      "lbl" : "obsolete rst7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection."
+        },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001049"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001051",
@@ -23642,7 +23890,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001059",
-      "lbl" : "conflib  format",
+      "lbl" : "conflib format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -23653,7 +23901,7 @@
           "val" : ".conflib"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "LMOD conflib  format"
+          "val" : "LMOD conflib format"
         } ]
       }
     }, {
@@ -23689,11 +23937,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)"
+          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".pqr"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -23702,11 +23954,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)"
+          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Molecular Operating Environment"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -23808,10 +24064,7 @@
       "meta" : {
         "definition" : {
           "val" : "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)"
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001073",
@@ -23819,8 +24072,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001074",
@@ -23987,6 +24244,7 @@
         "definition" : {
           "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -24010,6 +24268,7 @@
         "definition" : {
           "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
         },
+        "comments" : [ "Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -24118,7 +24377,7 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "skf  format"
+          "val" : "skf format"
         } ]
       }
     }, {
@@ -24305,11 +24564,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)"
+          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER mdinfo format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -24318,8 +24581,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)"
-        }
+          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001120",
@@ -24686,8 +24953,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)"
-        }
+          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001202",
@@ -24832,8 +25103,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)"
-        }
+          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001216",
@@ -24841,8 +25116,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)"
-        }
+          "val" : "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001217",
@@ -26106,8 +26385,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)"
-        }
+          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001338",
@@ -26133,8 +26416,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)"
-        }
+          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001341",
@@ -26491,8 +26778,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)"
-        }
+          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001367",
@@ -27223,8 +27514,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)"
-        }
+          "val" : "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001433",
@@ -27325,8 +27620,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)"
-        }
+          "val" : "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001443",
@@ -27334,8 +27633,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)"
-        }
+          "val" : "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001444",
@@ -27830,8 +28133,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001495",
@@ -28170,8 +28477,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)"
-        }
+          "val" : "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001531",
@@ -28429,8 +28740,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)"
-        }
+          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001559",
@@ -28497,12 +28812,20 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001566",
-      "lbl" : "library",
+      "lbl" : "software library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)"
-        }
+          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "library"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001567",
@@ -28555,8 +28878,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)"
-        }
+          "val" : "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001573",
@@ -28564,8 +28891,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)"
-        }
+          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001574",
@@ -28694,12 +29025,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001587",
-      "lbl" : "Intel Math Kernel Library",
+      "lbl" : "Intel oneAPI Math Kernel Library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)"
-        }
+          "val" : "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001588",
@@ -28707,8 +29042,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)"
-        }
+          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001589",
@@ -28716,8 +29055,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)"
-        }
+          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001590",
@@ -28907,7 +29250,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
+          "val" : "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -29134,8 +29477,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)"
-        }
+          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001632",
@@ -29323,8 +29670,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)"
-        }
+          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001653",
@@ -29332,8 +29683,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)"
-        }
+          "val" : "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001654",
@@ -29395,8 +29750,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)"
-        }
+          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001661",
@@ -29404,8 +29763,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)"
-        }
+          "val" : "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001662",
@@ -29503,8 +29866,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)"
-        }
+          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001673",
@@ -29512,8 +29879,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)"
-        }
+          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001674",
@@ -29579,8 +29950,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)"
-        }
+          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001681",
@@ -29599,6 +29974,10 @@
         "definition" : {
           "val" : "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures."
         },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "x3DNA"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0002-4303-9349"
@@ -29622,8 +30001,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001685",
@@ -30199,8 +30582,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)"
-        }
+          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001744",
@@ -30226,8 +30613,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)"
-        }
+          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
@@ -30316,6 +30707,9 @@
           "val" : "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -30591,8 +30985,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)"
-        }
+          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
@@ -30600,44 +30998,72 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)"
-        }
+          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "lbl" : "helix",
+      "lbl" : "obsolete helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001114"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "lbl" : "3-10 helix",
+      "lbl" : "obsolete 3-10 helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001119"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "lbl" : "alpha helix",
+      "lbl" : "obsolete alpha helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001117"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "lbl" : "pi helix",
+      "lbl" : "obsolete pi helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001118"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
@@ -30654,8 +31080,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)"
-        }
+          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001791",
@@ -30672,8 +31102,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)"
-        }
+          "val" : "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001793",
@@ -30707,8 +31141,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)"
-        }
+          "val" : "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001796",
@@ -31306,8 +31744,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)"
-        }
+          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001851",
@@ -31462,8 +31904,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)"
-        }
+          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001867",
@@ -31761,8 +32207,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)"
-        }
+          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001890",
@@ -31818,8 +32268,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)"
-        }
+          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001895",
@@ -32142,8 +32596,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)"
-        }
+          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001923",
@@ -32151,8 +32609,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)"
-        }
+          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001924",
@@ -32160,8 +32622,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)"
-        }
+          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001925",
@@ -32187,8 +32653,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)"
-        }
+          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001928",
@@ -32196,8 +32666,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)"
-        }
+          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001929",
@@ -32236,8 +32710,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)"
-        }
+          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001933",
@@ -32245,11 +32723,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)"
+          "val" : "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Mol*"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -32466,8 +32948,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001956",
@@ -32493,8 +32979,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)"
-        }
+          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001959",
@@ -32502,8 +32992,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001960",
@@ -32560,8 +33054,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)"
-        }
+          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001966",
@@ -32569,8 +33067,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)"
-        }
+          "val" : "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001967",
@@ -32600,8 +33102,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)"
-        }
+          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001970",
@@ -32851,8 +33357,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)"
-        }
+          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001996",
@@ -33022,8 +33532,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)"
-        }
+          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002013",
@@ -33281,9 +33795,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An atom ID is usually a number, that uniquely defines a given atom in structure."
+          "val" : "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -33294,8 +33811,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)"
-        }
+          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002041",
@@ -33303,8 +33824,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)"
-        }
+          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002042",
@@ -33312,11 +33837,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)"
+          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "data visualization tool"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33383,8 +33912,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
-        }
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002050",
@@ -33392,11 +33925,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Genetic Optimisation for Ligand Docking"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33405,11 +33942,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Grid-based Ligand Docking with Energetics"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33504,8 +34045,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
-        }
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002059",
@@ -33526,8 +34071,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)"
-        }
+          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002061",
@@ -33548,7 +34097,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)"
+          "val" : "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33556,6 +34105,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "maegz format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33942,7 +34495,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)"
         }
       }
     }, {
@@ -33951,7 +34504,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -33960,7 +34513,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)"
         }
       }
     }, {
@@ -33969,7 +34522,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)"
         }
       }
     }, {
@@ -33978,7 +34531,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)"
         }
       }
     }, {
@@ -33987,7 +34540,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)"
         }
       }
     }, {
@@ -33996,7 +34549,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)"
         }
       }
     }, {
@@ -34005,7 +34558,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)"
         }
       }
     }, {
@@ -34014,7 +34567,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)"
         }
       }
     }, {
@@ -34023,7 +34576,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -34032,7 +34585,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)"
         }
       }
     }, {
@@ -34041,7 +34594,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)"
         }
       }
     }, {
@@ -34050,7 +34603,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)"
         }
       }
     }, {
@@ -34059,7 +34612,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)"
         }
       }
     }, {
@@ -34068,7 +34621,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -34077,7 +34630,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)"
         }
       }
     }, {
@@ -34086,7 +34639,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)"
         }
       }
     }, {
@@ -34095,7 +34648,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)"
         }
       }
     }, {
@@ -34104,7 +34657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)"
         }
       }
     }, {
@@ -34113,7 +34666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)"
         }
       }
     }, {
@@ -34122,7 +34675,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)"
         }
       }
     }, {
@@ -34131,7 +34684,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -34140,7 +34693,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -34149,7 +34702,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)"
         }
       }
     }, {
@@ -34158,7 +34711,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -34167,7 +34720,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -34176,7 +34729,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)"
         }
       }
     }, {
@@ -34185,7 +34738,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)"
         }
       }
     }, {
@@ -34194,7 +34747,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34203,7 +34756,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)"
         }
       }
     }, {
@@ -34212,7 +34765,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)"
         }
       }
     }, {
@@ -34221,7 +34774,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -34230,7 +34783,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -34239,7 +34792,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -34248,7 +34801,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)"
         }
       }
     }, {
@@ -34257,7 +34810,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)"
         }
       }
     }, {
@@ -34266,7 +34819,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)"
         }
       }
     }, {
@@ -34275,7 +34828,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)"
         }
       }
     }, {
@@ -34284,7 +34837,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)"
         }
       }
     }, {
@@ -34293,7 +34846,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)"
         }
       }
     }, {
@@ -34302,7 +34855,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)"
+          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34315,7 +34868,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)"
+          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34328,7 +34881,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)"
+          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34341,7 +34894,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)"
         }
       }
     }, {
@@ -34350,7 +34903,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -34359,7 +34912,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)"
         }
       }
     }, {
@@ -34368,7 +34921,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)"
         }
       }
     }, {
@@ -34377,7 +34930,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)"
         }
       }
     }, {
@@ -34386,7 +34939,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)"
         }
       }
     }, {
@@ -34395,7 +34948,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)"
         }
       }
     }, {
@@ -34404,7 +34957,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)"
         }
       }
     }, {
@@ -34413,7 +34966,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34422,7 +34975,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)"
         }
       }
     }, {
@@ -34431,7 +34984,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)"
         }
       }
     }, {
@@ -34440,7 +34993,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)"
         }
       }
     }, {
@@ -34449,7 +35002,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34458,7 +35011,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -34467,7 +35020,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)"
         }
       }
     }, {
@@ -34476,7 +35029,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)"
         }
       }
     }, {
@@ -34485,7 +35038,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -34494,7 +35047,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34503,7 +35056,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34512,7 +35065,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34521,7 +35074,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34530,7 +35083,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -34539,7 +35092,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)"
         }
       }
     }, {
@@ -34548,8 +35101,21 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)"
         }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "lbl" : "DSSR",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "Dissecting the Spatial Structure of RNA"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
@@ -35123,6 +35689,189 @@
         "basicPropertyValues" : [ {
           "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
           "val" : "BS:00337"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001078",
+      "lbl" : "polypeptide_secondary_structure",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Biosapien term was secondary_structure." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "polypeptide secondary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "2nary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary structure region"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary_structure"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Secondary_structure",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00003"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001114",
+      "lbl" : "peptide_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A helix is a secondary_structure conformation where the peptide backbone forms a coil.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "helix"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00152"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001117",
+      "lbl" : "alpha_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "a-helix"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "helix",
+          "xrefs" : [ "uniprot:feature_type" ]
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Alpha_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00040"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001118",
+      "lbl" : "pi_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "pi helix"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Pi_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00153"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001119",
+      "lbl" : "three_ten_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "3(10) helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "3-10 helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "310 helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "three ten helix"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/310_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:0000340"
         }, {
           "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
           "val" : "sequence"
@@ -36385,7 +37134,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -36395,7 +37144,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)"
         }
       }
     }, {
@@ -36405,7 +37154,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -36415,7 +37164,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)"
         }
       }
     }, {
@@ -36425,7 +37174,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)"
         }
       }
     }, {
@@ -36435,7 +37184,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)"
         }
       }
     }, {
@@ -36445,7 +37194,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)"
         }
       }
     }, {
@@ -36455,7 +37204,17 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)"
+        }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "lbl" : "follows protocol",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "definition" : {
+          "val" : "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -37117,7 +37876,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)"
         }
       }
     }, {
@@ -37127,7 +37886,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)"
         }
       }
     }, {
@@ -37137,7 +37896,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)"
         }
       }
     }, {
@@ -37147,7 +37906,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)"
         },
         "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
@@ -37158,7 +37917,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -37168,7 +37927,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -37178,7 +37937,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)"
         }
       }
     }, {
@@ -37188,7 +37947,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)"
         }
       }
     }, {
@@ -37198,7 +37957,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)"
         }
       }
     }, {
@@ -37208,7 +37967,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)"
         }
       }
     }, {
@@ -37218,7 +37977,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)"
         }
       }
     }, {
@@ -37228,7 +37987,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)"
         }
       }
     }, {
@@ -37238,7 +37997,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)"
         }
       }
     }, {
@@ -37248,7 +38007,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -37258,7 +38017,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37268,7 +38027,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -37278,7 +38037,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37288,7 +38047,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37298,7 +38057,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)"
         }
       }
     }, {
@@ -37308,7 +38067,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37318,7 +38077,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -37328,7 +38087,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -37338,7 +38097,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37348,7 +38107,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)"
         }
       }
     }, {
@@ -37358,7 +38117,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37368,7 +38127,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)"
         }
       }
     }, {
@@ -37378,7 +38137,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37388,7 +38147,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)"
         }
       }
     }, {
@@ -37398,7 +38157,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37408,7 +38167,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -37418,7 +38177,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37428,7 +38187,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)"
         }
       }
     }, {
@@ -37438,7 +38197,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)"
         }
       }
     }, {
@@ -37448,7 +38207,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -37458,7 +38217,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37468,7 +38227,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37478,7 +38237,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37488,7 +38247,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -37498,7 +38257,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)"
         }
       }
     }, {
@@ -37508,7 +38267,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37518,7 +38277,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37528,7 +38287,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37538,7 +38297,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)"
         }
       }
     }, {
@@ -37548,7 +38307,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)"
         }
       }
     }, {
@@ -37558,7 +38317,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)"
         }
       }
     }, {
@@ -37568,7 +38327,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)"
         }
       }
     }, {
@@ -37578,7 +38337,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)"
         }
       }
     }, {
@@ -37588,7 +38347,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)"
         }
       }
     }, {
@@ -37598,7 +38357,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -37608,7 +38367,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)"
         }
       }
     }, {
@@ -37618,7 +38377,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37628,7 +38387,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -37638,7 +38397,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -37648,7 +38407,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -37658,7 +38417,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)"
         }
       }
     }, {
@@ -37668,7 +38427,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)"
         }
       }
     }, {
@@ -37678,7 +38437,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)"
         }
       }
     }, {
@@ -37688,7 +38447,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)"
         }
       }
     }, {
@@ -37698,7 +38457,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -37708,7 +38467,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -37718,7 +38477,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)"
         }
       }
     }, {
@@ -37728,7 +38487,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)"
         }
       }
     }, {
@@ -37738,7 +38497,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)"
         }
       }
     }, {
@@ -37748,7 +38507,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)"
         }
       }
     }, {
@@ -37758,7 +38517,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)"
         }
       }
     }, {
@@ -37768,7 +38527,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)"
         }
       }
     }, {
@@ -37778,7 +38537,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)"
         }
       }
     }, {
@@ -37788,7 +38547,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)"
         }
       }
     }, {
@@ -37798,7 +38557,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)"
         }
       }
     }, {
@@ -37808,7 +38567,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)"
         }
       }
     }, {
@@ -37818,7 +38577,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)"
         }
       }
     }, {
@@ -38586,9 +39345,8 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)"
-        },
-        "comments" : [ "The Cambridge Structural Database (CSD) is the world's primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)" ]
+          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)"
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001945",
@@ -38611,7 +39369,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)"
         }
       }
     }, {
@@ -38620,7 +39378,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)"
         }
       }
     }, {
@@ -38629,7 +39387,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -38638,7 +39396,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -38647,7 +39405,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -38920,6 +39678,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
+      "lbl" : "term replaced by",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -38984,10 +39743,6 @@
       }
     }, {
       "id" : "http://purl.org/dc/elements/1.1/source",
-      "type" : "PROPERTY",
-      "propertyType" : "ANNOTATION"
-    }, {
-      "id" : "http://purl.org/dc/terms/BibliographicResource",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -40509,15 +41264,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
       "pred" : "is_a",
@@ -41739,6 +42494,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000610"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000310",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001072"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
@@ -42283,10 +43042,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001090"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000430"
@@ -42418,10 +43173,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000939"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
       "pred" : "is_a",
@@ -43229,11 +43980,11 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000686",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000687",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
       "pred" : "is_a",
@@ -44387,10 +45138,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -44412,10 +45159,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
     }, {
@@ -47133,7 +47876,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001781",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001333"
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001078"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001782",
       "pred" : "is_a",
@@ -47146,22 +47889,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001782"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001781"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
       "pred" : "is_a",
@@ -48691,6 +49418,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002162"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001960"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/UO_1000010"
@@ -48866,6 +49597,26 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0000839"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001078",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001070"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001114",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001781"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001117",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001118",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001119",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0001236",
       "pred" : "is_a",
@@ -49587,6 +50338,10 @@
       "pred" : "subPropertyOf",
       "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "pred" : "subPropertyOf",
+      "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/OBI_0000299",
       "pred" : "subPropertyOf",
       "obj" : "http://purl.obolibrary.org/obo/RO_0000057"
@@ -49776,7 +50531,7 @@
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001994" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002167",
-      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ],
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002156" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002168",
@@ -49806,6 +50561,10 @@
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002202",
       "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001164" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
+      "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/OBI_0000299",
       "domainClassIds" : [ "http://purl.obolibrary.org/obo/COB_0000035" ]

--- a/molsim-full.obo
+++ b/molsim-full.obo
@@ -1,8 +1,8 @@
 format-version: 1.2
-data-version: molsim/releases/2026-07-29/molsim-full.owl
+data-version: molsim/releases/2026-08-07/molsim-full.owl
 default-namespace: molsim
 idspace: chemrof https://w3id.org/chemrof/ 
-idspace: dce http://purl.org/dc/elements/1.1/ 
+idspace: dc http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: foaf http://xmlns.com/foaf/0.1/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
@@ -12,8 +12,14 @@ idspace: swrl http://www.w3.org/2003/11/swrl#
 idspace: swrlb http://www.w3.org/2003/11/swrlb# 
 remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
 remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
+remark: Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.
 ontology: molsim/molsim-full
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
+property_value: dcterms:contributor orcid:0000-0002-2294-5393
+property_value: dcterms:contributor orcid:0000-0002-4303-9349
+property_value: dcterms:contributor orcid:0000-0002-7544-0938
+property_value: dcterms:contributor orcid:0000-0002-8291-8071
+property_value: dcterms:contributor orcid:0000-0003-4177-3619
 property_value: dcterms:contributor orcid:0009-0007-1391-4986
 property_value: dcterms:creator orcid:0000-0001-8613-1447
 property_value: dcterms:creator orcid:0000-0003-4846-8051
@@ -22,7 +28,7 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-29" xsd:string
+property_value: owl:versionInfo "2026-08-07" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
@@ -3934,7 +3940,8 @@ property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
 [Term]
 id: MOLSIM:000000
 name: molecular dynamics process
-def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)" []
+def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation." []
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000001
@@ -3943,27 +3950,31 @@ def: "Software refers to the set of instructions, data, or programs used to oper
 
 [Term]
 id: MOLSIM:000002
-name: preparation
+name: simulation preparation
 def: "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "preparation" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000003
-name: execution
-def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+name: simulation execution
+def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies." []
+synonym: "execution" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000004
-name: analysis
+name: simulation analysis
 def: "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "analysis" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000005
 name: protonation
 def: "A specific step within the preparation process where the ionization states (presence or absence of protons) of ionizable residues (like acids, bases, histidines) and ligands are determined and assigned based on estimated pKa values relevant to the target pH of the simulation. Correct protonation is critical for accurately modeling electrostatic interactions and pH-dependent phenomena. Specialized tools are often used for this task. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 disjoint_from: MOLSIM:000208 ! thermalization
 
 [Term]
@@ -3981,7 +3992,7 @@ is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:000008
-name: lipid  force field
+name: lipid force field
 def: "A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)" []
 is_a: MOLSIM:000772 ! chemical entity-based force field
 disjoint_from: MOLSIM:000009 ! protein force field
@@ -4048,20 +4059,21 @@ disjoint_from: MOLSIM:000485 ! split-valence
 id: MOLSIM:000018
 name: lipid21
 def: "A specific version of a lipid force field, part of the AMBER family, providing parameters optimized for simulating lipids. Released around 2021, it incorporates updates and refinements based on contemporary data and methodologies to improve accuracy in membrane simulations. Its name indicates the originating group (AMBER) and year of major update. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 disjoint_from: MOLSIM:000019 ! lipid14
 
 [Term]
 id: MOLSIM:000019
 name: lipid14
 def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2014. It provides parameters optimized for simulating a range of common lipid types found in biological membranes. This version aimed to improve upon previous lipid models within the AMBER family. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:000020
 name: lipid17
-def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails." []
+is_a: MOLSIM:000008 ! lipid force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000021
@@ -4440,6 +4452,7 @@ id: MOLSIM:000076
 name: Tversky index algorithm
 def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
+property_value: IAO:0000116 "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1." xsd:string
 
 [Term]
 id: MOLSIM:000077
@@ -4511,9 +4524,10 @@ is_a: MOLSIM:000037 ! algorithm
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected." []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000089
@@ -4690,8 +4704,8 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000114
 name: HOLE
 def: "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms." []
+xref: https://doi.org/10.1016/S0263-7855(97)00009-X
 is_a: MOLSIM:000245 ! tunnel predictor tool
-property_value: dcterms:BibliographicResource "https://doi.org/10.1016/S0263-7855(97)00009-X" xsd:string
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -4957,9 +4971,10 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000156
 name: GROMACS mdp format
-def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)" []
+def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
 disjoint_from: MOLSIM:000469 ! AMBER mdin format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000157
@@ -4985,8 +5000,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000160
 name: molecular dynamics engine
-def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)" []
+def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS." []
 is_a: MOLSIM:001851 ! simulation engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000161
@@ -4997,8 +5013,9 @@ is_a: MOLSIM:001851 ! simulation engine
 [Term]
 id: MOLSIM:000162
 name: docking tool
-def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)" []
+def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000163
@@ -5009,20 +5026,23 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:000164
 name: analysis tool
-def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)" []
+def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000165
 name: data processing tool
-def: "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)" []
+def: "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000166
 name: file conversion tool
-def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)" []
+def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)." []
 is_a: MOLSIM:000165 ! data processing tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000167
@@ -5306,20 +5326,22 @@ is_a: MOLSIM:001802 ! script
 id: MOLSIM:000208
 name: thermalization
 def: "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+synonym: "heating" EXACT []
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000209
 name: equilibration
-def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration." []
+is_a: MOLSIM:000002 ! simulation preparation
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000210
 name: umbrella sampling
 def: "A specific simulation execution technique used to enhance sampling along a chosen reaction coordinate or order parameter, often for calculating the potential of mean force (PMF) or free energy profile associated with a process like ligand unbinding or a conformational change. It involves running multiple simulations, each confined ('biased') by a potential (the 'umbrella') to sample a specific window along the coordinate, with subsequent analysis required to unbias the results and reconstruct the overall profile. It falls under the category of enhanced sampling methods." []
 synonym: "US" EXACT []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 disjoint_from: MOLSIM:000211 ! production
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -5327,19 +5349,19 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000211
 name: production
 def: "The main data-gathering phase of a simulation execution, performed after the system has been properly prepared and equilibrated. During the production run, the system is simulated for a significant length of time under the desired conditions (ensemble, temperature, pressure) without strong restraints or equilibration protocols, and the resulting trajectory (positions and velocities over time) is saved for later analysis. The goal is to generate statistically meaningful data about the system's behavior. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000212
 name: free energy calculation
 def: "A type of simulation execution specifically designed to compute the free energy difference between two states (e.g., bound vs unbound, state A vs state B) or the free energy profile along a reaction coordinate. Common methods include Free Energy Perturbation (FEP), Thermodynamic Integration (TI), Umbrella Sampling (for PMFs), and sometimes methods based on endpoint analysis like MM/PBSA or MM/GBSA (though these are technically post-processing analyses estimating free energy). These calculations are computationally demanding but crucial for understanding binding affinities, reaction barriers, and relative stabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000213
 name: adaptive steered molecular dynamics
 def: "An enhanced sampling simulation technique that enhances traditional steered molecular dynamics (SMD) to calculate binding affinities, mechanical unfolding pathways, and free energy profiles (e.g., Potential of Mean Force) in biomolecules. It works by breaking long pulling processes into a series of stages or windows along a specific reaction coordinate." []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -5358,7 +5380,7 @@ is_a: MOLSIM:000017 ! minimal
 id: MOLSIM:000216
 name: visualization
 def: "The process of creating graphical representations of molecular structures, trajectories, and simulation data using specialized software. Visualization is essential for inspecting system setup, monitoring simulation progress, understanding molecular motion and interactions, identifying structural features, and communicating results effectively through images and animations. It is an integral part of both preparation and analysis stages. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:000217
@@ -5390,20 +5412,23 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:000221
 name: PDB2PQR
-def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)" []
+def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)." []
 is_a: MOLSIM:000223 ! generic protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000222
 name: ligand protonation tool
-def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)" []
+def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000223
 name: generic protonation tool
-def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)" []
+def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000224
@@ -5427,14 +5452,16 @@ disjoint_from: MOLSIM:001927 ! CHARMM-GUI
 [Term]
 id: MOLSIM:000227
 name: membrane protein orientation tool
-def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)" []
+def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000228
 name: memembed
-def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)" []
+def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential." []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000229
@@ -5513,8 +5540,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000240
 name: pKa tool
-def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)" []
+def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example." []
 is_a: MOLSIM:000490 ! structure preparation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000241
@@ -5531,8 +5559,9 @@ is_a: MOLSIM:000460 ! molecular mechanics Poisson-Boltzmann surface area tool
 [Term]
 id: MOLSIM:000243
 name: in-silico mutagenesis tool
-def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)" []
+def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000244
@@ -5934,8 +5963,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000305
 name: modeling method
-def: "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)" []
+def: "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy." []
 is_a: MOLSIM:000140 ! computational method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000306
@@ -5967,12 +5997,13 @@ is_a: MOLSIM:000610 ! thermodynamics analysis
 id: MOLSIM:000310
 name: plan specification
 def: "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)" []
-comment: TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)
+comment: Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.
+is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:000311
 name: RMSD analysis
-def: "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms." []
+def: "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms." []
 is_a: MOLSIM:000917 ! structural analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -6871,10 +6902,10 @@ def: "An identifier is a unique name, code, or label assigned to a specific enti
 
 [Term]
 id: MOLSIM:000448
-name: protein database ID
-def: "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
-is_a: MOLSIM:000447 ! identifier
-property_value: IAO:0000117 orcid:0000-0003-4177-3619
+name: obsolete protein database ID
+def: "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
+comment: Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000449
@@ -6991,10 +7022,11 @@ is_a: MOLSIM:000462 ! molecular mechanics generalized Born surface area tool
 [Term]
 id: MOLSIM:000466
 name: orientations of proteins in membranes
-def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)" []
+def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations." []
 synonym: "OPM" EXACT []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000467
@@ -7013,8 +7045,9 @@ is_a: MOLSIM:000909 ! volumetric data format
 [Term]
 id: MOLSIM:000469
 name: AMBER mdin format
-def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)" []
+def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000470
@@ -7030,10 +7063,11 @@ disjoint_from: MOLSIM:000879 ! ADF output format
 [Term]
 id: MOLSIM:000471
 name: AMBER restart format
-def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)" []
+def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)." []
 is_a: MOLSIM:000441 ! simulation state format
 disjoint_from: MOLSIM:000880 ! rkf format
 disjoint_from: MOLSIM:000890 ! GAUSSIAN chk format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000472
@@ -7084,8 +7118,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000479
 name: Connolly surface analysis
-def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)" []
+def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent." []
 is_a: MOLSIM:000478 ! molecular surface analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000480
@@ -7095,10 +7130,11 @@ is_a: MOLSIM:000939 ! dynamics analysis
 
 [Term]
 id: MOLSIM:000481
-name: 2D RMSD analysis
-def: "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
-is_a: MOLSIM:000917 ! structural analysis
-property_value: IAO:0000117 orcid:0000-0002-2294-5393
+name: obsolete 2D RMSD analysis
+def: "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
+comment: Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45.
+is_obsolete: true
+replaced_by: MOLSIM:000311
 
 [Term]
 id: MOLSIM:000482
@@ -7180,7 +7216,7 @@ is_a: MOLSIM:002041 ! molecular structure visualization tool
 id: MOLSIM:000494
 name: minimization
 def: "Minimization is a computational step that relaxes a molecular structure to remove any bad clashes between atoms. As a stage of the preparation process, energy minimization is a procedure that adjusts the atomic coordinates to find a nearby local minimum on the potential energy surface, thereby removing steric strain from the initial model. This is achieved by using algorithms like steepest descent or conjugate gradient to iteratively reduce the net forces on the atoms until a convergence criterion, such as grms_tol, is met. This process is referred to in log files and inputs with terms like \"MINIMIZATION,\" \"ntmin=1,\" \"emtol,\" and \"ncyc.\" (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000495
@@ -7192,7 +7228,7 @@ is_a: MOLSIM:000272 ! radii set
 id: MOLSIM:000496
 name: pyMBAR
 def: "pyMBAR refers to a specific Python software library implementation of the Multistate Bennett Acceptance Ratio (MBAR) method. MBAR itself is a statistical technique for optimally combining data from multiple simulations to calculate free energies and expectation values. Therefore, pyMBAR is a tool used for the analysis stage of free energy calculations, particularly for processing data generated by methods like umbrella sampling or replica exchange simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:000497
@@ -7779,9 +7815,10 @@ is_a: MOLSIM:000590 ! plot data format
 [Term]
 id: MOLSIM:000596
 name: grid format
-def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)" []
+def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule." []
 synonym: ".grid" EXACT []
 is_a: MOLSIM:000590 ! plot data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000597
@@ -8263,8 +8300,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000670
 name: coordinate centering analysis
-def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)" []
+def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization." []
 is_a: MOLSIM:000917 ! structural analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000671
@@ -8320,7 +8358,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 id: MOLSIM:000679
 name: obsolete image bond fixing analysis
 def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+comment: Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45.
 is_obsolete: true
+replaced_by: MOLSIM:000659
 
 [Term]
 id: MOLSIM:000680
@@ -8365,13 +8405,13 @@ is_a: MOLSIM:000141 ! theoretical approach
 id: MOLSIM:000686
 name: PDB ID
 def: "A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., '1TIM', '6M0J') serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000687
 name: Uniprot ID
 def: "A UniProt ID, more formally known as a UniProt Accession Number (e.g., 'P00761', 'Q8WZ42'), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000688
@@ -8499,8 +8539,9 @@ is_a: MOLSIM:000703 ! secondary database
 [Term]
 id: MOLSIM:000706
 name: pathway database
-def: "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)" []
+def: "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples." []
 is_a: MOLSIM:000703 ! secondary database
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000707
@@ -8653,8 +8694,9 @@ disjoint_from: MOLSIM:001472 ! bonded metal model
 [Term]
 id: MOLSIM:000741
 name: amber ff02
-def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)" []
+def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000742
@@ -8720,8 +8762,9 @@ is_a: MOLSIM:000009 ! protein force field
 [Term]
 id: MOLSIM:000752
 name: CHARMM 19
-def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)" []
+def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000753
@@ -8852,8 +8895,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000774
 name: Abalone
-def: "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)" []
+def: "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field." []
 is_a: MOLSIM:001664 ! software suite
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000775
@@ -8870,9 +8914,10 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000777
 name: Desmond
-def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)" []
+def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
 disjoint_from: MOLSIM:000784 ! LAMMPS
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000778
@@ -8925,8 +8970,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000786
 name: NAMD
-def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)" []
+def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000787
@@ -9283,9 +9329,10 @@ is_a: MOLSIM:000841 ! empirical method
 [Term]
 id: MOLSIM:000843
 name: molecular dynamics
-def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)" []
+def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems." []
 synonym: "MD" EXACT []
 is_a: MOLSIM:000308 ! simulation method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000844
@@ -9452,8 +9499,9 @@ disjoint_from: MOLSIM:000868 ! GAMESS input format
 [Term]
 id: MOLSIM:000867
 name: CHARMM input format
-def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)" []
+def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results." []
 is_a: MOLSIM:000438 ! script format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000868
@@ -9477,9 +9525,10 @@ is_a: MOLSIM:000437 ! simulation input format
 
 [Term]
 id: MOLSIM:000871
-name: GROMACS input  format
-def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)" []
+name: GROMACS input format
+def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000872
@@ -9508,14 +9557,16 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000876
 name: NAMD configuration format
-def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)" []
+def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000877
 name: NWChem input format
-def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)" []
+def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system." []
 is_a: MOLSIM:000437 ! simulation input format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000878
@@ -9540,8 +9591,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000881
 name: CHARMM output format
-def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)" []
+def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000882
@@ -9564,8 +9616,9 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000885
 name: GROMACS output format
-def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)" []
+def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000886
@@ -9612,8 +9665,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000893
 name: NWChem restart format
-def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)" []
+def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)." []
 is_a: MOLSIM:000441 ! simulation state format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000894
@@ -9645,10 +9699,11 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000898
 name: itp format
-def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)" []
+def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive." []
 synonym: "GROMACS include topology format" EXACT []
 synonym: "GROMACS itp format" EXACT []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000899
@@ -9674,8 +9729,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000902
 name: dcd format
-def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)" []
+def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability." []
 is_a: MOLSIM:001090 ! molecular trajectory format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000903
@@ -9694,6 +9750,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:000905
 name: obsolete small molecule structure
 def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -9785,8 +9842,9 @@ is_a: MOLSIM:000917 ! structural analysis
 [Term]
 id: MOLSIM:000921
 name: crd format
-def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)" []
+def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used." []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000923
@@ -9851,7 +9909,7 @@ is_a: MOLSIM:000937 ! structure clustering analysis
 id: MOLSIM:000939
 name: dynamics analysis
 def: "Dynamics analysis involves processing the time-series data generated from molecular dynamics simulations, primarily the trajectory files, to extract quantitative information and insights about the system's behavior. This encompasses a wide range of techniques aimed at understanding molecular motions, conformational changes, interactions, and kinetic or thermodynamic properties. The goal is to translate raw simulation output into meaningful physical or biological understanding." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 is_a: MOLSIM:000026 ! analysis method
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -9866,8 +9924,9 @@ disjoint_from: MOLSIM:001079 ! frcmod format
 [Term]
 id: MOLSIM:000941
 name: coordinate rotation modeling
-def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)" []
+def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure." []
 is_a: MOLSIM:000305 ! modeling method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000942
@@ -9969,7 +10028,7 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 id: MOLSIM:000963
 name: AMBER crd format
 def: "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information." []
-comment: Amber's standard ASCII coordinate trajectory file format.\n\nThe "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
+comment: Amber's standard ASCII coordinate trajectory file format. The "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
 synonym: "AMBER inpcrd format" EXACT []
 synonym: "AMBER prmcrd format" EXACT []
 is_a: MOLSIM:000921 ! crd format
@@ -10210,7 +10269,7 @@ is_a: MOLSIM:000921 ! crd format
 id: MOLSIM:001039
 name: trj format
 def: "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited." []
-comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
+comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
 synonym: "AMBER trj format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
@@ -10218,33 +10277,39 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001040
 name: distance matrix format
-def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)" []
-comment: Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
+def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule." []
+comment: Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
 is_a: MOLSIM:010020 ! molecular trajectory analysis format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001041
-name: xpm  format
+name: xpm format
 def: "The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)" []
 synonym: ".xpm" EXACT []
-synonym: "GROMACS xpm  format" EXACT []
+synonym: "GROMACS xpm format" EXACT []
 is_a: MOLSIM:001040 ! distance matrix format
 
 [Term]
 id: MOLSIM:001042
 name: prmtop format
 def: "The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)" []
+synonym: "AMBER PARM7 format" EXACT []
+synonym: "AMBER parm7 format" EXACT []
 synonym: "AMBER parmtop format" EXACT []
 synonym: "AMBER prmtop format" EXACT []
+synonym: "parm7 format" EXACT []
 is_a: MOLSIM:000472 ! AMBER topology format
 
 [Term]
 id: MOLSIM:001043
-name: parm7 format
-def: "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)" []
+name: obsolete parm7 format
+def: "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.
 synonym: "AMBER PARM7 format" EXACT []
 synonym: "AMBER parm7 format" EXACT []
-is_a: MOLSIM:000472 ! AMBER topology format
+is_obsolete: true
+replaced_by: MOLSIM:001042
 
 [Term]
 id: MOLSIM:001044
@@ -10290,15 +10355,19 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001049
 name: rst format
-def: "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)" []
+def: "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)" []
+synonym: "restrt format" EXACT []
+synonym: "rst7 format" EXACT []
 is_a: MOLSIM:000471 ! AMBER restart format
-disjoint_from: MOLSIM:001050 ! rst7 format
+disjoint_from: MOLSIM:001050 ! obsolete rst7 format
 
 [Term]
 id: MOLSIM:001050
-name: rst7 format
-def: "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)" []
-is_a: MOLSIM:000471 ! AMBER restart format
+name: obsolete rst7 format
+def: "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.
+is_obsolete: true
+replaced_by: MOLSIM:001049
 
 [Term]
 id: MOLSIM:001051
@@ -10361,10 +10430,10 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 
 [Term]
 id: MOLSIM:001059
-name: conflib  format
+name: conflib format
 def: "The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)" []
 synonym: ".conflib" EXACT []
-synonym: "LMOD conflib  format" EXACT []
+synonym: "LMOD conflib format" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
 
 [Term]
@@ -10385,17 +10454,19 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:001062
 name: pqr format
-def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)" []
+def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field." []
 synonym: ".pqr" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001063
 name: MOE
-def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)" []
+def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface." []
 synonym: "Molecular Operating Environment" EXACT []
 is_a: MOLSIM:000490 ! structure preparation tool
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001064
@@ -10457,14 +10528,14 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 id: MOLSIM:001072
 name: information content entity
 def: "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)" []
-property_value: dcterms:BibliographicResource "" xsd:string
 
 [Term]
 id: MOLSIM:001073
 name: molecular system specification
-def: "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)" []
+def: "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed." []
 is_a: MOLSIM:001072 ! information content entity
 disjoint_from: MOLSIM:001074 ! process specification
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001074
@@ -10559,6 +10630,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 id: MOLSIM:001087
 name: obsolete macromolecular structure format
 def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -10572,6 +10644,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:001089
 name: obsolete software-specific coordinate format
 def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+comment: Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -10636,7 +10709,7 @@ is_a: MOLSIM:002066 ! force field parameter format
 id: MOLSIM:001099
 name: DFTB parameter format
 def: "The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)" []
-synonym: "skf  format" EXACT []
+synonym: "skf format" EXACT []
 is_a: MOLSIM:002066 ! force field parameter format
 
 [Term]
@@ -10755,15 +10828,17 @@ is_a: MOLSIM:010022 ! quantum chemistry format
 [Term]
 id: MOLSIM:001118
 name: mdinfo format
-def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)" []
+def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file." []
 synonym: "AMBER mdinfo format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001119
 name: database web server
-def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)" []
+def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system." []
 is_a: MOLSIM:001671 ! web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001120
@@ -11004,8 +11079,9 @@ is_a: MOLSIM:001199 ! external field parameter
 [Term]
 id: MOLSIM:001201
 name: constraint and restraint parameter
-def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)" []
+def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001202
@@ -11093,14 +11169,16 @@ is_a: MOLSIM:001210 ! system setup parameter
 [Term]
 id: MOLSIM:001215
 name: alchemical transformation state
-def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)" []
+def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001216
 name: number of replicates
-def: "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)" []
+def: "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001217
@@ -11868,8 +11946,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001337
 name: hydrogen mass repartitioning analysis
-def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)" []
+def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics." []
 is_a: MOLSIM:000328 ! system setup modeling
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001338
@@ -11886,8 +11965,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:001340
 name: dihedral angle
-def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)" []
+def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001341
@@ -12076,8 +12156,9 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 [Term]
 id: MOLSIM:001366
 name: base pair step parameter
-def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)" []
+def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist." []
 is_a: MOLSIM:001358 ! nucleic acid parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001367
@@ -12511,8 +12592,9 @@ is_a: MOLSIM:001427 ! miscellaneous descriptor
 [Term]
 id: MOLSIM:001432
 name: adaptive string method
-def: "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)" []
+def: "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path." []
 is_a: MOLSIM:000860 ! string method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001433
@@ -12574,14 +12656,16 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001442
 name: amber ff03
-def: "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)" []
+def: "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001443
 name: amber ff03ua
-def: "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)" []
+def: "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001444
@@ -12619,13 +12703,13 @@ is_a: MOLSIM:000010 ! DNA force field
 id: MOLSIM:001449
 name: lipid11
 def: "Lipid11 is a specific version of the AMBER lipid force field, released around 2011, that provided an updated set of parameters for simulating common phospholipid molecules. It served as an improvement over earlier lipid models within the AMBER family for modeling biological membranes. It has since been superseded by more recent versions like LIPID14 and LIPID17, but represents an important step in the development of AMBER's membrane simulation capabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001450
 name: GAFFLipid
 def: "GAFFLipid is a force field for simulating a wide variety of lipid molecules, built upon the principles of the General Amber Force Field (GAFF). It uses the GAFF atom typing and parameterization strategy to automatically generate parameters for lipids that are not covered by specialized lipid force fields like LIPID17. This makes it a versatile tool for modeling novel or unusual lipid species in membrane simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001451
@@ -12899,8 +12983,9 @@ is_a: MOLSIM:000014 ! water model force field
 [Term]
 id: MOLSIM:001494
 name: crystallographic model component
-def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)" []
+def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid." []
 is_a: MOLSIM:000006 ! model
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001495
@@ -13121,8 +13206,9 @@ is_a: MOLSIM:000204 ! ligand charge model
 [Term]
 id: MOLSIM:001530
 name: amber fb15
-def: "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)" []
+def: "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001531
@@ -13288,8 +13374,9 @@ is_a: MOLSIM:001956 ! system packing and solvation tool
 [Term]
 id: MOLSIM:001558
 name: electrostatics analysis tool
-def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)" []
+def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001559
@@ -13335,15 +13422,17 @@ is_a: MOLSIM:001968 ! alchemical analysis tool
 
 [Term]
 id: MOLSIM:001566
-name: library
-def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)" []
+name: software library
+def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing." []
+synonym: "library" EXACT []
 is_a: MOLSIM:000170 ! software component
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001567
 name: FFTW
 def: "FFTW is a highly optimized software library for computing the discrete Fourier transform, a fundamental mathematical operation used in many scientific applications. In biomolecular simulations, it is most commonly used to perform the Fast Fourier Transform (FFT) required for the Particle Mesh Ewald (PME) method of calculating long-range electrostatic forces. For simulation engines, using the FFTW library is essential for achieving high performance in the most computationally demanding part of the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001568
@@ -13372,14 +13461,16 @@ is_a: MOLSIM:000272 ! radii set
 [Term]
 id: MOLSIM:001572
 name: ndfes
-def: "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)" []
+def: "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods." []
 is_a: MOLSIM:001969 ! free energy surface analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001573
 name: ParmEd
-def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001574
@@ -13417,7 +13508,7 @@ id: MOLSIM:001579
 name: pytraj
 def: "Pytraj is a Python library that provides a programmable interface to the powerful trajectory analysis capabilities of the cpptraj engine from the AmberTools suite. It allows users to write Python scripts to perform a wide range of analyses, such as calculating RMSD, distances, and hydrogen bonds, directly on simulation trajectories. Pytraj enables the creation of complex, automated, and reproducible analysis workflows that integrate seamlessly with other Python data science tools." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -13436,7 +13527,7 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 id: MOLSIM:001582
 name: torch PBSA runtime
 def: "The torch PBSA runtime is a software library that leverages the PyTorch deep learning framework to perform Poisson-Boltzmann Surface Area (PBSA) calculations. By using PyTorch, it can take advantage of GPU acceleration to significantly speed up the computationally intensive process of solving the Poisson-Boltzmann equation. For researchers, this library offers a high-performance tool for estimating solvation free energies as part of binding free energy calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001583
@@ -13464,21 +13555,24 @@ is_a: MOLSIM:001585 ! build system tool
 
 [Term]
 id: MOLSIM:001587
-name: Intel Math Kernel Library
-def: "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+name: Intel oneAPI Math Kernel Library
+def: "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001588
 name: package manager
-def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)" []
+def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments." []
 is_a: MOLSIM:000171 ! software development and management tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001589
 name: Miniconda
-def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)" []
+def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software." []
 is_a: MOLSIM:001588 ! package manager
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001590
@@ -13532,7 +13626,7 @@ is_a: MOLSIM:000157 ! framework
 id: MOLSIM:001598
 name: TCPB-cpp
 def: "TCPB-cpp is a software tool that acts as a bridge, allowing a classical simulation program to communicate with the TeraChem quantum chemistry program. It is a C++ library that provides an Application Programming Interface (API), enabling a molecular dynamics engine to send a small, quantum mechanical (QM) part of the system to TeraChem for a high-performance, GPU-accelerated energy and force calculation. This allows for the creation of powerful and efficient QM/MM simulations, where the speed of a classical simulation is combined with the accuracy of TeraChem's quantum calculations for studying chemical reactions. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001599
@@ -13598,7 +13692,7 @@ is_a: MOLSIM:001970 ! parameter assignment tool
 [Term]
 id: MOLSIM:001608
 name: parmcal
-def: "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
+def: "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
 is_a: MOLSIM:001970 ! parameter assignment tool
 
 [Term]
@@ -13741,8 +13835,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001631
 name: ambpdb
-def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)" []
+def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001632
@@ -13867,20 +13962,22 @@ is_a: MOLSIM:001569 ! utility script
 [Term]
 id: MOLSIM:001652
 name: chamber
-def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)" []
+def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001653
 name: match_atomname
-def: "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)" []
+def: "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001654
 name: MPI library
 def: "An MPI library is a software library that implements the Message Passing Interface (MPI) standard for parallel programming. It provides functions that allow multiple independent processes, typically running on different computers in a cluster, to communicate and exchange data with each other. For high-performance biomolecular simulations, an MPI library is essential for parallelizing the calculations and distributing the workload across many processors to simulate large systems efficiently. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001655
@@ -13892,7 +13989,7 @@ is_a: MOLSIM:001654 ! MPI library
 id: MOLSIM:001656
 name: ARPACK
 def: "ARPACK is a software library for solving large-scale eigenvalue problems, which involve finding the characteristic modes and values of a large matrix. It is particularly efficient at finding a subset of eigenvalues and their corresponding eigenvectors, which is often what is needed in scientific computing. In biomolecular simulation, ARPACK is used in analysis methods like Normal Mode Analysis or Principal Component Analysis to calculate the dominant modes of molecular motion. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001657
@@ -13915,14 +14012,16 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001660
 name: NAB
-def: "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)" []
+def: "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository." []
 is_a: MOLSIM:001659 ! programming language
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001661
 name: FE-ToolKit
-def: "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001662
@@ -13987,27 +14086,29 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001672
 name: GLYCAM-Web
-def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)" []
+def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages." []
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001673
 name: Glycoprotein Builder
-def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)" []
+def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein." []
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001674
 name: RDKit
 def: "RDKit is an open-source software library for cheminformatics, providing a wide range of tools for working with chemical structures. It allows users to read and write molecular file formats, generate 2D and 3D coordinates, calculate molecular descriptors, and perform substructure searching. In the context of biomolecular simulation, RDKit is frequently used in preparatory workflows to process, analyze, and prepare small molecule ligands for subsequent modeling and simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001675
 name: OpenMM
 def: "OpenMM is a high-performance software library that provides a toolkit for running molecular dynamics simulations, with a strong emphasis on GPU acceleration. It is not a monolithic application but rather a flexible library that allows developers to easily add simulation capabilities to their own programs. For the simulation community, OpenMM provides a powerful, hardware-accelerated, and easily customizable platform for developing new simulation methods and applications. (UNVERIFIED)" []
 is_a: MOLSIM:000160 ! molecular dynamics engine
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001676
@@ -14026,30 +14127,32 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:001678
 name: BLAS
 def: "BLAS, or Basic Linear Algebra Subprograms, is a specification that defines a set of low-level routines for performing common linear algebra operations such as vector and matrix multiplication. Highly optimized libraries that implement the BLAS standard are available and provide a foundation for more complex numerical software. For simulation and quantum chemistry programs, using an optimized BLAS library is critical for achieving high performance in matrix-intensive calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001679
 name: LAPACK
 def: "LAPACK, or the Linear Algebra Package, is a standard software library that provides routines for solving more advanced numerical linear algebra problems. It includes functions for solving systems of linear equations, finding eigenvalues and eigenvectors, and performing matrix factorizations. For computational chemistry and simulation analysis tools, LAPACK is an essential component for tasks like matrix diagonalization in Principal Component Analysis or solving equations in quantum mechanical calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001680
 name: DL-Find
-def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001681
 name: sff
 def: "The sff library is a software component, often used with the OpenMM simulation toolkit, for parsing and interpreting force field definition files. It is designed to read standard force field file formats, such as those from AMBER, and make the parameters available to a simulation engine. This library provides the essential function of translating the human-readable force field files into the internal representation needed to calculate forces during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001682
 name: 3DNA
 def: "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures." []
+synonym: "x3DNA" EXACT []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 property_value: IAO:0000117 orcid:0000-0002-4303-9349
 property_value: IAO:0000117 orcid:0000-0002-7544-0938
@@ -14063,8 +14166,9 @@ is_a: MOLSIM:000160 ! molecular dynamics engine
 [Term]
 id: MOLSIM:001684
 name: match analysis tool
-def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)" []
+def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001685
@@ -14438,8 +14542,9 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001743
 name: ICOSA algorithm
-def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)" []
+def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment." []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001744
@@ -14456,9 +14561,10 @@ is_a: MOLSIM:001696 ! analysis algorithm
 [Term]
 id: MOLSIM:001746
 name: DSSP algorithm
-def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)" []
+def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation." []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 disjoint_from: MOLSIM:010012 ! STRIDE algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001747
@@ -14516,6 +14622,7 @@ id: MOLSIM:001755
 name: atom name
 def: "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
@@ -14593,20 +14700,20 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001767
 name: trajectory post-processing
 def: "Trajectory post-processing is the general process of cleaning and preparing raw simulation trajectory files before performing detailed scientific analysis. This typically involves essential steps like removing the overall rotation and translation of a target molecule to keep it centered, and fixing any molecules that appear \"broken\" by the periodic boundary conditions. These routine procedures are necessary to create a clean trajectory that is suitable for correct visualization and accurate calculation of structural properties." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001768
 name: match list preparation
 def: "This is a setup step in some advanced simulation or analysis workflows where a list is created to define a correspondence between atoms in two different molecules or structures. This \"match list\" is essential for methods like alchemical free energy calculations, where it specifies which atom in one molecule transforms into which atom in another. The correct preparation of this list is a critical and often manual step that defines the mapping for the entire transformation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001769
 name: topology and coordinate file preparation
 def: "This is the fundamental setup process in preparing a molecular simulation, where two distinct but essential files are created. The first is the topology file, which defines the molecule's chemical identity, including its atoms, bonds, and force field parameters. The second is the coordinate file, which provides the initial three-dimensional positions of all the atoms, serving as the starting snapshot for the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001770
@@ -14631,13 +14738,13 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001773
 name: LEaP preparation
 def: "LEaP preparation is the process of using the LEaP program from the AmberTools software suite to build a complete molecular system that is ready for simulation. This involves loading a molecular structure file, applying a specific force field to assign parameters, adding a box of solvent molecules, and introducing ions to neutralize the system's charge. This step is the standard and essential procedure for assembling all the necessary components into the final topology and coordinate files needed to run an AMBER simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001774
 name: momentum removal
 def: "Momentum removal is a procedure applied periodically during a molecular dynamics simulation to prevent the entire system from drifting or spinning over time. It works by resetting the total linear and angular momentum of the system to zero at regular intervals, which can otherwise accumulate due to numerical inaccuracies in the integration algorithm. This is a standard housekeeping procedure that ensures the molecule of interest remains centered in the simulation box for easier analysis. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001775
@@ -14679,7 +14786,7 @@ is_a: MOLSIM:001778 ! wavefunction model
 id: MOLSIM:001781
 name: secondary structure
 def: "Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein's overall architecture and how its shape changes during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001333 ! structural property
+is_a: SO:0001078 ! polypeptide_secondary_structure
 
 [Term]
 id: MOLSIM:001782
@@ -14690,38 +14797,48 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001783
 name: parallel beta sheet
-def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)" []
+def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001784
 name: anti-parallel beta sheet
-def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)" []
+def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001785
-name: helix
-def: "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)" []
-is_a: MOLSIM:001781 ! secondary structure
+name: obsolete helix
+def: "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001114
 
 [Term]
 id: MOLSIM:001786
-name: 3-10 helix
-def: "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete 3-10 helix
+def: "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001119
 
 [Term]
 id: MOLSIM:001787
-name: alpha helix
-def: "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete alpha helix
+def: "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001117
 
 [Term]
 id: MOLSIM:001788
-name: pi helix
-def: "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete pi helix
+def: "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001118
 
 [Term]
 id: MOLSIM:001789
@@ -14732,8 +14849,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001790
 name: bend
-def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)" []
+def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001791
@@ -14744,8 +14862,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001792
 name: beta bridge
-def: "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)" []
+def: "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001793
@@ -14764,8 +14883,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001795
 name: MDL solvent model format
-def: "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)" []
+def: "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions." []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001796
@@ -15114,13 +15234,14 @@ is_a: MOLSIM:001463 ! QM/MM model component
 id: MOLSIM:001849
 name: convergence analysis
 def: "Convergence analysis is the process of checking whether a simulation has been run for a sufficient amount of time to provide a stable and reliable result. This is typically done by monitoring a key property, such as the system's energy or a structural measurement, to see if its average value stops changing and remains steady over the later parts of the simulation. Performing this analysis is a critical step to ensure that the calculated properties are statistically meaningful and not just an artifact of a short, unrepresentative trajectory. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001850
 name: modeling and setup tool
-def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)" []
+def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation." []
 is_a: MOLSIM:000158 ! simulation and modeling software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001851
@@ -15176,7 +15297,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001859
 name: network analysis
 def: "Network analysis is a method that represents a molecule as a graph of nodes (atoms or residues) connected by edges (interactions or correlations) to analyze how information is communicated through its structure. By applying graph theory, this approach can identify critical residues that act as communication hubs and map the pathways of correlated motion that connect distant parts of the molecule. This is a powerful tool for understanding allosteric regulation and the long-range effects of mutations. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001860
@@ -15188,7 +15309,7 @@ is_a: MOLSIM:000917 ! structural analysis
 id: MOLSIM:001861
 name: ligand analysis
 def: "Ligand analysis is a broad category of methods focused on characterizing the behavior of a small molecule, or ligand, during a simulation of its complex with a larger receptor. This includes analyzing the stability of its binding pose, its internal flexibility and conformational changes, and its specific interactions with the protein or nucleic acid. These analyses are fundamental to structure-based drug design for understanding the determinants of binding affinity and specificity. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001862
@@ -15220,21 +15341,22 @@ is_a: MOLSIM:001403 ! statistical property
 [Term]
 id: MOLSIM:001866
 name: backbone DH fluctuations
-def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)" []
+def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001867
 name: membrane analysis
 def: "Membrane analysis is a category of analysis methods specifically focused on characterizing the properties of lipid bilayer simulations. These methods are used to quantify the structural and dynamic behavior of the membrane itself and its interactions with other molecules, like embedded proteins. This includes calculating key properties such as the area per lipid, membrane thickness, and lipid order parameters to validate the simulation and understand membrane function." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
 id: MOLSIM:001868
 name: area per lipid
 def: "The area per lipid is a fundamental biophysical metric representing the average cross-sectional surface area occupied by a single lipid molecule within a lipid bilayer. It is calculated by dividing the total area of the simulation box in the membrane plane by the number of lipids in one leaflet." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -15355,7 +15477,7 @@ is_a: MOLSIM:000342 ! correlation analysis
 id: MOLSIM:001885
 name: trajectory meta analysis
 def: "Trajectory meta-analysis refers to a higher level of analysis that involves comparing, contrasting, or combining the results from multiple, independent simulation trajectories. This can be used to improve statistical certainty, assess the convergence of a simulation, or identify the differences in dynamics between a wild-type protein and a mutant. This approach is essential for drawing robust conclusions that are not dependent on a single simulation run." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -15381,8 +15503,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001889
 name: complex system
-def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)" []
+def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together." []
 is_a: MOLSIM:001887 ! molecular simulation system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001890
@@ -15414,8 +15537,9 @@ is_a: MOLSIM:001890 ! ligand complex system
 [Term]
 id: MOLSIM:001894
 name: hybrid complex system
-def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)" []
+def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair." []
 is_a: MOLSIM:001889 ! complex system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001895
@@ -15576,7 +15700,7 @@ id: MOLSIM:001918
 name: MDAnalysis
 def: "MDAnalysis is an open-source Python library used for the analysis of molecular dynamics simulation trajectories. It provides a flexible and object-oriented framework that allows users to read, write, and manipulate atomic coordinate data from a wide variety of simulation packages. MDAnalysis is a powerful tool for writing custom, complex, and reproducible analysis scripts in a familiar Python environment." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -15584,41 +15708,44 @@ id: MOLSIM:001919
 name: MDTraj
 def: "MDTraj is a modern, open-source Python library designed for the fast and efficient analysis of molecular dynamics trajectories. It excels at reading and writing a very broad range of trajectory and topology file formats, making it highly interoperable. MDTraj provides a fast and powerful toolkit for performing common structural and time-series analyses on simulation data." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001920
 name: ProDy
 def: "ProDy is a free and open-source Python package for analyzing protein structural dynamics. It provides a comprehensive set of tools for tasks such as parsing structure files, analyzing conformational ensembles, and calculating collective modes of motion using methods like Normal Mode Analysis. For researchers studying protein function, ProDy offers a powerful environment for exploring the link between a protein's structure and its dynamic behavior. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001921
 name: BioBB
 def: "BioBB, or BioExcel Building Blocks, is a library of Python wrappers that create a standardized interface for many common biomolecular simulation programs like GROMACS and AmberTools. Each building block performs a specific task, such as running an energy minimization or calculating an RMSD, using a consistent input and output format. For computational biologists, BioBB provides an interoperable toolkit for constructing complex, reproducible, and portable simulation workflows." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001922
 name: 3DMol.js
-def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001923
 name: NGL
-def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001924
 name: Open Babel
-def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)" []
+def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files." []
 is_a: MOLSIM:000166 ! file conversion tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001925
@@ -15635,15 +15762,17 @@ is_a: MOLSIM:000251 ! trajectory processing tool
 [Term]
 id: MOLSIM:001927
 name: CHARMM-GUI
-def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)" []
+def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations." []
 is_a: MOLSIM:000225 ! membrane packing tool
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001928
 name: Modeller
-def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)" []
+def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation." []
 is_a: MOLSIM:001958 ! homology modeling tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001929
@@ -15667,15 +15796,17 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001932
 name: Jmol
-def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)" []
+def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001933
 name: MolStar
-def: "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)" []
+def: "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies." []
 synonym: "Mol*" EXACT []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001934
@@ -15812,8 +15943,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001955
 name: crystallographic build tool
-def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)" []
+def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment." []
 is_a: MOLSIM:001556 ! system setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001956
@@ -15830,14 +15962,16 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:001958
 name: homology modeling tool
-def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)" []
+def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001959
 name: AutoDock Vina
-def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)" []
+def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001960
@@ -15873,14 +16007,16 @@ is_a: MOLSIM:001684 ! match analysis tool
 [Term]
 id: MOLSIM:001965
 name: DALI
-def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)" []
+def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001966
 name: LS-align
-def: "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)" []
+def: "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001967
@@ -15898,8 +16034,9 @@ is_a: MOLSIM:001564 ! free energy analysis tool
 [Term]
 id: MOLSIM:001969
 name: free energy surface analysis tool
-def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)" []
+def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates." []
 is_a: MOLSIM:001564 ! free energy analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001970
@@ -15954,7 +16091,7 @@ is_a: MOLSIM:001531 ! united-atom force field
 id: MOLSIM:001978
 name: PLUMED
 def: "PLUMED is an open-source software library designed to analyze molecular dynamics simulations and perform enhanced sampling of free energy landscapes. It functions as middleware that interfaces with various simulation engines to calculate collective variables and apply biasing potentials in real-time." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -16060,8 +16197,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001995
 name: position restraints
-def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)" []
+def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol." []
 is_a: MOLSIM:001552 ! restraint potential
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001996
@@ -16157,7 +16295,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:002010
 name: solvation
 def: "Solvation is the computational process of immersing a solute molecule, such as a protein, into a box containing solvent molecules, typically water. This step involves placing the solute coordinates into a pre-equilibrated solvent box, removing solvent molecules that overlap with the solute atoms, and updating the system topology. For experts, this process defines the simulation box dimensions, density, and total number of atoms, which are critical for the efficiency and validity of periodic boundary condition simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:002011
@@ -16168,8 +16306,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:002012
 name: continuation state
-def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)" []
+def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002013
@@ -16335,28 +16474,32 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:002039
 name: atom ID
-def: "An atom ID is usually a number, that uniquely defines a given atom in structure." []
+def: "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
 id: MOLSIM:002040
 name: JSmol
-def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)" []
+def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002041
 name: molecular structure visualization tool
-def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)" []
+def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships." []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002042
 name: data plotting tool
-def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)" []
+def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files." []
 synonym: "data visualization tool" EXACT []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002043
@@ -16387,33 +16530,36 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:002047
 name: OpenMPI
 def: "Open MPI is an open-source, freely available implementation of the Message Passing Interface (MPI) standard. It is widely used in high-performance computing to facilitate communication between distributed processes. In biomolecular simulation, it is a standard library used to compile and run parallel simulation engines, such as GROMACS, LAMMPS, and NAMD, across multiple nodes of a computer cluster to ensure efficient scaling and data exchange. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002048
 name: MPICH
 def: "MPICH is a highly efficient, open-source implementation of the Message Passing Interface (MPI) standard. It serves as both a widely used standalone MPI library for high-performance computing and as the foundational framework for many other vendor-specific or derivative MPI implementations (such as Intel MPI and MVAPICH). For biomolecular simulations on distributed-memory supercomputers, MPICH provides the essential message-passing infrastructure required for large-scale parallelization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement." []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations." []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002052
@@ -16462,10 +16608,11 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms." []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002059
@@ -16477,8 +16624,9 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002060
 name: docking log format
-def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)" []
+def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files." []
 is_a: MOLSIM:000715 ! prediction data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002061
@@ -16490,11 +16638,12 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002062
 name: Maestro format
-def: "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)" []
+def: "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties." []
 synonym: "mae format" EXACT []
 synonym: "maegz format" EXACT []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002063
@@ -16724,411 +16873,418 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:002098
 name: restart simulation process
-def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)" []
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:002099
 name: metadata extraction tool
-def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000165 ! data processing tool
 
 [Term]
 id: MOLSIM:002100
 name: PMEMD.cuda
-def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)" []
 is_a: MOLSIM:001669 ! PMEMD
 
 [Term]
 id: MOLSIM:002101
 name: metadata validation process
-def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002102
 name: coordinate wrapping process
-def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)" []
 is_a: MOLSIM:001767 ! trajectory post-processing
 
 [Term]
 id: MOLSIM:002103
 name: NMR restrained simulation
-def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)" []
 is_a: MOLSIM:000364 ! restrained simulation method
 
 [Term]
 id: MOLSIM:002104
 name: belly dynamics
-def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)" []
 is_a: MOLSIM:000335 ! restrained subset dynamics
 
 [Term]
 id: MOLSIM:002105
 name: replica exchange attempt frequency
-def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)" []
 is_a: MOLSIM:001219 ! enhanced sampling parameter
 
 [Term]
 id: MOLSIM:002106
 name: center of mass removal interval
-def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002107
 name: multi-timestep inner loop count
-def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002108
 name: output control parameter
-def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002109
 name: energy output interval
-def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002110
 name: restart output interval
-def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002111
 name: log output interval
-def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002112
 name: simulation state time
-def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:001083 ! simulation state
 
 [Term]
 id: MOLSIM:002113
 name: final density
-def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002114
 name: computational performance metric
-def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)" []
 is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:002115
 name: total wallclock time
-def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 disjoint_from: MOLSIM:002116 ! total cpu time
 
 [Term]
 id: MOLSIM:002116
 name: total cpu time
-def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002117
 name: setup wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002118
 name: production wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002119
 name: average integration step time
-def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002120
 name: simulation throughput
-def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002155
 name: simulation protocol
-def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002156
 name: simulation stage
-def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)" []
 is_a: MOLSIM:000000 ! molecular dynamics process
 
 [Term]
 id: MOLSIM:002157
 name: simulation parameter schedule
-def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002158
 name: simulation continuity check
-def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002159
 name: cross-source validation
-def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002160
 name: file parsing error
-def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002161
 name: file format convention
-def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)" []
 is_a: MOLSIM:000436 ! data format
 
 [Term]
 id: MOLSIM:002162
 name: system classification label
-def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002163
 name: atom selection mask
-def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002164
 name: trajectory frame interval
-def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 disjoint_from: MOLSIM:002165 ! inter-stage time gap
 
 [Term]
 id: MOLSIM:002165
 name: inter-stage time gap
-def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 
 [Term]
 id: MOLSIM:002166
 name: hydrogen detection strategy
-def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)" []
 is_a: MOLSIM:001696 ! analysis algorithm
 
 [Term]
 id: MOLSIM:002192
 name: initial density
-def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002196
 name: atom count consistency check
-def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 disjoint_from: MOLSIM:002197 ! box consistency check
 
 [Term]
 id: MOLSIM:002197
 name: box consistency check
-def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002198
 name: timing consistency check
-def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002199
 name: sampling consistency check
-def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002203
 name: protein domain
-def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)" []
+def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains." []
 is_a: SO:0000417 ! polypeptide_domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002204
 name: receptor-binding domain
-def: "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)" []
+def: "A protein domain whose function is to attach to a matching partner molecule called a receptor." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002205
 name: catalytic domain
-def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)" []
+def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002206
 name: protein functional class label
-def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002207
 name: enzyme classification label
-def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002208
 name: transport protein classification label
-def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002209
 name: structural protein classification label
-def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002210
 name: regulatory protein classification label
-def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002211
 name: signaling protein classification label
-def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002212
 name: motor protein classification label
-def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002213
 name: immune protein classification label
-def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002214
 name: storage protein classification label
-def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002226
 name: periodic box angles
-def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)" []
 is_a: MOLSIM:001210 ! system setup parameter
 
 [Term]
 id: MOLSIM:002230
 name: SMILES code
-def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)" []
 is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:002232
 name: compiler
-def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)" []
 is_a: MOLSIM:000171 ! software development and management tool
 
 [Term]
 id: MOLSIM:002233
 name: atom index group
-def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002234
 name: classical molecular dynamics
-def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000843 ! molecular dynamics
 
 [Term]
 id: MOLSIM:002235
 name: source structure residue mapping
-def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002236
 name: oligomeric state
-def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)" []
 is_a: MOLSIM:001333 ! structural property
 
 [Term]
 id: MOLSIM:002237
 name: monomeric state
-def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 disjoint_from: MOLSIM:002238 ! dimeric state
 
 [Term]
 id: MOLSIM:002238
 name: dimeric state
-def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002239
 name: trimeric state
-def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002240
 name: tetrameric state
-def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002241
 name: higher-order oligomeric state
-def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002246
 name: spike opening conformational state
-def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)" []
 is_a: MOLSIM:000105 ! conformational state
 
 [Term]
 id: MOLSIM:002247
 name: biological strain classification label
-def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002248
 name: histone variant classification label
-def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
+
+[Term]
+id: MOLSIM:002249
+name: DSSR
+def: "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)" []
+synonym: "Dissecting the Spatial Structure of RNA" EXACT []
+is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
 id: MOLSIM:010001
@@ -17437,6 +17593,73 @@ synonym: "polypeptide structural region" EXACT []
 synonym: "structural_region" RELATED []
 is_a: MOLSIM:002090 ! molecular entity
 is_a: SO:0000839 ! polypeptide_region
+
+[Term]
+id: SO:0001078
+name: polypeptide_secondary_structure
+namespace: sequence
+alt_id: BS:00003
+def: "A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain." [EBIBS:GAR]
+comment: Biosapien term was secondary_structure.
+subset: biosapiens
+synonym: "2nary structure" RELATED BS []
+synonym: "polypeptide secondary structure" EXACT []
+synonym: "secondary structure" RELATED BS []
+synonym: "secondary structure region" RELATED BS []
+synonym: "secondary_structure" RELATED BS []
+xref: http://en.wikipedia.org/wiki/Secondary_structure "wiki"
+is_a: SO:0001070 ! polypeptide_structural_region
+
+[Term]
+id: SO:0001114
+name: peptide_helix
+namespace: sequence
+alt_id: BS:00152
+def: "A helix is a secondary_structure conformation where the peptide backbone forms a coil." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "helix" RELATED BS []
+is_a: MOLSIM:001781 ! secondary structure
+
+[Term]
+id: SO:0001117
+name: alpha_helix
+namespace: sequence
+alt_id: BS:00040
+def: "The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "a-helix" RELATED BS []
+synonym: "helix" RELATED BS [uniprot:feature_type]
+xref: http://en.wikipedia.org/wiki/Alpha_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
+
+[Term]
+id: SO:0001118
+name: pi_helix
+namespace: sequence
+alt_id: BS:00153
+def: "The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "pi helix" EXACT []
+xref: http://en.wikipedia.org/wiki/Pi_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
+
+[Term]
+id: SO:0001119
+name: three_ten_helix
+namespace: sequence
+alt_id: BS:0000340
+def: "The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "3(10) helix" EXACT []
+synonym: "3-10 helix" EXACT []
+synonym: "310 helix" EXACT []
+synonym: "three ten helix" EXACT []
+xref: http://en.wikipedia.org/wiki/310_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
 
 [Term]
 id: SO:0001236
@@ -18054,7 +18277,7 @@ range: MOLSIM:000001 ! software
 id: MOLSIM:000507
 name: alignment tool
 def: "In molecular dynamics, alignment tool provides spatial re-orientation of membrane proteins with respect to the hydrocarbon core of the lipid bilayer. It connects a structural alignment procedure or analysis step to the specific software program or tool used to perform the alignment of molecular structures. Structural alignment is used to superimpose molecular structures (e.g., proteins, nucleic acids) to compare their conformations or identify conserved regions. This property identifies the computational tool responsible for generating the alignment. (UNVERIFIED)" []
-domain: MOLSIM:000004 ! analysis
+domain: MOLSIM:000004 ! simulation analysis
 range: MOLSIM:000001 ! software
 
 [Typedef]
@@ -18095,14 +18318,14 @@ range: MOLSIM:001994 ! reaction coordinate
 [Typedef]
 id: MOLSIM:002167
 name: has simulation stage
-def: "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)" []
-domain: MOLSIM:002155 ! simulation protocol
+def: "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002156 ! simulation stage
 
 [Typedef]
 id: MOLSIM:002168
 name: has parameter schedule
-def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002157 ! simulation parameter schedule
 is_a: MOLSIM:002202 ! has simulation parameter
@@ -18110,44 +18333,51 @@ is_a: MOLSIM:002202 ! has simulation parameter
 [Typedef]
 id: MOLSIM:002169
 name: has continuity check
-def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002158 ! simulation continuity check
 
 [Typedef]
 id: MOLSIM:002170
 name: has parsing error
-def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002160 ! file parsing error
 
 [Typedef]
 id: MOLSIM:002171
 name: has system classification
-def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)" []
 domain: MOLSIM:001887 ! molecular simulation system
 range: MOLSIM:002162 ! system classification label
 
 [Typedef]
 id: MOLSIM:002172
 name: has format convention
-def: "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)" []
 domain: MOLSIM:000436 ! data format
 range: MOLSIM:002161 ! file format convention
 
 [Typedef]
 id: MOLSIM:002173
 name: has restraint mask
-def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002163 ! atom selection mask
 
 [Typedef]
 id: MOLSIM:002202
 name: has simulation parameter
-def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:001164 ! simulation parameter
+
+[Typedef]
+id: MOLSIM:002250
+name: follows protocol
+def: "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
+range: MOLSIM:002155 ! simulation protocol
 
 [Typedef]
 id: OBI:0000299

--- a/molsim-full.owl
+++ b/molsim-full.owl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/molsim/molsim-full.owl#"
      xml:base="http://purl.obolibrary.org/obo/molsim/molsim-full.owl"
-     xmlns:dce="http://purl.org/dc/elements/1.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -17,9 +17,14 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim/molsim-full.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim-full.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim-full.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0001-8613-1447"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0003-4846-8051"/>
@@ -30,7 +35,8 @@
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
         <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
         <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
-        <owl:versionInfo>2026-07-29</owl:versionInfo>
+        <rdfs:comment xml:lang="en">Scope note: MOLSIM&apos;s boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.</rdfs:comment>
+        <owl:versionInfo>2026-08-07</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -197,7 +203,9 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
+    </owl:AnnotationProperty>
     
 
 
@@ -240,12 +248,6 @@ We also have the outstanding issue of how to aim different definitions to differ
     <!-- http://purl.org/dc/elements/1.1/source -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/BibliographicResource -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/BibliographicResource"/>
     
 
 
@@ -692,9 +694,9 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002167">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation stage</rdfs:label>
     </owl:ObjectProperty>
     
@@ -706,7 +708,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002202"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002157"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parameter schedule</rdfs:label>
     </owl:ObjectProperty>
     
@@ -718,7 +720,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002158"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has continuity check</rdfs:label>
     </owl:ObjectProperty>
     
@@ -730,7 +732,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002160"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parsing error</rdfs:label>
     </owl:ObjectProperty>
     
@@ -742,7 +744,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has system classification</rdfs:label>
     </owl:ObjectProperty>
     
@@ -754,7 +756,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has format convention</rdfs:label>
     </owl:ObjectProperty>
     
@@ -766,7 +768,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002163"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint mask</rdfs:label>
     </owl:ObjectProperty>
     
@@ -778,8 +780,20 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation parameter</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002250 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002250">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">follows protocol</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -1531,7 +1545,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002121">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">first solvent molecule index</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1542,7 +1556,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002122">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of solvent molecules</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1553,7 +1567,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002123">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of atoms per frame</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1564,7 +1578,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
@@ -1576,7 +1590,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002125">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total angles</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1587,7 +1601,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002126">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total dihedrals</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1598,7 +1612,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002127">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001139"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of constraint failures</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1609,7 +1623,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002128">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has completion status</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1620,7 +1634,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002129">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">continuation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1631,7 +1645,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002130">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1642,7 +1656,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002131">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QM/MM activation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1653,7 +1667,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002132">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">self-guided Langevin dynamics flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1664,7 +1678,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002133">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spherical cap flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1675,7 +1689,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002134">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has box dimensions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1686,7 +1700,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002135">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has velocities flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1697,7 +1711,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002136">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box type flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1707,7 +1721,7 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002137">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory metadata descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1718,7 +1732,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002138">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of frames</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1729,7 +1743,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002139">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate format specifier</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1740,7 +1754,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002140">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural and dimensional arrays</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1751,7 +1765,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002141">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1762,7 +1776,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002142">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1773,7 +1787,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002143">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system nomenclature descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1784,7 +1798,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002144">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent residue name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1795,7 +1809,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002145">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue labels</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1806,7 +1820,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002146">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique residue names</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1817,7 +1831,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002147">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique atom types</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1828,7 +1842,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002148">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">born radii set name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1839,7 +1853,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002149">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log and validation descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1850,7 +1864,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002150">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has error message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1861,7 +1875,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002151">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has warning message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1872,7 +1886,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002152">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation warning</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1883,7 +1897,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002153">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation error</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1894,7 +1908,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002154">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">consistency check result</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1905,7 +1919,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002179">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has coordinates array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1916,7 +1930,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002180">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1927,7 +1941,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002181">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has time array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1938,7 +1952,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002182">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has NMR restraints active</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1949,7 +1963,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002183">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is degraded extraction mode</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1960,7 +1974,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002184">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has temperature schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1971,7 +1985,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002185">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1982,7 +1996,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002186">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has cutoff schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1993,7 +2007,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002187">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">force field feature</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2004,7 +2018,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002188">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue composition map</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2015,7 +2029,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002189">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">raw control parameters</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2026,7 +2040,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002190">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">REMD variant type</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2037,7 +2051,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002191">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart file path</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2048,7 +2062,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002193">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is charge neutral</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2059,7 +2073,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002194">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen mass summary</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2071,7 +2085,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001941"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">gpu model name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2082,7 +2096,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002200">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">HMR inferred from timestep flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2094,7 +2108,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total simulation steps</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2105,7 +2119,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002215">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2116,7 +2130,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002216">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2127,7 +2141,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002217">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2138,7 +2152,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002218">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ion atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2149,7 +2163,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002219">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2160,7 +2174,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002220">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">other atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2171,7 +2185,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002221">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2182,7 +2196,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002222">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2193,7 +2207,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002223">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2204,7 +2218,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002224">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleosomes</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2215,7 +2229,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002225">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleotides per DNA strand</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2226,7 +2240,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002227">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box angles array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2237,7 +2251,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002228">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has positions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2248,7 +2262,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002229">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2260,7 +2274,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">software version</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2271,7 +2285,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002242">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains antibody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2282,7 +2296,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002243">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains nanobody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2293,7 +2307,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002244">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains linker histone</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2304,7 +2318,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002245">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone tails present</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -15943,7 +15957,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000000">
-        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics process</rdfs:label>
     </owl:Class>
     
@@ -15961,9 +15976,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">preparation</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">preparation</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation preparation</rdfs:label>
     </owl:Class>
     
 
@@ -15971,9 +15987,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">execution</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
+        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">execution</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation execution</rdfs:label>
     </owl:Class>
     
 
@@ -15981,9 +15999,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000004">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">analysis</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">analysis</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation analysis</rdfs:label>
     </owl:Class>
     
 
@@ -16024,7 +16043,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000772"/>
         <obo:IAO_0000115 xml:lang="en">A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">lipid  force field</rdfs:label>
+        <rdfs:label xml:lang="en">lipid force field</rdfs:label>
     </owl:Class>
     
 
@@ -16146,7 +16165,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000008"/>
-        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It&apos;s designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">lipid17</rdfs:label>
     </owl:Class>
     
@@ -16729,6 +16749,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
         <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1.</obo:IAO_0000116>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16848,7 +16869,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -17128,7 +17150,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000245"/>
         <obo:IAO_0000115 xml:lang="en">HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
-        <dcterms:BibliographicResource>https://doi.org/10.1016/S0263-7855(97)00009-X</dcterms:BibliographicResource>
+        <oboInOwl:hasDbXref>https://doi.org/10.1016/S0263-7855(97)00009-X</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">HOLE</rdfs:label>
     </owl:Class>
     
@@ -17560,7 +17582,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS mdp format</rdfs:label>
     </owl:Class>
     
@@ -17603,7 +17626,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001851"/>
-        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics engine</rdfs:label>
     </owl:Class>
     
@@ -17623,7 +17647,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking tool</rdfs:label>
     </owl:Class>
     
@@ -17643,7 +17668,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">analysis tool</rdfs:label>
     </owl:Class>
     
@@ -17653,7 +17679,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">data processing tool</rdfs:label>
     </owl:Class>
     
@@ -17663,7 +17690,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">file conversion tool</rdfs:label>
     </owl:Class>
     
@@ -18107,6 +18135,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
         <obo:IAO_0000115 xml:lang="en">A step within the preparation or equilibration phase where the system&apos;s temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">heating</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">thermalization</rdfs:label>
     </owl:Class>
     
@@ -18116,7 +18145,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
-        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">equilibration</rdfs:label>
     </owl:Class>
     
@@ -18242,7 +18272,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000221">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000223"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDB2PQR</rdfs:label>
     </owl:Class>
     
@@ -18252,7 +18283,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000222">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ligand protonation tool</rdfs:label>
     </owl:Class>
     
@@ -18262,7 +18294,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000223">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">generic protonation tool</rdfs:label>
     </owl:Class>
     
@@ -18302,7 +18335,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000227">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">membrane protein orientation tool</rdfs:label>
     </owl:Class>
     
@@ -18312,7 +18346,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000228">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
-        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein&apos;s position and orientation to minimize the calculated free energy of transferring the protein&apos;s amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">memembed</rdfs:label>
     </owl:Class>
     
@@ -18439,7 +18474,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pKa tool</rdfs:label>
     </owl:Class>
     
@@ -18469,7 +18505,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000243">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">in-silico mutagenesis tool</rdfs:label>
     </owl:Class>
     
@@ -19111,7 +19148,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000305">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000140"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include &quot;molecular docking,&quot; &quot;homology modeling,&quot; &quot;scoring function,&quot; and &quot;binding pose prediction.&quot; (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling method</rdfs:label>
     </owl:Class>
     
@@ -19162,8 +19200,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
         <obo:IAO_0000115 xml:lang="en">A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled &quot;Experimental Design,&quot; &quot;Study Protocol,&quot; &quot;Selection Criteria,&quot; or &quot;Computational Strategy.&quot; (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)</rdfs:comment>
+        <rdfs:comment xml:lang="en">Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.</rdfs:comment>
         <rdfs:label xml:lang="en">plan specification</rdfs:label>
     </owl:Class>
     
@@ -19173,7 +19212,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000311">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">RMSD analysis is a calculation that measures how much a molecule&apos;s shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A calculation that measures how much a molecule&apos;s shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">RMSD analysis</rdfs:label>
     </owl:Class>
@@ -20610,10 +20649,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000448 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000448">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
-        <rdfs:label xml:lang="en">protein database ID</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete protein database ID</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20802,7 +20841,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">OPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">orientations of proteins in membranes</rdfs:label>
     </owl:Class>
@@ -20835,7 +20875,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER mdin format</rdfs:label>
     </owl:Class>
     
@@ -20857,7 +20898,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER restart format</rdfs:label>
     </owl:Class>
     
@@ -20940,7 +20982,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000478"/>
-        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Connolly surface analysis</rdfs:label>
     </owl:Class>
     
@@ -20959,10 +21002,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000481 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000481">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
-        <rdfs:label xml:lang="en">2D RMSD analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000311"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with &apos;RMSD analysis&apos; (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term&apos;s definition. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 2D RMSD analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22089,7 +22133,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000596">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000590"/>
-        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">.grid</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">grid format</rdfs:label>
     </owl:Class>
@@ -22867,7 +22912,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000670">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate centering analysis</rdfs:label>
     </owl:Class>
     
@@ -22958,6 +23004,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with its former parent &apos;periodic boundary imaging&apos; (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term&apos;s definition now states so. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -23030,7 +23078,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000686 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000686">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., &apos;1TIM&apos;, &apos;6M0J&apos;) serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDB ID</rdfs:label>
     </owl:Class>
@@ -23040,7 +23088,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000687 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000687">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A UniProt ID, more formally known as a UniProt Accession Number (e.g., &apos;P00761&apos;, &apos;Q8WZ42&apos;), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Uniprot ID</rdfs:label>
     </owl:Class>
@@ -23243,7 +23291,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000706">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000703"/>
-        <obo:IAO_0000115 xml:lang="en">A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pathway database</rdfs:label>
     </owl:Class>
     
@@ -23487,7 +23536,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000741">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff02</rdfs:label>
     </owl:Class>
     
@@ -23598,7 +23648,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000752">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM 19</rdfs:label>
     </owl:Class>
     
@@ -23818,7 +23869,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000774">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001664"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Abalone</rdfs:label>
     </owl:Class>
     
@@ -23848,7 +23900,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000777">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Desmond</rdfs:label>
     </owl:Class>
     
@@ -23938,7 +23991,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000786">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD</rdfs:label>
     </owl:Class>
     
@@ -24515,7 +24569,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000843">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000308"/>
-        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">MD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">molecular dynamics</rdfs:label>
     </owl:Class>
@@ -24778,7 +24833,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000867">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000438"/>
-        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM input format</rdfs:label>
     </owl:Class>
     
@@ -24820,8 +24876,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000871">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">GROMACS input  format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">GROMACS input format</rdfs:label>
     </owl:Class>
     
 
@@ -24870,7 +24927,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000876">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD configuration format</rdfs:label>
     </owl:Class>
     
@@ -24880,7 +24938,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000877">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000437"/>
-        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem input format</rdfs:label>
     </owl:Class>
     
@@ -24922,7 +24981,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000881">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM output format</rdfs:label>
     </owl:Class>
     
@@ -24962,7 +25022,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000885">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS output format</rdfs:label>
     </owl:Class>
     
@@ -25042,7 +25103,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000893">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem restart format</rdfs:label>
     </owl:Class>
     
@@ -25095,7 +25157,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000898">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS include topology format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS itp format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">itp format</rdfs:label>
@@ -25140,7 +25203,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000902">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dcd format</rdfs:label>
     </owl:Class>
     
@@ -25171,6 +25235,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -25319,7 +25384,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crd format</rdfs:label>
     </owl:Class>
     
@@ -25445,7 +25511,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000941">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000305"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate rotation modeling</rdfs:label>
     </owl:Class>
     
@@ -25614,15 +25681,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER inpcrd format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmcrd format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format.
-
-The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. 
-
-Users can interact with it using file-based commands:
-
-Loading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.
-
-Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
+        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format. The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
         <rdfs:label xml:lang="en">AMBER crd format</rdfs:label>
     </owl:Class>
     
@@ -26009,13 +26068,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
         <obo:IAO_0000115 xml:lang="en">The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential &quot;frames&quot; where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER trj format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:
-
-vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.
-
-vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.
-
-vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
         <rdfs:label xml:lang="en">trj format</rdfs:label>
     </owl:Class>
     
@@ -26025,14 +26078,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010020"/>
-        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">Common examples include:
-
-- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.
-
-- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.
-
-- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:comment xml:lang="en">Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
         <rdfs:label xml:lang="en">distance matrix format</rdfs:label>
     </owl:Class>
     
@@ -26044,8 +26092,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001040"/>
         <obo:IAO_0000115 xml:lang="en">The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.xpm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">xpm  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">xpm format</rdfs:label>
     </owl:Class>
     
 
@@ -26055,8 +26103,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
         <obo:IAO_0000115 xml:lang="en">The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parmtop format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmtop format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">parm7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">prmtop format</rdfs:label>
     </owl:Class>
     
@@ -26065,11 +26116,13 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001042"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">parm7 format</rdfs:label>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete parm7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26139,7 +26192,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">restrt format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">rst7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">rst format</rdfs:label>
     </owl:Class>
     
@@ -26148,9 +26203,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">rst7 format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001049"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete rst7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26251,8 +26308,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
         <obo:IAO_0000115 xml:lang="en">The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.conflib</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">conflib  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">conflib format</rdfs:label>
     </owl:Class>
     
 
@@ -26284,7 +26341,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym>.pqr</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">pqr format</rdfs:label>
     </owl:Class>
@@ -26296,7 +26354,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001063">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Molecular Operating Environment</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MOE</rdfs:label>
     </owl:Class>
@@ -26394,8 +26453,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001072 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001072">
-        <obo:IAO_0000115>An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
-        <dcterms:BibliographicResource></dcterms:BibliographicResource>
+        <obo:IAO_0000115 xml:lang="en">An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">information content entity</rdfs:label>
     </owl:Class>
     
@@ -26405,7 +26463,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001073">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular system specification</rdfs:label>
     </owl:Class>
     
@@ -26555,6 +26614,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -26576,6 +26636,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Related discussion in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -26681,7 +26742,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002066"/>
         <obo:IAO_0000115 xml:lang="en">The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)</obo:IAO_0000115>
-        <oboInOwl:hasExactSynonym xml:lang="en">skf  format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">skf format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">DFTB parameter format</rdfs:label>
     </owl:Class>
     
@@ -26875,7 +26936,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER mdinfo format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">mdinfo format</rdfs:label>
     </owl:Class>
@@ -26886,7 +26948,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001671"/>
-        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">database web server</rdfs:label>
     </owl:Class>
     
@@ -27299,7 +27362,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">constraint and restraint parameter</rdfs:label>
     </owl:Class>
     
@@ -27444,7 +27508,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001215">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">alchemical transformation state</rdfs:label>
     </owl:Class>
     
@@ -27454,7 +27519,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001216">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">number of replicates</rdfs:label>
     </owl:Class>
     
@@ -28707,7 +28773,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000328"/>
-        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hydrogen mass repartitioning analysis</rdfs:label>
     </owl:Class>
     
@@ -28737,7 +28804,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dihedral angle</rdfs:label>
     </owl:Class>
     
@@ -29031,7 +29099,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001358"/>
-        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">base pair step parameter</rdfs:label>
     </owl:Class>
     
@@ -29730,7 +29799,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000860"/>
-        <obo:IAO_0000115 xml:lang="en">The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (&quot;images&quot;) along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">adaptive string method</rdfs:label>
     </owl:Class>
     
@@ -29833,7 +29903,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03</rdfs:label>
     </owl:Class>
     
@@ -29843,7 +29914,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03ua</rdfs:label>
     </owl:Class>
     
@@ -30363,7 +30435,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic model component</rdfs:label>
     </owl:Class>
     
@@ -30727,7 +30800,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber fb15 is a specific &quot;recipe&quot; or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber fb15</rdfs:label>
     </owl:Class>
     
@@ -31001,7 +31075,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001558">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">electrostatics analysis tool</rdfs:label>
     </owl:Class>
     
@@ -31081,8 +31156,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001566">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000170"/>
-        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">library</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">software library</rdfs:label>
     </owl:Class>
     
 
@@ -31141,7 +31218,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001572">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001969"/>
-        <obo:IAO_0000115 xml:lang="en">ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ndfes</rdfs:label>
     </owl:Class>
     
@@ -31151,7 +31229,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001573">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ParmEd</rdfs:label>
     </owl:Class>
     
@@ -31294,8 +31373,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001587">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Intel Math Kernel Library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">Intel oneAPI Math Kernel Library</rdfs:label>
     </owl:Class>
     
 
@@ -31304,7 +31384,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001588">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">package manager</rdfs:label>
     </owl:Class>
     
@@ -31314,7 +31395,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001589">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001588"/>
-        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Miniconda</rdfs:label>
     </owl:Class>
     
@@ -31510,7 +31592,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001608">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001970"/>
-        <obo:IAO_0000115 xml:lang="en">an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parmcal</rdfs:label>
     </owl:Class>
     
@@ -31745,7 +31827,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001631">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ambpdb</rdfs:label>
     </owl:Class>
     
@@ -31955,7 +32038,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001652">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">chamber</rdfs:label>
     </owl:Class>
     
@@ -31965,7 +32049,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001653">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match_atomname</rdfs:label>
     </owl:Class>
     
@@ -32035,7 +32120,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001660">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001659"/>
-        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAB</rdfs:label>
     </owl:Class>
     
@@ -32045,7 +32131,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001661">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">FE-ToolKit</rdfs:label>
     </owl:Class>
     
@@ -32155,7 +32242,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001672">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GLYCAM-Web</rdfs:label>
     </owl:Class>
     
@@ -32165,7 +32253,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001673">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Glycoprotein Builder</rdfs:label>
     </owl:Class>
     
@@ -32237,7 +32326,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001680">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DL-Find</rdfs:label>
     </owl:Class>
     
@@ -32260,6 +32350,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <obo:IAO_0000115 xml:lang="en">x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">x3DNA</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">3DNA</rdfs:label>
     </owl:Class>
     
@@ -32279,7 +32370,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001684">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match analysis tool</rdfs:label>
     </owl:Class>
     
@@ -32882,7 +32974,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001743">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ICOSA algorithm</rdfs:label>
     </owl:Class>
     
@@ -32913,7 +33006,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001746">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010012"/>
-        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DSSP algorithm</rdfs:label>
     </owl:Class>
     
@@ -33006,6 +33100,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001755">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names &apos;CA&apos; and &apos;CB&apos; are used to differentiate the alpha-carbon from the beta-carbon.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom name</rdfs:label>
     </owl:Class>
@@ -33272,7 +33367,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001781 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001781">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
         <obo:IAO_0000115 xml:lang="en">Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein&apos;s overall architecture and how its shape changes during a simulation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">secondary structure</rdfs:label>
     </owl:Class>
@@ -33293,7 +33388,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001783">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -33303,7 +33399,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001784">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">anti-parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -33312,9 +33409,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001785 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001785">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33322,9 +33421,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001786 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001786">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">3-10 helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 3-10 helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33332,9 +33433,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001787 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001787">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">alpha helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete alpha helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33342,9 +33445,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001788 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001788">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">pi helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete pi helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33363,7 +33468,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001790">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein&apos;s compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">bend</rdfs:label>
     </owl:Class>
     
@@ -33383,7 +33489,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001792">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein&apos;s folded structure together. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">beta bridge</rdfs:label>
     </owl:Class>
     
@@ -33415,7 +33522,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent&apos;s bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">MDL solvent model format</rdfs:label>
     </owl:Class>
     
@@ -33990,7 +34098,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001850">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000158"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling and setup tool</rdfs:label>
     </owl:Class>
     
@@ -34154,7 +34263,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001866">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">backbone DH fluctuations</rdfs:label>
     </owl:Class>
     
@@ -34407,7 +34517,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001889">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
-        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">complex system</rdfs:label>
     </owl:Class>
     
@@ -34460,7 +34571,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001894">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001889"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hybrid complex system</rdfs:label>
     </owl:Class>
     
@@ -34761,7 +34873,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001922">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">3DMol.js</rdfs:label>
     </owl:Class>
     
@@ -34772,7 +34885,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001923">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NGL</rdfs:label>
     </owl:Class>
     
@@ -34782,7 +34896,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001924">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000166"/>
-        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Open Babel</rdfs:label>
     </owl:Class>
     
@@ -34813,7 +34928,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001927">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000225"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM-GUI</rdfs:label>
     </owl:Class>
     
@@ -34823,7 +34939,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001928">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001958"/>
-        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Modeller</rdfs:label>
     </owl:Class>
     
@@ -34864,7 +34981,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001932">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Jmol</rdfs:label>
     </owl:Class>
     
@@ -34874,7 +34992,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001933">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Mol*</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MolStar</rdfs:label>
     </owl:Class>
@@ -35094,7 +35213,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001955">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001556"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic build tool</rdfs:label>
     </owl:Class>
     
@@ -35124,7 +35244,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001958">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">homology modeling tool</rdfs:label>
     </owl:Class>
     
@@ -35134,7 +35255,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001959">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock Vina</rdfs:label>
     </owl:Class>
     
@@ -35195,7 +35317,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001965">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DALI</rdfs:label>
     </owl:Class>
     
@@ -35205,7 +35328,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001966">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">LS-align</rdfs:label>
     </owl:Class>
     
@@ -35236,7 +35360,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001969">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001564"/>
-        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">free energy surface analysis tool</rdfs:label>
     </owl:Class>
     
@@ -35501,7 +35626,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001995">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001552"/>
-        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">position restraints</rdfs:label>
     </owl:Class>
     
@@ -35677,7 +35803,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the &quot;flying ice cube&quot; effect). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">continuation state</rdfs:label>
     </owl:Class>
     
@@ -35951,7 +36078,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in structure.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom ID</rdfs:label>
     </owl:Class>
@@ -35962,7 +36090,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">JSmol</rdfs:label>
     </owl:Class>
     
@@ -35972,7 +36101,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular structure visualization tool</rdfs:label>
     </owl:Class>
     
@@ -35982,7 +36112,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">data visualization tool</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">data plotting tool</rdfs:label>
     </owl:Class>
@@ -36054,7 +36185,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -36064,7 +36196,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -36075,7 +36208,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -36155,7 +36289,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -36176,7 +36311,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
-        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking log format</rdfs:label>
     </owl:Class>
     
@@ -36198,7 +36334,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">mae format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">maegz format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Maestro format</rdfs:label>
@@ -36575,7 +36712,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002098">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000003"/>
-        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart simulation process</rdfs:label>
     </owl:Class>
     
@@ -36585,7 +36722,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata extraction tool</rdfs:label>
     </owl:Class>
     
@@ -36595,7 +36732,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001669"/>
-        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PMEMD.cuda</rdfs:label>
     </owl:Class>
     
@@ -36605,7 +36742,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata validation process</rdfs:label>
     </owl:Class>
     
@@ -36615,7 +36752,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002102">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001767"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping process</rdfs:label>
     </owl:Class>
     
@@ -36625,7 +36762,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002103">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000364"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NMR restrained simulation</rdfs:label>
     </owl:Class>
     
@@ -36635,7 +36772,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000335"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">belly dynamics</rdfs:label>
     </owl:Class>
     
@@ -36645,7 +36782,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001219"/>
-        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">replica exchange attempt frequency</rdfs:label>
     </owl:Class>
     
@@ -36655,7 +36792,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002106">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">center of mass removal interval</rdfs:label>
     </owl:Class>
     
@@ -36665,7 +36802,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002107">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-timestep inner loop count</rdfs:label>
     </owl:Class>
     
@@ -36675,7 +36812,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002108">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">output control parameter</rdfs:label>
     </owl:Class>
     
@@ -36685,7 +36822,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">energy output interval</rdfs:label>
     </owl:Class>
     
@@ -36695,7 +36832,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart output interval</rdfs:label>
     </owl:Class>
     
@@ -36705,7 +36842,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002111">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log output interval</rdfs:label>
     </owl:Class>
     
@@ -36715,7 +36852,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002112">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001083"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation state time</rdfs:label>
     </owl:Class>
     
@@ -36725,7 +36862,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002113">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">final density</rdfs:label>
     </owl:Class>
     
@@ -36735,7 +36872,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002114">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001292"/>
-        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computational performance metric</rdfs:label>
     </owl:Class>
     
@@ -36745,7 +36882,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002115">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36755,7 +36892,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002116">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total cpu time</rdfs:label>
     </owl:Class>
     
@@ -36765,7 +36902,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">setup wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36775,7 +36912,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">production wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36785,7 +36922,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">average integration step time</rdfs:label>
     </owl:Class>
     
@@ -36795,7 +36932,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation throughput</rdfs:label>
     </owl:Class>
     
@@ -36805,7 +36942,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002155">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation protocol</rdfs:label>
     </owl:Class>
     
@@ -36815,7 +36952,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation stage</rdfs:label>
     </owl:Class>
     
@@ -36825,7 +36962,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002157">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation parameter schedule</rdfs:label>
     </owl:Class>
     
@@ -36835,7 +36972,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002158">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation continuity check</rdfs:label>
     </owl:Class>
     
@@ -36845,7 +36982,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002159">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">cross-source validation</rdfs:label>
     </owl:Class>
     
@@ -36855,7 +36992,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file parsing error</rdfs:label>
     </owl:Class>
     
@@ -36865,7 +37002,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002161">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
-        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file format convention</rdfs:label>
     </owl:Class>
     
@@ -36875,7 +37012,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system classification label</rdfs:label>
     </owl:Class>
     
@@ -36885,7 +37022,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002163">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom selection mask</rdfs:label>
     </owl:Class>
     
@@ -36896,7 +37033,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002165"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory frame interval</rdfs:label>
     </owl:Class>
     
@@ -36906,7 +37043,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">inter-stage time gap</rdfs:label>
     </owl:Class>
     
@@ -36916,7 +37053,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001696"/>
-        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen detection strategy</rdfs:label>
     </owl:Class>
     
@@ -36926,7 +37063,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002192">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial density</rdfs:label>
     </owl:Class>
     
@@ -36936,7 +37073,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002196">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom count consistency check</rdfs:label>
     </owl:Class>
     
@@ -36946,7 +37083,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002197">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box consistency check</rdfs:label>
     </owl:Class>
     
@@ -36956,7 +37093,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002198">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">timing consistency check</rdfs:label>
     </owl:Class>
     
@@ -36966,7 +37103,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002199">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">sampling consistency check</rdfs:label>
     </owl:Class>
     
@@ -36976,7 +37113,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
-        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">protein domain</rdfs:label>
     </owl:Class>
@@ -36987,7 +37124,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">receptor-binding domain</rdfs:label>
     </owl:Class>
@@ -36998,7 +37135,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002205">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">catalytic domain</rdfs:label>
     </owl:Class>
@@ -37009,7 +37146,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002206">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein functional class label</rdfs:label>
     </owl:Class>
     
@@ -37019,7 +37156,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002207">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">enzyme classification label</rdfs:label>
     </owl:Class>
     
@@ -37029,7 +37166,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">transport protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37039,7 +37176,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37049,7 +37186,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002210">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">regulatory protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37059,7 +37196,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002211">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">signaling protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37069,7 +37206,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002212">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">motor protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37079,7 +37216,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002213">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">immune protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37089,7 +37226,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002214">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">storage protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37099,7 +37236,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002226">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">periodic box angles</rdfs:label>
     </owl:Class>
     
@@ -37109,7 +37246,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002230">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SMILES code</rdfs:label>
     </owl:Class>
     
@@ -37119,7 +37256,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002232">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">compiler</rdfs:label>
     </owl:Class>
     
@@ -37129,7 +37266,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002233">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom index group</rdfs:label>
     </owl:Class>
     
@@ -37139,7 +37276,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000843"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">classical molecular dynamics</rdfs:label>
     </owl:Class>
     
@@ -37149,7 +37286,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002235">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">source structure residue mapping</rdfs:label>
     </owl:Class>
     
@@ -37159,7 +37296,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002236">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -37169,7 +37306,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002237">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">monomeric state</rdfs:label>
     </owl:Class>
     
@@ -37179,7 +37316,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002238">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">dimeric state</rdfs:label>
     </owl:Class>
     
@@ -37189,7 +37326,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trimeric state</rdfs:label>
     </owl:Class>
     
@@ -37199,7 +37336,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">tetrameric state</rdfs:label>
     </owl:Class>
     
@@ -37209,7 +37346,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002241">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">higher-order oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -37219,7 +37356,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002246">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000105"/>
-        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spike opening conformational state</rdfs:label>
     </owl:Class>
     
@@ -37229,7 +37366,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002247">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">biological strain classification label</rdfs:label>
     </owl:Class>
     
@@ -37239,8 +37376,19 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002248">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone variant classification label</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002249">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
+        <obo:IAO_0000115 xml:lang="en">A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">Dissecting the Spatial Structure of RNA</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">DSSR</rdfs:label>
     </owl:Class>
     
 
@@ -37357,7 +37505,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -37367,7 +37515,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -37387,7 +37535,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -37397,7 +37545,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -37805,6 +37953,195 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <owl:annotatedTarget>Region of polypeptide with a given structural property.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>SO:cb</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001078">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001070"/>
+        <obo:IAO_0000115>A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00003</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Secondary_structure</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>polypeptide secondary structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>2nary structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary structure region</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary_structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001078</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Biosapien term was secondary_structure.</rdfs:comment>
+        <rdfs:label>polypeptide_secondary_structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Secondary_structure</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>2nary structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary structure region</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary_structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
+        <obo:IAO_0000115>A helix is a secondary_structure conformation where the peptide backbone forms a coil.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00152</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001114</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>peptide_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A helix is a secondary_structure conformation where the peptide backbone forms a coil.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>helix</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00040</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Alpha_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>a-helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001117</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>alpha_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Alpha_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>a-helix</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>helix</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>uniprot:feature_type</oboInOwl:hasDbXref>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00153</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Pi_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>pi helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001118</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>pi_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Pi_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:0000340</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/310_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>3(10) helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>3-10 helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>310 helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>three ten helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001119</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>three_ten_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/310_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
     </owl:Axiom>
     
 
@@ -39787,8 +40124,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001532">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001522"/>
-        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">The Cambridge Structural Database (CSD) is the world&apos;s primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Cambridge Structural Database</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39810,7 +40146,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002174">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERRESTART NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39820,7 +40156,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002175">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBER trajectory NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39830,7 +40166,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002176">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Protein / Ligand in Explicit Water</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39840,7 +40176,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002177">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atomic number HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39850,7 +40186,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002178">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom name HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     

--- a/molsim.json
+++ b/molsim.json
@@ -10,6 +10,21 @@
         "val" : "https://orcid.org/0000-0002-0476-9699"
       }, {
         "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-2294-5393"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-4303-9349"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-7544-0938"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0002-8291-8071"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
+        "val" : "https://orcid.org/0000-0003-4177-3619"
+      }, {
+        "pred" : "http://purl.org/dc/terms/contributor",
         "val" : "https://orcid.org/0009-0007-1391-4986"
       }, {
         "pred" : "http://purl.org/dc/terms/creator",
@@ -39,13 +54,16 @@
         "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
         "val" : "Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content."
       }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README."
+      }, {
         "pred" : "http://www.w3.org/2002/07/owl#versionInfo",
-        "val" : "2026-07-29"
+        "val" : "2026-08-07"
       }, {
         "pred" : "http://xmlns.com/foaf/0.1/homepage",
         "val" : "https://github.com/CPCLab/molsim-ontology"
       } ],
-      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim.json"
+      "version" : "http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim.json"
     },
     "nodes" : [ {
       "id" : "http://purl.obolibrary.org/obo/APOLLO_SV_00000008",
@@ -13307,8 +13325,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)"
-        }
+          "val" : "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000001",
@@ -13321,30 +13343,46 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
-      "lbl" : "preparation",
+      "lbl" : "simulation preparation",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "preparation"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
-      "lbl" : "execution",
+      "lbl" : "simulation execution",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)"
-        }
+          "val" : "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "execution"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
-      "lbl" : "analysis",
+      "lbl" : "simulation analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
           "val" : "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "analysis"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
@@ -13380,7 +13418,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000008",
-      "lbl" : "lipid  force field",
+      "lbl" : "lipid force field",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -13504,8 +13542,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)"
-        }
+          "val" : "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000021",
@@ -14091,7 +14133,11 @@
       "meta" : {
         "definition" : {
           "val" : "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)"
-        }
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000116",
+          "val" : "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1."
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000077",
@@ -14198,8 +14244,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)"
-        }
+          "val" : "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000089",
@@ -14498,12 +14548,12 @@
         "definition" : {
           "val" : "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms."
         },
+        "xrefs" : [ {
+          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0009-0007-1391-4986"
-        }, {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource",
-          "val" : "https://doi.org/10.1016/S0263-7855(97)00009-X"
         } ]
       }
     }, {
@@ -14929,8 +14979,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000157",
@@ -14977,8 +15031,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)"
-        }
+          "val" : "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000161",
@@ -14995,8 +15053,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)"
-        }
+          "val" : "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000163",
@@ -15013,8 +15075,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)"
-        }
+          "val" : "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000165",
@@ -15022,8 +15088,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)"
-        }
+          "val" : "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000166",
@@ -15031,8 +15101,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)"
-        }
+          "val" : "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000167",
@@ -15489,7 +15563,11 @@
       "meta" : {
         "definition" : {
           "val" : "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)"
-        }
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "heating"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000209",
@@ -15497,8 +15575,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)"
-        }
+          "val" : "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000210",
@@ -15629,8 +15711,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)"
-        }
+          "val" : "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000222",
@@ -15638,8 +15724,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000223",
@@ -15647,8 +15737,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)"
-        }
+          "val" : "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000224",
@@ -15683,8 +15777,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)"
-        }
+          "val" : "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000228",
@@ -15692,8 +15790,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)"
-        }
+          "val" : "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000229",
@@ -15824,8 +15926,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000241",
@@ -15851,8 +15957,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)"
-        }
+          "val" : "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000244",
@@ -16510,8 +16620,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)"
-        }
+          "val" : "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000306",
@@ -16557,7 +16671,7 @@
         "definition" : {
           "val" : "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)"
         },
-        "comments" : [ "TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)" ]
+        "comments" : [ "Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened." ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
@@ -16565,7 +16679,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms."
+          "val" : "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -18054,16 +18168,14 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "lbl" : "protein database ID",
+      "lbl" : "obsolete protein database ID",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
+          "val" : "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information."
         },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0003-4177-3619"
-        } ]
+        "comments" : [ "Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review." ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
@@ -18260,11 +18372,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)"
+          "val" : "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "OPM"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -18299,8 +18415,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000470",
@@ -18324,8 +18444,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)"
-        }
+          "val" : "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000472",
@@ -18408,8 +18532,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)"
-        }
+          "val" : "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
@@ -18422,16 +18550,18 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "lbl" : "2D RMSD analysis",
+      "lbl" : "obsolete 2D RMSD analysis",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
+          "val" : "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure."
         },
+        "comments" : [ "Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45." ],
         "basicPropertyValues" : [ {
-          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
-          "val" : "https://orcid.org/0000-0002-2294-5393"
-        } ]
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000311"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
@@ -19463,11 +19593,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)"
+          "val" : "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".grid"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -20265,8 +20399,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)"
-        }
+          "val" : "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000671",
@@ -20352,6 +20490,11 @@
         "definition" : {
           "val" : "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis."
         },
+        "comments" : [ "Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_000659"
+        } ],
         "deprecated" : true
       }
     }, {
@@ -20643,8 +20786,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)"
-        }
+          "val" : "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000707",
@@ -20886,8 +21033,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)"
-        }
+          "val" : "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000742",
@@ -20989,8 +21140,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)"
-        }
+          "val" : "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000753",
@@ -21187,8 +21342,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)"
-        }
+          "val" : "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000775",
@@ -21214,8 +21373,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)"
-        }
+          "val" : "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000778",
@@ -21295,8 +21458,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)"
-        }
+          "val" : "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000787",
@@ -21850,11 +22017,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)"
+          "val" : "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "MD"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -22158,8 +22329,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)"
-        }
+          "val" : "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000868",
@@ -22197,12 +22372,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000871",
-      "lbl" : "GROMACS input  format",
+      "lbl" : "GROMACS input format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)"
-        }
+          "val" : "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000872",
@@ -22246,8 +22425,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)"
-        }
+          "val" : "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000877",
@@ -22255,8 +22438,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)"
-        }
+          "val" : "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000878",
@@ -22298,8 +22485,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)"
-        }
+          "val" : "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000882",
@@ -22334,8 +22525,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)"
-        }
+          "val" : "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000886",
@@ -22406,8 +22601,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)"
-        }
+          "val" : "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000894",
@@ -22463,7 +22662,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)"
+          "val" : "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -22471,6 +22670,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "GROMACS itp format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -22516,8 +22719,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)"
-        }
+          "val" : "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000903",
@@ -22549,6 +22756,7 @@
         "definition" : {
           "val" : "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -22698,8 +22906,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)"
-        }
+          "val" : "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000923",
@@ -22826,8 +23038,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)"
-        }
+          "val" : "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_000942",
@@ -22988,7 +23204,7 @@
         "definition" : {
           "val" : "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information."
         },
-        "comments" : [ "Amber's standard ASCII coordinate trajectory file format.\n\nThe \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
+        "comments" : [ "Amber's standard ASCII coordinate trajectory file format. The \"Coordinates Data Set\" or \"COORDS\" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special \"COORDS format.\"" ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER inpcrd format"
@@ -23376,7 +23592,7 @@
         "definition" : {
           "val" : "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited."
         },
-        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
+        "comments" : [ "The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER trj format"
@@ -23392,13 +23608,17 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)"
+          "val" : "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule."
         },
-        "comments" : [ "Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ]
+        "comments" : [ "Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001041",
-      "lbl" : "xpm  format",
+      "lbl" : "xpm format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -23409,7 +23629,7 @@
           "val" : ".xpm"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "GROMACS xpm  format"
+          "val" : "GROMACS xpm format"
         } ]
       }
     }, {
@@ -23422,27 +23642,42 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
+          "val" : "AMBER PARM7 format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "AMBER parm7 format"
+        }, {
+          "pred" : "hasExactSynonym",
           "val" : "AMBER parmtop format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER prmtop format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "parm7 format"
         } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "lbl" : "parm7 format",
+      "lbl" : "obsolete parm7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)"
+          "val" : "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format."
         },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042." ],
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER PARM7 format"
         }, {
           "pred" : "hasExactSynonym",
           "val" : "AMBER parm7 format"
-        } ]
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001042"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
@@ -23526,17 +23761,30 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)"
-        }
+          "val" : "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "restrt format"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "rst7 format"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
-      "lbl" : "rst7 format",
+      "lbl" : "obsolete rst7 format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection."
+        },
+        "comments" : [ "Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/MOLSIM_001049"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001051",
@@ -23642,7 +23890,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001059",
-      "lbl" : "conflib  format",
+      "lbl" : "conflib format",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
@@ -23653,7 +23901,7 @@
           "val" : ".conflib"
         }, {
           "pred" : "hasExactSynonym",
-          "val" : "LMOD conflib  format"
+          "val" : "LMOD conflib format"
         } ]
       }
     }, {
@@ -23689,11 +23937,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)"
+          "val" : "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : ".pqr"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -23702,11 +23954,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)"
+          "val" : "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Molecular Operating Environment"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -23808,10 +24064,7 @@
       "meta" : {
         "definition" : {
           "val" : "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)"
-        },
-        "basicPropertyValues" : [ {
-          "pred" : "http://purl.org/dc/terms/BibliographicResource"
-        } ]
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001073",
@@ -23819,8 +24072,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)"
-        }
+          "val" : "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001074",
@@ -23987,6 +24244,7 @@
         "definition" : {
           "val" : "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats."
         },
+        "comments" : [ "Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -24010,6 +24268,7 @@
         "definition" : {
           "val" : "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations."
         },
+        "comments" : [ "Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20." ],
         "deprecated" : true
       }
     }, {
@@ -24118,7 +24377,7 @@
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
-          "val" : "skf  format"
+          "val" : "skf format"
         } ]
       }
     }, {
@@ -24305,11 +24564,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)"
+          "val" : "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "AMBER mdinfo format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -24318,8 +24581,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)"
-        }
+          "val" : "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001120",
@@ -24686,8 +24953,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)"
-        }
+          "val" : "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001202",
@@ -24832,8 +25103,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)"
-        }
+          "val" : "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001216",
@@ -24841,8 +25116,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)"
-        }
+          "val" : "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001217",
@@ -26106,8 +26385,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)"
-        }
+          "val" : "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001338",
@@ -26133,8 +26416,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)"
-        }
+          "val" : "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001341",
@@ -26491,8 +26778,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)"
-        }
+          "val" : "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001367",
@@ -27223,8 +27514,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)"
-        }
+          "val" : "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001433",
@@ -27325,8 +27620,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)"
-        }
+          "val" : "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001443",
@@ -27334,8 +27633,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)"
-        }
+          "val" : "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001444",
@@ -27830,8 +28133,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001495",
@@ -28170,8 +28477,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)"
-        }
+          "val" : "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001531",
@@ -28429,8 +28740,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)"
-        }
+          "val" : "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001559",
@@ -28497,12 +28812,20 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001566",
-      "lbl" : "library",
+      "lbl" : "software library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)"
-        }
+          "val" : "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing."
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "library"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001567",
@@ -28555,8 +28878,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)"
-        }
+          "val" : "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001573",
@@ -28564,8 +28891,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)"
-        }
+          "val" : "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001574",
@@ -28694,12 +29025,16 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001587",
-      "lbl" : "Intel Math Kernel Library",
+      "lbl" : "Intel oneAPI Math Kernel Library",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)"
-        }
+          "val" : "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001588",
@@ -28707,8 +29042,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)"
-        }
+          "val" : "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001589",
@@ -28716,8 +29055,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)"
-        }
+          "val" : "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001590",
@@ -28907,7 +29250,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
+          "val" : "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -29134,8 +29477,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)"
-        }
+          "val" : "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001632",
@@ -29323,8 +29670,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)"
-        }
+          "val" : "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001653",
@@ -29332,8 +29683,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)"
-        }
+          "val" : "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001654",
@@ -29395,8 +29750,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)"
-        }
+          "val" : "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001661",
@@ -29404,8 +29763,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)"
-        }
+          "val" : "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001662",
@@ -29503,8 +29866,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)"
-        }
+          "val" : "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001673",
@@ -29512,8 +29879,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)"
-        }
+          "val" : "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001674",
@@ -29579,8 +29950,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)"
-        }
+          "val" : "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001681",
@@ -29599,6 +29974,10 @@
         "definition" : {
           "val" : "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures."
         },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "x3DNA"
+        } ],
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0002-4303-9349"
@@ -29622,8 +30001,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001685",
@@ -30199,8 +30582,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)"
-        }
+          "val" : "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001744",
@@ -30226,8 +30613,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)"
-        }
+          "val" : "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001747",
@@ -30316,6 +30707,9 @@
           "val" : "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -30591,8 +30985,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)"
-        }
+          "val" : "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
@@ -30600,44 +30998,72 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)"
-        }
+          "val" : "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "lbl" : "helix",
+      "lbl" : "obsolete helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001114"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "lbl" : "3-10 helix",
+      "lbl" : "obsolete 3-10 helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001119"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "lbl" : "alpha helix",
+      "lbl" : "obsolete alpha helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001117"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "lbl" : "pi helix",
+      "lbl" : "obsolete pi helix",
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)"
-        }
+          "val" : "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix."
+        },
+        "comments" : [ "Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place." ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0100001",
+          "val" : "http://purl.obolibrary.org/obo/SO_0001118"
+        } ],
+        "deprecated" : true
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
@@ -30654,8 +31080,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)"
-        }
+          "val" : "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001791",
@@ -30672,8 +31102,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)"
-        }
+          "val" : "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001793",
@@ -30707,8 +31141,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)"
-        }
+          "val" : "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001796",
@@ -31306,8 +31744,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)"
-        }
+          "val" : "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001851",
@@ -31462,8 +31904,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)"
-        }
+          "val" : "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001867",
@@ -31761,8 +32207,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)"
-        }
+          "val" : "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001890",
@@ -31818,8 +32268,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)"
-        }
+          "val" : "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001895",
@@ -32142,8 +32596,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)"
-        }
+          "val" : "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001923",
@@ -32151,8 +32609,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)"
-        }
+          "val" : "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001924",
@@ -32160,8 +32622,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)"
-        }
+          "val" : "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001925",
@@ -32187,8 +32653,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)"
-        }
+          "val" : "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001928",
@@ -32196,8 +32666,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)"
-        }
+          "val" : "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001929",
@@ -32236,8 +32710,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)"
-        }
+          "val" : "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001933",
@@ -32245,11 +32723,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)"
+          "val" : "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Mol*"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -32466,8 +32948,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)"
-        }
+          "val" : "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001956",
@@ -32493,8 +32979,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)"
-        }
+          "val" : "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001959",
@@ -32502,8 +32992,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)"
-        }
+          "val" : "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001960",
@@ -32560,8 +33054,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)"
-        }
+          "val" : "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001966",
@@ -32569,8 +33067,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)"
-        }
+          "val" : "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001967",
@@ -32600,8 +33102,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)"
-        }
+          "val" : "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001970",
@@ -32851,8 +33357,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)"
-        }
+          "val" : "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001996",
@@ -33022,8 +33532,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)"
-        }
+          "val" : "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002013",
@@ -33281,9 +33795,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An atom ID is usually a number, that uniquely defines a given atom in structure."
+          "val" : "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system."
         },
         "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        }, {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
           "val" : "https://orcid.org/0000-0003-4177-3619"
         } ]
@@ -33294,8 +33811,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)"
-        }
+          "val" : "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002041",
@@ -33303,8 +33824,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)"
-        }
+          "val" : "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002042",
@@ -33312,11 +33837,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)"
+          "val" : "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "data visualization tool"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33383,8 +33912,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)"
-        }
+          "val" : "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002050",
@@ -33392,11 +33925,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)"
+          "val" : "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Genetic Optimisation for Ligand Docking"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33405,11 +33942,15 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)"
+          "val" : "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
           "val" : "Grid-based Ligand Docking with Energetics"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33504,8 +34045,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)"
-        }
+          "val" : "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002059",
@@ -33526,8 +34071,12 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)"
-        }
+          "val" : "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files."
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_002061",
@@ -33548,7 +34097,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)"
+          "val" : "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties."
         },
         "synonyms" : [ {
           "pred" : "hasExactSynonym",
@@ -33556,6 +34105,10 @@
         }, {
           "pred" : "hasExactSynonym",
           "val" : "maegz format"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
+          "val" : "https://orcid.org/0000-0002-8291-8071"
         } ]
       }
     }, {
@@ -33942,7 +34495,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)"
         }
       }
     }, {
@@ -33951,7 +34504,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)"
         }
       }
     }, {
@@ -33960,7 +34513,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)"
         }
       }
     }, {
@@ -33969,7 +34522,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)"
         }
       }
     }, {
@@ -33978,7 +34531,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)"
         }
       }
     }, {
@@ -33987,7 +34540,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)"
         }
       }
     }, {
@@ -33996,7 +34549,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)"
         }
       }
     }, {
@@ -34005,7 +34558,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)"
         }
       }
     }, {
@@ -34014,7 +34567,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)"
         }
       }
     }, {
@@ -34023,7 +34576,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -34032,7 +34585,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)"
         }
       }
     }, {
@@ -34041,7 +34594,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)"
         }
       }
     }, {
@@ -34050,7 +34603,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)"
         }
       }
     }, {
@@ -34059,7 +34612,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)"
         }
       }
     }, {
@@ -34068,7 +34621,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -34077,7 +34630,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)"
         }
       }
     }, {
@@ -34086,7 +34639,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)"
         }
       }
     }, {
@@ -34095,7 +34648,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)"
         }
       }
     }, {
@@ -34104,7 +34657,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)"
         }
       }
     }, {
@@ -34113,7 +34666,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)"
         }
       }
     }, {
@@ -34122,7 +34675,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)"
         }
       }
     }, {
@@ -34131,7 +34684,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)"
         }
       }
     }, {
@@ -34140,7 +34693,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)"
         }
       }
     }, {
@@ -34149,7 +34702,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)"
         }
       }
     }, {
@@ -34158,7 +34711,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -34167,7 +34720,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -34176,7 +34729,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)"
         }
       }
     }, {
@@ -34185,7 +34738,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)"
         }
       }
     }, {
@@ -34194,7 +34747,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34203,7 +34756,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)"
         }
       }
     }, {
@@ -34212,7 +34765,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)"
         }
       }
     }, {
@@ -34221,7 +34774,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)"
         }
       }
     }, {
@@ -34230,7 +34783,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)"
         }
       }
     }, {
@@ -34239,7 +34792,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -34248,7 +34801,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)"
         }
       }
     }, {
@@ -34257,7 +34810,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)"
         }
       }
     }, {
@@ -34266,7 +34819,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)"
         }
       }
     }, {
@@ -34275,7 +34828,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)"
         }
       }
     }, {
@@ -34284,7 +34837,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)"
         }
       }
     }, {
@@ -34293,7 +34846,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)"
         }
       }
     }, {
@@ -34302,7 +34855,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)"
+          "val" : "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34315,7 +34868,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)"
+          "val" : "A protein domain whose function is to attach to a matching partner molecule called a receptor."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34328,7 +34881,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)"
+          "val" : "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme."
         },
         "basicPropertyValues" : [ {
           "pred" : "http://purl.obolibrary.org/obo/IAO_0000117",
@@ -34341,7 +34894,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)"
         }
       }
     }, {
@@ -34350,7 +34903,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -34359,7 +34912,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)"
         }
       }
     }, {
@@ -34368,7 +34921,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)"
         }
       }
     }, {
@@ -34377,7 +34930,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)"
         }
       }
     }, {
@@ -34386,7 +34939,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)"
         }
       }
     }, {
@@ -34395,7 +34948,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)"
         }
       }
     }, {
@@ -34404,7 +34957,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)"
         }
       }
     }, {
@@ -34413,7 +34966,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34422,7 +34975,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)"
         }
       }
     }, {
@@ -34431,7 +34984,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)"
         }
       }
     }, {
@@ -34440,7 +34993,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)"
         }
       }
     }, {
@@ -34449,7 +35002,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)"
         }
       }
     }, {
@@ -34458,7 +35011,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)"
         }
       }
     }, {
@@ -34467,7 +35020,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)"
         }
       }
     }, {
@@ -34476,7 +35029,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)"
         }
       }
     }, {
@@ -34485,7 +35038,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)"
         }
       }
     }, {
@@ -34494,7 +35047,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34503,7 +35056,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34512,7 +35065,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34521,7 +35074,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)"
         }
       }
     }, {
@@ -34530,7 +35083,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -34539,7 +35092,7 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)"
         }
       }
     }, {
@@ -34548,8 +35101,21 @@
       "type" : "CLASS",
       "meta" : {
         "definition" : {
-          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)"
         }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "lbl" : "DSSR",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)"
+        },
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "Dissecting the Spatial Structure of RNA"
+        } ]
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
@@ -35123,6 +35689,189 @@
         "basicPropertyValues" : [ {
           "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
           "val" : "BS:00337"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001078",
+      "lbl" : "polypeptide_secondary_structure",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Biosapien term was secondary_structure." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "polypeptide secondary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "2nary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary structure"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary structure region"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "secondary_structure"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Secondary_structure",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00003"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001114",
+      "lbl" : "peptide_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "A helix is a secondary_structure conformation where the peptide backbone forms a coil.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "helix"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00152"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001117",
+      "lbl" : "alpha_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "a-helix"
+        }, {
+          "synonymType" : "http://purl.obolibrary.org/obo/so#BS",
+          "pred" : "hasRelatedSynonym",
+          "val" : "helix",
+          "xrefs" : [ "uniprot:feature_type" ]
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Alpha_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00040"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001118",
+      "lbl" : "pi_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "pi helix"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/Pi_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:00153"
+        }, {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "sequence"
+        } ]
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SO_0001119",
+      "lbl" : "three_ten_helix",
+      "type" : "CLASS",
+      "meta" : {
+        "definition" : {
+          "val" : "The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.",
+          "xrefs" : [ "EBIBS:GAR" ]
+        },
+        "comments" : [ "Range." ],
+        "subsets" : [ "http://purl.obolibrary.org/obo/so#biosapiens" ],
+        "synonyms" : [ {
+          "pred" : "hasExactSynonym",
+          "val" : "3(10) helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "3-10 helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "310 helix"
+        }, {
+          "pred" : "hasExactSynonym",
+          "val" : "three ten helix"
+        } ],
+        "xrefs" : [ {
+          "val" : "http://en.wikipedia.org/wiki/310_helix",
+          "meta" : {
+            "basicPropertyValues" : [ {
+              "pred" : "http://www.w3.org/2000/01/rdf-schema#label",
+              "val" : "wiki"
+            } ]
+          }
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasAlternativeId",
+          "val" : "BS:0000340"
         }, {
           "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
           "val" : "sequence"
@@ -36385,7 +37134,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -36395,7 +37144,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)"
         }
       }
     }, {
@@ -36405,7 +37154,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)"
         }
       }
     }, {
@@ -36415,7 +37164,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)"
         }
       }
     }, {
@@ -36425,7 +37174,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)"
         }
       }
     }, {
@@ -36435,7 +37184,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)"
         }
       }
     }, {
@@ -36445,7 +37194,7 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)"
         }
       }
     }, {
@@ -36455,7 +37204,17 @@
       "propertyType" : "OBJECT",
       "meta" : {
         "definition" : {
-          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)"
+        }
+      }
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "lbl" : "follows protocol",
+      "type" : "PROPERTY",
+      "propertyType" : "OBJECT",
+      "meta" : {
+        "definition" : {
+          "val" : "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)"
         }
       }
     }, {
@@ -37117,7 +37876,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)"
         }
       }
     }, {
@@ -37127,7 +37886,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)"
         }
       }
     }, {
@@ -37137,7 +37896,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)"
         }
       }
     }, {
@@ -37147,7 +37906,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)"
         },
         "comments" : [ "This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {\"Na+\": 12, \"Cl-\": 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files." ]
       }
@@ -37158,7 +37917,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -37168,7 +37927,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)"
         }
       }
     }, {
@@ -37178,7 +37937,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)"
         }
       }
     }, {
@@ -37188,7 +37947,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)"
         }
       }
     }, {
@@ -37198,7 +37957,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)"
         }
       }
     }, {
@@ -37208,7 +37967,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)"
         }
       }
     }, {
@@ -37218,7 +37977,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)"
         }
       }
     }, {
@@ -37228,7 +37987,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)"
         }
       }
     }, {
@@ -37238,7 +37997,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)"
         }
       }
     }, {
@@ -37248,7 +38007,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)"
         }
       }
     }, {
@@ -37258,7 +38017,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37268,7 +38027,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -37278,7 +38037,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37288,7 +38047,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37298,7 +38057,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)"
         }
       }
     }, {
@@ -37308,7 +38067,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37318,7 +38077,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)"
         }
       }
     }, {
@@ -37328,7 +38087,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)"
         }
       }
     }, {
@@ -37338,7 +38097,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37348,7 +38107,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)"
         }
       }
     }, {
@@ -37358,7 +38117,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system's topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37368,7 +38127,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)"
         }
       }
     }, {
@@ -37378,7 +38137,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37388,7 +38147,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)"
         }
       }
     }, {
@@ -37398,7 +38157,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)"
         }
       }
     }, {
@@ -37408,7 +38167,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -37418,7 +38177,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)"
         }
       }
     }, {
@@ -37428,7 +38187,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)"
         }
       }
     }, {
@@ -37438,7 +38197,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)"
         }
       }
     }, {
@@ -37448,7 +38207,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)"
         }
       }
     }, {
@@ -37458,7 +38217,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37468,7 +38227,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37478,7 +38237,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)"
         }
       }
     }, {
@@ -37488,7 +38247,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)"
         }
       }
     }, {
@@ -37498,7 +38257,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)"
         }
       }
     }, {
@@ -37508,7 +38267,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37518,7 +38277,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37528,7 +38287,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)"
         }
       }
     }, {
@@ -37538,7 +38297,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)"
         }
       }
     }, {
@@ -37548,7 +38307,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)"
         }
       }
     }, {
@@ -37558,7 +38317,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)"
         }
       }
     }, {
@@ -37568,7 +38327,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)"
         }
       }
     }, {
@@ -37578,7 +38337,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)"
         }
       }
     }, {
@@ -37588,7 +38347,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)"
         }
       }
     }, {
@@ -37598,7 +38357,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -37608,7 +38367,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)"
         }
       }
     }, {
@@ -37618,7 +38377,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)"
         }
       }
     }, {
@@ -37628,7 +38387,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)"
         }
       }
     }, {
@@ -37638,7 +38397,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -37648,7 +38407,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)"
         }
       }
     }, {
@@ -37658,7 +38417,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)"
         }
       }
     }, {
@@ -37668,7 +38427,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)"
         }
       }
     }, {
@@ -37678,7 +38437,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)"
         }
       }
     }, {
@@ -37688,7 +38447,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)"
         }
       }
     }, {
@@ -37698,7 +38457,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -37708,7 +38467,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)"
         }
       }
     }, {
@@ -37718,7 +38477,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)"
         }
       }
     }, {
@@ -37728,7 +38487,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)"
         }
       }
     }, {
@@ -37738,7 +38497,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)"
         }
       }
     }, {
@@ -37748,7 +38507,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)"
         }
       }
     }, {
@@ -37758,7 +38517,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)"
         }
       }
     }, {
@@ -37768,7 +38527,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)"
         }
       }
     }, {
@@ -37778,7 +38537,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)"
         }
       }
     }, {
@@ -37788,7 +38547,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)"
         }
       }
     }, {
@@ -37798,7 +38557,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)"
         }
       }
     }, {
@@ -37808,7 +38567,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)"
         }
       }
     }, {
@@ -37818,7 +38577,7 @@
       "propertyType" : "DATA",
       "meta" : {
         "definition" : {
-          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)"
         }
       }
     }, {
@@ -38586,9 +39345,8 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)"
-        },
-        "comments" : [ "The Cambridge Structural Database (CSD) is the world's primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)" ]
+          "val" : "The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)"
+        }
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/MOLSIM_001945",
@@ -38611,7 +39369,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBERRESTART in a NetCDF file's global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)"
         }
       }
     }, {
@@ -38620,7 +39378,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The file format convention denoted by the string AMBER in a NetCDF file's global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)"
         }
       }
     }, {
@@ -38629,7 +39387,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)"
         }
       }
     }, {
@@ -38638,7 +39396,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -38647,7 +39405,7 @@
       "type" : "INDIVIDUAL",
       "meta" : {
         "definition" : {
-          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)"
+          "val" : "The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom's name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)"
         }
       }
     }, {
@@ -38920,6 +39678,7 @@
       }
     }, {
       "id" : "http://purl.obolibrary.org/obo/IAO_0100001",
+      "lbl" : "term replaced by",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -38984,10 +39743,6 @@
       }
     }, {
       "id" : "http://purl.org/dc/elements/1.1/source",
-      "type" : "PROPERTY",
-      "propertyType" : "ANNOTATION"
-    }, {
-      "id" : "http://purl.org/dc/terms/BibliographicResource",
       "type" : "PROPERTY",
       "propertyType" : "ANNOTATION"
     }, {
@@ -40509,15 +41264,15 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000002",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000003",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000004",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000000"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002156"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000005",
       "pred" : "is_a",
@@ -41739,6 +42494,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000610"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000310",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001072"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000311",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
@@ -42283,10 +43042,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001090"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000448",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000449",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000430"
@@ -42418,10 +43173,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000480",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000939"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000481",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000917"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000482",
       "pred" : "is_a",
@@ -43229,11 +43980,11 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000686",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000687",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000448"
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_000689",
       "pred" : "is_a",
@@ -44387,10 +45138,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001043",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000472"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001044",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001088"
@@ -44412,10 +45159,6 @@
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000447"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001049",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001050",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_000471"
     }, {
@@ -47133,7 +47876,7 @@
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001781",
       "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001333"
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001078"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001782",
       "pred" : "is_a",
@@ -47146,22 +47889,6 @@
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001784",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001782"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001785",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001781"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001786",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001787",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001788",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001785"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_001789",
       "pred" : "is_a",
@@ -48691,6 +49418,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/MOLSIM_002162"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002249",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001960"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/MOLSIM_010001",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/UO_1000010"
@@ -48866,6 +49597,26 @@
       "sub" : "http://purl.obolibrary.org/obo/SO_0001070",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/SO_0000839"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001078",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001070"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001114",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/MOLSIM_001781"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001117",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001118",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/SO_0001119",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/SO_0001114"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/SO_0001236",
       "pred" : "is_a",
@@ -49587,6 +50338,10 @@
       "pred" : "subPropertyOf",
       "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "pred" : "subPropertyOf",
+      "obj" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/OBI_0000299",
       "pred" : "subPropertyOf",
       "obj" : "http://purl.obolibrary.org/obo/RO_0000057"
@@ -49776,7 +50531,7 @@
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001994" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002167",
-      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ],
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002156" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002168",
@@ -49806,6 +50561,10 @@
       "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002202",
       "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
       "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_001164" ]
+    }, {
+      "predicateId" : "http://purl.obolibrary.org/obo/MOLSIM_002250",
+      "domainClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_000000" ],
+      "rangeClassIds" : [ "http://purl.obolibrary.org/obo/MOLSIM_002155" ]
     }, {
       "predicateId" : "http://purl.obolibrary.org/obo/OBI_0000299",
       "domainClassIds" : [ "http://purl.obolibrary.org/obo/COB_0000035" ]

--- a/molsim.obo
+++ b/molsim.obo
@@ -1,8 +1,8 @@
 format-version: 1.2
-data-version: releases/2026-07-29
+data-version: releases/2026-08-07
 default-namespace: molsim
 idspace: chemrof https://w3id.org/chemrof/ 
-idspace: dce http://purl.org/dc/elements/1.1/ 
+idspace: dc http://purl.org/dc/elements/1.1/ 
 idspace: dcterms http://purl.org/dc/terms/ 
 idspace: foaf http://xmlns.com/foaf/0.1/ 
 idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
@@ -12,8 +12,14 @@ idspace: swrl http://www.w3.org/2003/11/swrl#
 idspace: swrlb http://www.w3.org/2003/11/swrlb# 
 remark: AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.
 remark: Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.
+remark: Scope note: MOLSIM's boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.
 ontology: molsim
 property_value: dcterms:contributor orcid:0000-0002-0476-9699
+property_value: dcterms:contributor orcid:0000-0002-2294-5393
+property_value: dcterms:contributor orcid:0000-0002-4303-9349
+property_value: dcterms:contributor orcid:0000-0002-7544-0938
+property_value: dcterms:contributor orcid:0000-0002-8291-8071
+property_value: dcterms:contributor orcid:0000-0003-4177-3619
 property_value: dcterms:contributor orcid:0009-0007-1391-4986
 property_value: dcterms:creator orcid:0000-0001-8613-1447
 property_value: dcterms:creator orcid:0000-0003-4846-8051
@@ -22,7 +28,7 @@ property_value: dcterms:license https://creativecommons.org/licenses/by/4.0/
 property_value: dcterms:subject "biomolecular simulation" xsd:string
 property_value: dcterms:title "Molecular Simulation Ontology" xsd:string
 property_value: foaf:homepage "https://github.com/CPCLab/molsim-ontology" xsd:string
-property_value: owl:versionInfo "2026-07-29" xsd:string
+property_value: owl:versionInfo "2026-08-07" xsd:string
 property_value: protege:defaultLanguage "en" xsd:string
 
 [Term]
@@ -3934,7 +3940,8 @@ property_value: IAO:0000117 "Mathias Brochhausen" xsd:string
 [Term]
 id: MOLSIM:000000
 name: molecular dynamics process
-def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)" []
+def: "A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation." []
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000001
@@ -3943,27 +3950,31 @@ def: "Software refers to the set of instructions, data, or programs used to oper
 
 [Term]
 id: MOLSIM:000002
-name: preparation
+name: simulation preparation
 def: "The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "preparation" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000003
-name: execution
-def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+name: simulation execution
+def: "The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies." []
+synonym: "execution" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000004
-name: analysis
+name: simulation analysis
 def: "The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)" []
-is_a: MOLSIM:000000 ! molecular dynamics process
+synonym: "analysis" EXACT []
+is_a: MOLSIM:002156 ! simulation stage
 
 [Term]
 id: MOLSIM:000005
 name: protonation
 def: "A specific step within the preparation process where the ionization states (presence or absence of protons) of ionizable residues (like acids, bases, histidines) and ligands are determined and assigned based on estimated pKa values relevant to the target pH of the simulation. Correct protonation is critical for accurately modeling electrostatic interactions and pH-dependent phenomena. Specialized tools are often used for this task. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 disjoint_from: MOLSIM:000208 ! thermalization
 
 [Term]
@@ -3981,7 +3992,7 @@ is_a: MOLSIM:000006 ! model
 
 [Term]
 id: MOLSIM:000008
-name: lipid  force field
+name: lipid force field
 def: "A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)" []
 is_a: MOLSIM:000772 ! chemical entity-based force field
 disjoint_from: MOLSIM:000009 ! protein force field
@@ -4048,20 +4059,21 @@ disjoint_from: MOLSIM:000485 ! split-valence
 id: MOLSIM:000018
 name: lipid21
 def: "A specific version of a lipid force field, part of the AMBER family, providing parameters optimized for simulating lipids. Released around 2021, it incorporates updates and refinements based on contemporary data and methodologies to improve accuracy in membrane simulations. Its name indicates the originating group (AMBER) and year of major update. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 disjoint_from: MOLSIM:000019 ! lipid14
 
 [Term]
 id: MOLSIM:000019
 name: lipid14
 def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2014. It provides parameters optimized for simulating a range of common lipid types found in biological membranes. This version aimed to improve upon previous lipid models within the AMBER family. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:000020
 name: lipid17
-def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It's designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+def: "A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails." []
+is_a: MOLSIM:000008 ! lipid force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000021
@@ -4440,6 +4452,7 @@ id: MOLSIM:000076
 name: Tversky index algorithm
 def: "A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)" []
 is_a: MOLSIM:000074 ! similarity calculation algorithm
+property_value: IAO:0000116 "General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1." xsd:string
 
 [Term]
 id: MOLSIM:000077
@@ -4511,9 +4524,10 @@ is_a: MOLSIM:000037 ! algorithm
 [Term]
 id: MOLSIM:000088
 name: Kruskal's algorithm
-def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)" []
+def: "A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal's algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected." []
 is_a: MOLSIM:000087 ! optimal transformation path algorithm
 disjoint_from: MOLSIM:000089 ! Prim's algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000089
@@ -4690,8 +4704,8 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000114
 name: HOLE
 def: "HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms." []
+xref: https://doi.org/10.1016/S0263-7855(97)00009-X
 is_a: MOLSIM:000245 ! tunnel predictor tool
-property_value: dcterms:BibliographicResource "https://doi.org/10.1016/S0263-7855(97)00009-X" xsd:string
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -4957,9 +4971,10 @@ is_a: MOLSIM:000143 ! ligand pairs selection criteria
 [Term]
 id: MOLSIM:000156
 name: GROMACS mdp format
-def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)" []
+def: "The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a \".mdp\" extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
 disjoint_from: MOLSIM:000469 ! AMBER mdin format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000157
@@ -4985,8 +5000,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000160
 name: molecular dynamics engine
-def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)" []
+def: "Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS." []
 is_a: MOLSIM:001851 ! simulation engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000161
@@ -4997,8 +5013,9 @@ is_a: MOLSIM:001851 ! simulation engine
 [Term]
 id: MOLSIM:000162
 name: docking tool
-def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)" []
+def: "A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000163
@@ -5009,20 +5026,23 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:000164
 name: analysis tool
-def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)" []
+def: "Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000165
 name: data processing tool
-def: "A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)" []
+def: "A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools." []
 is_a: MOLSIM:000001 ! software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000166
 name: file conversion tool
-def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)" []
+def: "A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf)." []
 is_a: MOLSIM:000165 ! data processing tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000167
@@ -5306,20 +5326,22 @@ is_a: MOLSIM:001802 ! script
 id: MOLSIM:000208
 name: thermalization
 def: "A step within the preparation or equilibration phase where the system's temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+synonym: "heating" EXACT []
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000209
 name: equilibration
-def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+def: "A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to 'forget' its initial, potentially artificial starting configuration." []
+is_a: MOLSIM:000002 ! simulation preparation
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000210
 name: umbrella sampling
 def: "A specific simulation execution technique used to enhance sampling along a chosen reaction coordinate or order parameter, often for calculating the potential of mean force (PMF) or free energy profile associated with a process like ligand unbinding or a conformational change. It involves running multiple simulations, each confined ('biased') by a potential (the 'umbrella') to sample a specific window along the coordinate, with subsequent analysis required to unbias the results and reconstruct the overall profile. It falls under the category of enhanced sampling methods." []
 synonym: "US" EXACT []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 disjoint_from: MOLSIM:000211 ! production
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
@@ -5327,19 +5349,19 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:000211
 name: production
 def: "The main data-gathering phase of a simulation execution, performed after the system has been properly prepared and equilibrated. During the production run, the system is simulated for a significant length of time under the desired conditions (ensemble, temperature, pressure) without strong restraints or equilibration protocols, and the resulting trajectory (positions and velocities over time) is saved for later analysis. The goal is to generate statistically meaningful data about the system's behavior. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000212
 name: free energy calculation
 def: "A type of simulation execution specifically designed to compute the free energy difference between two states (e.g., bound vs unbound, state A vs state B) or the free energy profile along a reaction coordinate. Common methods include Free Energy Perturbation (FEP), Thermodynamic Integration (TI), Umbrella Sampling (for PMFs), and sometimes methods based on endpoint analysis like MM/PBSA or MM/GBSA (though these are technically post-processing analyses estimating free energy). These calculations are computationally demanding but crucial for understanding binding affinities, reaction barriers, and relative stabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:000213
 name: adaptive steered molecular dynamics
 def: "An enhanced sampling simulation technique that enhances traditional steered molecular dynamics (SMD) to calculate binding affinities, mechanical unfolding pathways, and free energy profiles (e.g., Potential of Mean Force) in biomolecules. It works by breaking long pulling processes into a series of stages or windows along a specific reaction coordinate." []
-is_a: MOLSIM:000003 ! execution
+is_a: MOLSIM:000003 ! simulation execution
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -5358,7 +5380,7 @@ is_a: MOLSIM:000017 ! minimal
 id: MOLSIM:000216
 name: visualization
 def: "The process of creating graphical representations of molecular structures, trajectories, and simulation data using specialized software. Visualization is essential for inspecting system setup, monitoring simulation progress, understanding molecular motion and interactions, identifying structural features, and communicating results effectively through images and animations. It is an integral part of both preparation and analysis stages. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:000217
@@ -5390,20 +5412,23 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:000221
 name: PDB2PQR
-def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)" []
+def: "A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius)." []
 is_a: MOLSIM:000223 ! generic protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000222
 name: ligand protonation tool
-def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)" []
+def: "A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000223
 name: generic protonation tool
-def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)" []
+def: "A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool." []
 is_a: MOLSIM:000220 ! protonation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000224
@@ -5427,14 +5452,16 @@ disjoint_from: MOLSIM:001927 ! CHARMM-GUI
 [Term]
 id: MOLSIM:000227
 name: membrane protein orientation tool
-def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)" []
+def: "A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000228
 name: memembed
-def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein's position and orientation to minimize the calculated free energy of transferring the protein's amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)" []
+def: "A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential." []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000229
@@ -5513,8 +5540,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000240
 name: pKa tool
-def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)" []
+def: "A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example." []
 is_a: MOLSIM:000490 ! structure preparation tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000241
@@ -5531,8 +5559,9 @@ is_a: MOLSIM:000460 ! molecular mechanics Poisson-Boltzmann surface area tool
 [Term]
 id: MOLSIM:000243
 name: in-silico mutagenesis tool
-def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)" []
+def: "A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000244
@@ -5934,8 +5963,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000305
 name: modeling method
-def: "A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include \"molecular docking,\" \"homology modeling,\" \"scoring function,\" and \"binding pose prediction.\" (UNVERIFIED)" []
+def: "A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy." []
 is_a: MOLSIM:000140 ! computational method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000306
@@ -5967,12 +5997,13 @@ is_a: MOLSIM:000610 ! thermodynamics analysis
 id: MOLSIM:000310
 name: plan specification
 def: "A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled \"Experimental Design,\" \"Study Protocol,\" \"Selection Criteria,\" or \"Computational Strategy.\" (UNVERIFIED)" []
-comment: TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)
+comment: Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.
+is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:000311
 name: RMSD analysis
-def: "RMSD analysis is a calculation that measures how much a molecule's shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms." []
+def: "A calculation that measures how much a molecule's shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms." []
 is_a: MOLSIM:000917 ! structural analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -6871,10 +6902,10 @@ def: "An identifier is a unique name, code, or label assigned to a specific enti
 
 [Term]
 id: MOLSIM:000448
-name: protein database ID
-def: "A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
-is_a: MOLSIM:000447 ! identifier
-property_value: IAO:0000117 orcid:0000-0003-4177-3619
+name: obsolete protein database ID
+def: "OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., '1TIM') or UniProt (accession number, e.g., 'P00761'). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information." []
+comment: Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.
+is_obsolete: true
 
 [Term]
 id: MOLSIM:000449
@@ -6991,10 +7022,11 @@ is_a: MOLSIM:000462 ! molecular mechanics generalized Born surface area tool
 [Term]
 id: MOLSIM:000466
 name: orientations of proteins in membranes
-def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)" []
+def: "OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It's a valuable resource for obtaining initial membrane protein placements for simulations." []
 synonym: "OPM" EXACT []
 is_a: MOLSIM:000227 ! membrane protein orientation tool
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000467
@@ -7013,8 +7045,9 @@ is_a: MOLSIM:000909 ! volumetric data format
 [Term]
 id: MOLSIM:000469
 name: AMBER mdin format
-def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)" []
+def: "A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000470
@@ -7030,10 +7063,11 @@ disjoint_from: MOLSIM:000879 ! ADF output format
 [Term]
 id: MOLSIM:000471
 name: AMBER restart format
-def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)" []
+def: "A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst)." []
 is_a: MOLSIM:000441 ! simulation state format
 disjoint_from: MOLSIM:000880 ! rkf format
 disjoint_from: MOLSIM:000890 ! GAUSSIAN chk format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000472
@@ -7084,8 +7118,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:000479
 name: Connolly surface analysis
-def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)" []
+def: "A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent." []
 is_a: MOLSIM:000478 ! molecular surface analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000480
@@ -7095,10 +7130,11 @@ is_a: MOLSIM:000939 ! dynamics analysis
 
 [Term]
 id: MOLSIM:000481
-name: 2D RMSD analysis
-def: "A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
-is_a: MOLSIM:000917 ! structural analysis
-property_value: IAO:0000117 orcid:0000-0002-2294-5393
+name: obsolete 2D RMSD analysis
+def: "OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure." []
+comment: Retired as redundant with 'RMSD analysis' (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term's definition. Reported and approved by the term verifier in GitHub issue #45.
+is_obsolete: true
+replaced_by: MOLSIM:000311
 
 [Term]
 id: MOLSIM:000482
@@ -7180,7 +7216,7 @@ is_a: MOLSIM:002041 ! molecular structure visualization tool
 id: MOLSIM:000494
 name: minimization
 def: "Minimization is a computational step that relaxes a molecular structure to remove any bad clashes between atoms. As a stage of the preparation process, energy minimization is a procedure that adjusts the atomic coordinates to find a nearby local minimum on the potential energy surface, thereby removing steric strain from the initial model. This is achieved by using algorithms like steepest descent or conjugate gradient to iteratively reduce the net forces on the atoms until a convergence criterion, such as grms_tol, is met. This process is referred to in log files and inputs with terms like \"MINIMIZATION,\" \"ntmin=1,\" \"emtol,\" and \"ncyc.\" (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:000495
@@ -7192,7 +7228,7 @@ is_a: MOLSIM:000272 ! radii set
 id: MOLSIM:000496
 name: pyMBAR
 def: "pyMBAR refers to a specific Python software library implementation of the Multistate Bennett Acceptance Ratio (MBAR) method. MBAR itself is a statistical technique for optimally combining data from multiple simulations to calculate free energies and expectation values. Therefore, pyMBAR is a tool used for the analysis stage of free energy calculations, particularly for processing data generated by methods like umbrella sampling or replica exchange simulations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:000497
@@ -7779,9 +7815,10 @@ is_a: MOLSIM:000590 ! plot data format
 [Term]
 id: MOLSIM:000596
 name: grid format
-def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)" []
+def: "A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule." []
 synonym: ".grid" EXACT []
 is_a: MOLSIM:000590 ! plot data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000597
@@ -8263,8 +8300,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:000670
 name: coordinate centering analysis
-def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)" []
+def: "Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization." []
 is_a: MOLSIM:000917 ! structural analysis
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000671
@@ -8320,7 +8358,9 @@ is_a: MOLSIM:000328 ! system setup modeling
 id: MOLSIM:000679
 name: obsolete image bond fixing analysis
 def: "OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear \"broken\" in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis." []
+comment: Retired as redundant with its former parent 'periodic boundary imaging' (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term's definition now states so. Reported and approved by the term verifier in GitHub issue #45.
 is_obsolete: true
+replaced_by: MOLSIM:000659
 
 [Term]
 id: MOLSIM:000680
@@ -8365,13 +8405,13 @@ is_a: MOLSIM:000141 ! theoretical approach
 id: MOLSIM:000686
 name: PDB ID
 def: "A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., '1TIM', '6M0J') serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000687
 name: Uniprot ID
 def: "A UniProt ID, more formally known as a UniProt Accession Number (e.g., 'P00761', 'Q8WZ42'), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)" []
-is_a: MOLSIM:000448 ! protein database ID
+is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:000688
@@ -8499,8 +8539,9 @@ is_a: MOLSIM:000703 ! secondary database
 [Term]
 id: MOLSIM:000706
 name: pathway database
-def: "A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)" []
+def: "Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples." []
 is_a: MOLSIM:000703 ! secondary database
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000707
@@ -8653,8 +8694,9 @@ disjoint_from: MOLSIM:001472 ! bonded metal model
 [Term]
 id: MOLSIM:000741
 name: amber ff02
-def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)" []
+def: "A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000742
@@ -8720,8 +8762,9 @@ is_a: MOLSIM:000009 ! protein force field
 [Term]
 id: MOLSIM:000752
 name: CHARMM 19
-def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)" []
+def: "An earlier force field parameter set from the CHARMM family, notable for being a 'united-atom' force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000753
@@ -8852,8 +8895,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000774
 name: Abalone
-def: "A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)" []
+def: "Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field." []
 is_a: MOLSIM:001664 ! software suite
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000775
@@ -8870,9 +8914,10 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000777
 name: Desmond
-def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)" []
+def: "A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
 disjoint_from: MOLSIM:000784 ! LAMMPS
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000778
@@ -8925,8 +8970,9 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 [Term]
 id: MOLSIM:000786
 name: NAMD
-def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)" []
+def: "A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs." []
 is_a: MOLSIM:000160 ! molecular dynamics engine
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000787
@@ -9283,9 +9329,10 @@ is_a: MOLSIM:000841 ! empirical method
 [Term]
 id: MOLSIM:000843
 name: molecular dynamics
-def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)" []
+def: "Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton's equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems." []
 synonym: "MD" EXACT []
 is_a: MOLSIM:000308 ! simulation method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000844
@@ -9452,8 +9499,9 @@ disjoint_from: MOLSIM:000868 ! GAMESS input format
 [Term]
 id: MOLSIM:000867
 name: CHARMM input format
-def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)" []
+def: "A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results." []
 is_a: MOLSIM:000438 ! script format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000868
@@ -9477,9 +9525,10 @@ is_a: MOLSIM:000437 ! simulation input format
 
 [Term]
 id: MOLSIM:000871
-name: GROMACS input  format
-def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)" []
+name: GROMACS input format
+def: "In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000872
@@ -9508,14 +9557,16 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000876
 name: NAMD configuration format
-def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)" []
+def: "A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol." []
 is_a: MOLSIM:002065 ! simulation parameter format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000877
 name: NWChem input format
-def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)" []
+def: "An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system." []
 is_a: MOLSIM:000437 ! simulation input format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000878
@@ -9540,8 +9591,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000881
 name: CHARMM output format
-def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)" []
+def: "The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000882
@@ -9564,8 +9616,9 @@ is_a: MOLSIM:000439 ! simulation log format
 [Term]
 id: MOLSIM:000885
 name: GROMACS output format
-def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)" []
+def: "The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion." []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000886
@@ -9612,8 +9665,9 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:000893
 name: NWChem restart format
-def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)" []
+def: "Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst)." []
 is_a: MOLSIM:000441 ! simulation state format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000894
@@ -9645,10 +9699,11 @@ is_a: MOLSIM:001088 ! molecular structure format
 [Term]
 id: MOLSIM:000898
 name: itp format
-def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)" []
+def: "A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive." []
 synonym: "GROMACS include topology format" EXACT []
 synonym: "GROMACS itp format" EXACT []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000899
@@ -9674,8 +9729,9 @@ is_a: MOLSIM:001091 ! molecular topology format
 [Term]
 id: MOLSIM:000902
 name: dcd format
-def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)" []
+def: "The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability." []
 is_a: MOLSIM:001090 ! molecular trajectory format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000903
@@ -9694,6 +9750,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:000905
 name: obsolete small molecule structure
 def: "OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -9785,8 +9842,9 @@ is_a: MOLSIM:000917 ! structural analysis
 [Term]
 id: MOLSIM:000921
 name: crd format
-def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used. (UNVERIFIED)" []
+def: "A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a \".crd\" file. Due to its ambiguity, it is often necessary to specify which software's CRD format is being used." []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000923
@@ -9851,7 +9909,7 @@ is_a: MOLSIM:000937 ! structure clustering analysis
 id: MOLSIM:000939
 name: dynamics analysis
 def: "Dynamics analysis involves processing the time-series data generated from molecular dynamics simulations, primarily the trajectory files, to extract quantitative information and insights about the system's behavior. This encompasses a wide range of techniques aimed at understanding molecular motions, conformational changes, interactions, and kinetic or thermodynamic properties. The goal is to translate raw simulation output into meaningful physical or biological understanding." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 is_a: MOLSIM:000026 ! analysis method
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
@@ -9866,8 +9924,9 @@ disjoint_from: MOLSIM:001079 ! frcmod format
 [Term]
 id: MOLSIM:000941
 name: coordinate rotation modeling
-def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)" []
+def: "A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure." []
 is_a: MOLSIM:000305 ! modeling method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:000942
@@ -9969,7 +10028,7 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 id: MOLSIM:000963
 name: AMBER crd format
 def: "This refers to one of the file formats used by Amber to store atomic coordinates. Its extension is commonly .inpcrd, .crd or .mdcrd. It contains a list of coordinates in ASCII, usually read alongside a topology file, and may optionally include periodic box information." []
-comment: Amber's standard ASCII coordinate trajectory file format.\n\nThe "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. \n\nUsers can interact with it using file-based commands:\n\nLoading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.\n\nSaving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
+comment: Amber's standard ASCII coordinate trajectory file format. The "Coordinates Data Set" or "COORDS" in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special "COORDS format."
 synonym: "AMBER inpcrd format" EXACT []
 synonym: "AMBER prmcrd format" EXACT []
 is_a: MOLSIM:000921 ! crd format
@@ -10210,7 +10269,7 @@ is_a: MOLSIM:000921 ! crd format
 id: MOLSIM:001039
 name: trj format
 def: "The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential \"frames\" where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited." []
-comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:\n\nvs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.\n\nvs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.\n\nvs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
+comment: The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.
 synonym: "AMBER trj format" EXACT []
 is_a: MOLSIM:001090 ! molecular trajectory format
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
@@ -10218,33 +10277,39 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001040
 name: distance matrix format
-def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)" []
-comment: Common examples include:\n\n- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.\n\n- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.\n\n- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
+def: "A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule." []
+comment: Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy's .npy format, which is common in Python-based analysis workflows.
 is_a: MOLSIM:010020 ! molecular trajectory analysis format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001041
-name: xpm  format
+name: xpm format
 def: "The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)" []
 synonym: ".xpm" EXACT []
-synonym: "GROMACS xpm  format" EXACT []
+synonym: "GROMACS xpm format" EXACT []
 is_a: MOLSIM:001040 ! distance matrix format
 
 [Term]
 id: MOLSIM:001042
 name: prmtop format
 def: "The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)" []
+synonym: "AMBER PARM7 format" EXACT []
+synonym: "AMBER parm7 format" EXACT []
 synonym: "AMBER parmtop format" EXACT []
 synonym: "AMBER prmtop format" EXACT []
+synonym: "parm7 format" EXACT []
 is_a: MOLSIM:000472 ! AMBER topology format
 
 [Term]
 id: MOLSIM:001043
-name: parm7 format
-def: "A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)" []
+name: obsolete parm7 format
+def: "OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.
 synonym: "AMBER PARM7 format" EXACT []
 synonym: "AMBER parm7 format" EXACT []
-is_a: MOLSIM:000472 ! AMBER topology format
+is_obsolete: true
+replaced_by: MOLSIM:001042
 
 [Term]
 id: MOLSIM:001044
@@ -10290,15 +10355,19 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001049
 name: rst format
-def: "A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)" []
+def: "A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)" []
+synonym: "restrt format" EXACT []
+synonym: "rst7 format" EXACT []
 is_a: MOLSIM:000471 ! AMBER restart format
-disjoint_from: MOLSIM:001050 ! rst7 format
+disjoint_from: MOLSIM:001050 ! obsolete rst7 format
 
 [Term]
 id: MOLSIM:001050
-name: rst7 format
-def: "A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)" []
-is_a: MOLSIM:000471 ! AMBER restart format
+name: obsolete rst7 format
+def: "OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection." []
+comment: Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.
+is_obsolete: true
+replaced_by: MOLSIM:001049
 
 [Term]
 id: MOLSIM:001051
@@ -10361,10 +10430,10 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 
 [Term]
 id: MOLSIM:001059
-name: conflib  format
+name: conflib format
 def: "The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)" []
 synonym: ".conflib" EXACT []
-synonym: "LMOD conflib  format" EXACT []
+synonym: "LMOD conflib format" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
 
 [Term]
@@ -10385,17 +10454,19 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 [Term]
 id: MOLSIM:001062
 name: pqr format
-def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)" []
+def: "The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field." []
 synonym: ".pqr" EXACT []
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001063
 name: MOE
-def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)" []
+def: "The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface." []
 synonym: "Molecular Operating Environment" EXACT []
 is_a: MOLSIM:000490 ! structure preparation tool
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001064
@@ -10457,14 +10528,14 @@ is_a: MOLSIM:001090 ! molecular trajectory format
 id: MOLSIM:001072
 name: information content entity
 def: "An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)" []
-property_value: dcterms:BibliographicResource "" xsd:string
 
 [Term]
 id: MOLSIM:001073
 name: molecular system specification
-def: "A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)" []
+def: "A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed." []
 is_a: MOLSIM:001072 ! information content entity
 disjoint_from: MOLSIM:001074 ! process specification
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001074
@@ -10559,6 +10630,7 @@ is_a: MOLSIM:001091 ! molecular topology format
 id: MOLSIM:001087
 name: obsolete macromolecular structure format
 def: "OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats." []
+comment: Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Reported in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -10572,6 +10644,7 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 id: MOLSIM:001089
 name: obsolete software-specific coordinate format
 def: "OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations." []
+comment: Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of 'molecular structure format' (MOLSIM:001088). Related discussion in GitHub issue #20.
 is_obsolete: true
 
 [Term]
@@ -10636,7 +10709,7 @@ is_a: MOLSIM:002066 ! force field parameter format
 id: MOLSIM:001099
 name: DFTB parameter format
 def: "The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)" []
-synonym: "skf  format" EXACT []
+synonym: "skf format" EXACT []
 is_a: MOLSIM:002066 ! force field parameter format
 
 [Term]
@@ -10755,15 +10828,17 @@ is_a: MOLSIM:010022 ! quantum chemistry format
 [Term]
 id: MOLSIM:001118
 name: mdinfo format
-def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)" []
+def: "The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file." []
 synonym: "AMBER mdinfo format" EXACT []
 is_a: MOLSIM:000439 ! simulation log format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001119
 name: database web server
-def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)" []
+def: "A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system." []
 is_a: MOLSIM:001671 ! web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001120
@@ -11004,8 +11079,9 @@ is_a: MOLSIM:001199 ! external field parameter
 [Term]
 id: MOLSIM:001201
 name: constraint and restraint parameter
-def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)" []
+def: "A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001202
@@ -11093,14 +11169,16 @@ is_a: MOLSIM:001210 ! system setup parameter
 [Term]
 id: MOLSIM:001215
 name: alchemical transformation state
-def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)" []
+def: "A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ)." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001216
 name: number of replicates
-def: "A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)" []
+def: "A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design." []
 is_a: MOLSIM:001210 ! system setup parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001217
@@ -11868,8 +11946,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001337
 name: hydrogen mass repartitioning analysis
-def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics. (UNVERIFIED)" []
+def: "Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system's dynamics." []
 is_a: MOLSIM:000328 ! system setup modeling
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001338
@@ -11886,8 +11965,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:001340
 name: dihedral angle
-def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)" []
+def: "A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001341
@@ -12076,8 +12156,9 @@ property_value: IAO:0000117 orcid:0000-0002-7544-0938
 [Term]
 id: MOLSIM:001366
 name: base pair step parameter
-def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)" []
+def: "A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist." []
 is_a: MOLSIM:001358 ! nucleic acid parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001367
@@ -12511,8 +12592,9 @@ is_a: MOLSIM:001427 ! miscellaneous descriptor
 [Term]
 id: MOLSIM:001432
 name: adaptive string method
-def: "The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)" []
+def: "The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (\"images\") along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path." []
 is_a: MOLSIM:000860 ! string method
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001433
@@ -12574,14 +12656,16 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001442
 name: amber ff03
-def: "Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)" []
+def: "Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001443
 name: amber ff03ua
-def: "This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)" []
+def: "This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001444
@@ -12619,13 +12703,13 @@ is_a: MOLSIM:000010 ! DNA force field
 id: MOLSIM:001449
 name: lipid11
 def: "Lipid11 is a specific version of the AMBER lipid force field, released around 2011, that provided an updated set of parameters for simulating common phospholipid molecules. It served as an improvement over earlier lipid models within the AMBER family for modeling biological membranes. It has since been superseded by more recent versions like LIPID14 and LIPID17, but represents an important step in the development of AMBER's membrane simulation capabilities. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001450
 name: GAFFLipid
 def: "GAFFLipid is a force field for simulating a wide variety of lipid molecules, built upon the principles of the General Amber Force Field (GAFF). It uses the GAFF atom typing and parameterization strategy to automatically generate parameters for lipids that are not covered by specialized lipid force fields like LIPID17. This makes it a versatile tool for modeling novel or unusual lipid species in membrane simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000008 ! lipid  force field
+is_a: MOLSIM:000008 ! lipid force field
 
 [Term]
 id: MOLSIM:001451
@@ -12899,8 +12983,9 @@ is_a: MOLSIM:000014 ! water model force field
 [Term]
 id: MOLSIM:001494
 name: crystallographic model component
-def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)" []
+def: "A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid." []
 is_a: MOLSIM:000006 ! model
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001495
@@ -13121,8 +13206,9 @@ is_a: MOLSIM:000204 ! ligand charge model
 [Term]
 id: MOLSIM:001530
 name: amber fb15
-def: "Amber fb15 is a specific \"recipe\" or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)" []
+def: "The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles." []
 is_a: MOLSIM:000009 ! protein force field
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001531
@@ -13288,8 +13374,9 @@ is_a: MOLSIM:001956 ! system packing and solvation tool
 [Term]
 id: MOLSIM:001558
 name: electrostatics analysis tool
-def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)" []
+def: "An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule's surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001559
@@ -13335,15 +13422,17 @@ is_a: MOLSIM:001968 ! alchemical analysis tool
 
 [Term]
 id: MOLSIM:001566
-name: library
-def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)" []
+name: software library
+def: "A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing." []
+synonym: "library" EXACT []
 is_a: MOLSIM:000170 ! software component
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001567
 name: FFTW
 def: "FFTW is a highly optimized software library for computing the discrete Fourier transform, a fundamental mathematical operation used in many scientific applications. In biomolecular simulations, it is most commonly used to perform the Fast Fourier Transform (FFT) required for the Particle Mesh Ewald (PME) method of calculating long-range electrostatic forces. For simulation engines, using the FFTW library is essential for achieving high performance in the most computationally demanding part of the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001568
@@ -13372,14 +13461,16 @@ is_a: MOLSIM:000272 ! radii set
 [Term]
 id: MOLSIM:001572
 name: ndfes
-def: "ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)" []
+def: "The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods." []
 is_a: MOLSIM:001969 ! free energy surface analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001573
 name: ParmEd
-def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001574
@@ -13417,7 +13508,7 @@ id: MOLSIM:001579
 name: pytraj
 def: "Pytraj is a Python library that provides a programmable interface to the powerful trajectory analysis capabilities of the cpptraj engine from the AmberTools suite. It allows users to write Python scripts to perform a wide range of analyses, such as calculating RMSD, distances, and hydrogen bonds, directly on simulation trajectories. Pytraj enables the creation of complex, automated, and reproducible analysis workflows that integrate seamlessly with other Python data science tools." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -13436,7 +13527,7 @@ is_a: MOLSIM:000161 ! quantum chemistry engine
 id: MOLSIM:001582
 name: torch PBSA runtime
 def: "The torch PBSA runtime is a software library that leverages the PyTorch deep learning framework to perform Poisson-Boltzmann Surface Area (PBSA) calculations. By using PyTorch, it can take advantage of GPU acceleration to significantly speed up the computationally intensive process of solving the Poisson-Boltzmann equation. For researchers, this library offers a high-performance tool for estimating solvation free energies as part of binding free energy calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001583
@@ -13464,21 +13555,24 @@ is_a: MOLSIM:001585 ! build system tool
 
 [Term]
 id: MOLSIM:001587
-name: Intel Math Kernel Library
-def: "The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+name: Intel oneAPI Math Kernel Library
+def: "The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001588
 name: package manager
-def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)" []
+def: "A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments." []
 is_a: MOLSIM:000171 ! software development and management tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001589
 name: Miniconda
-def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)" []
+def: "Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software." []
 is_a: MOLSIM:001588 ! package manager
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001590
@@ -13532,7 +13626,7 @@ is_a: MOLSIM:000157 ! framework
 id: MOLSIM:001598
 name: TCPB-cpp
 def: "TCPB-cpp is a software tool that acts as a bridge, allowing a classical simulation program to communicate with the TeraChem quantum chemistry program. It is a C++ library that provides an Application Programming Interface (API), enabling a molecular dynamics engine to send a small, quantum mechanical (QM) part of the system to TeraChem for a high-performance, GPU-accelerated energy and force calculation. This allows for the creation of powerful and efficient QM/MM simulations, where the speed of a classical simulation is combined with the accuracy of TeraChem's quantum calculations for studying chemical reactions. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001599
@@ -13598,7 +13692,7 @@ is_a: MOLSIM:001970 ! parameter assignment tool
 [Term]
 id: MOLSIM:001608
 name: parmcal
-def: "an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
+def: "An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)" []
 is_a: MOLSIM:001970 ! parameter assignment tool
 
 [Term]
@@ -13741,8 +13835,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001631
 name: ambpdb
-def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)" []
+def: "The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER's native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001632
@@ -13867,20 +13962,22 @@ is_a: MOLSIM:001569 ! utility script
 [Term]
 id: MOLSIM:001652
 name: chamber
-def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)" []
+def: "The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001653
 name: match_atomname
-def: "match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)" []
+def: "match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations." []
 is_a: MOLSIM:001569 ! utility script
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001654
 name: MPI library
 def: "An MPI library is a software library that implements the Message Passing Interface (MPI) standard for parallel programming. It provides functions that allow multiple independent processes, typically running on different computers in a cluster, to communicate and exchange data with each other. For high-performance biomolecular simulations, an MPI library is essential for parallelizing the calculations and distributing the workload across many processors to simulate large systems efficiently. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001655
@@ -13892,7 +13989,7 @@ is_a: MOLSIM:001654 ! MPI library
 id: MOLSIM:001656
 name: ARPACK
 def: "ARPACK is a software library for solving large-scale eigenvalue problems, which involve finding the characteristic modes and values of a large matrix. It is particularly efficient at finding a subset of eigenvalues and their corresponding eigenvectors, which is often what is needed in scientific computing. In biomolecular simulation, ARPACK is used in analysis methods like Normal Mode Analysis or Principal Component Analysis to calculate the dominant modes of molecular motion. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001657
@@ -13915,14 +14012,16 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001660
 name: NAB
-def: "NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)" []
+def: "NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository." []
 is_a: MOLSIM:001659 ! programming language
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001661
 name: FE-ToolKit
-def: "The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001662
@@ -13987,27 +14086,29 @@ is_a: MOLSIM:000001 ! software
 [Term]
 id: MOLSIM:001672
 name: GLYCAM-Web
-def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)" []
+def: "GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages." []
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001673
 name: Glycoprotein Builder
-def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)" []
+def: "The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein." []
 is_a: MOLSIM:001119 ! database web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001674
 name: RDKit
 def: "RDKit is an open-source software library for cheminformatics, providing a wide range of tools for working with chemical structures. It allows users to read and write molecular file formats, generate 2D and 3D coordinates, calculate molecular descriptors, and perform substructure searching. In the context of biomolecular simulation, RDKit is frequently used in preparatory workflows to process, analyze, and prepare small molecule ligands for subsequent modeling and simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001675
 name: OpenMM
 def: "OpenMM is a high-performance software library that provides a toolkit for running molecular dynamics simulations, with a strong emphasis on GPU acceleration. It is not a monolithic application but rather a flexible library that allows developers to easily add simulation capabilities to their own programs. For the simulation community, OpenMM provides a powerful, hardware-accelerated, and easily customizable platform for developing new simulation methods and applications. (UNVERIFIED)" []
 is_a: MOLSIM:000160 ! molecular dynamics engine
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001676
@@ -14026,30 +14127,32 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:001678
 name: BLAS
 def: "BLAS, or Basic Linear Algebra Subprograms, is a specification that defines a set of low-level routines for performing common linear algebra operations such as vector and matrix multiplication. Highly optimized libraries that implement the BLAS standard are available and provide a foundation for more complex numerical software. For simulation and quantum chemistry programs, using an optimized BLAS library is critical for achieving high performance in matrix-intensive calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001679
 name: LAPACK
 def: "LAPACK, or the Linear Algebra Package, is a standard software library that provides routines for solving more advanced numerical linear algebra problems. It includes functions for solving systems of linear equations, finding eigenvalues and eigenvectors, and performing matrix factorizations. For computational chemistry and simulation analysis tools, LAPACK is an essential component for tasks like matrix diagonalization in Principal Component Analysis or solving equations in quantum mechanical calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001680
 name: DL-Find
-def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations." []
+is_a: MOLSIM:001566 ! software library
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001681
 name: sff
 def: "The sff library is a software component, often used with the OpenMM simulation toolkit, for parsing and interpreting force field definition files. It is designed to read standard force field file formats, such as those from AMBER, and make the parameters available to a simulation engine. This library provides the essential function of translating the human-readable force field files into the internal representation needed to calculate forces during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001682
 name: 3DNA
 def: "x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures." []
+synonym: "x3DNA" EXACT []
 is_a: MOLSIM:001960 ! nucleic acid analysis tool
 property_value: IAO:0000117 orcid:0000-0002-4303-9349
 property_value: IAO:0000117 orcid:0000-0002-7544-0938
@@ -14063,8 +14166,9 @@ is_a: MOLSIM:000160 ! molecular dynamics engine
 [Term]
 id: MOLSIM:001684
 name: match analysis tool
-def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)" []
+def: "A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound." []
 is_a: MOLSIM:000164 ! analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001685
@@ -14438,8 +14542,9 @@ is_a: MOLSIM:000447 ! identifier
 [Term]
 id: MOLSIM:001743
 name: ICOSA algorithm
-def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment. (UNVERIFIED)" []
+def: "The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule's exposure to its environment." []
 is_a: MOLSIM:001715 ! surface area calculation algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001744
@@ -14456,9 +14561,10 @@ is_a: MOLSIM:001696 ! analysis algorithm
 [Term]
 id: MOLSIM:001746
 name: DSSP algorithm
-def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)" []
+def: "The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation." []
 is_a: MOLSIM:001745 ! secondary structure assignment algorithm
 disjoint_from: MOLSIM:010012 ! STRIDE algorithm
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001747
@@ -14516,6 +14622,7 @@ id: MOLSIM:001755
 name: atom name
 def: "An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names 'CA' and 'CB' are used to differentiate the alpha-carbon from the beta-carbon." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
@@ -14593,20 +14700,20 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001767
 name: trajectory post-processing
 def: "Trajectory post-processing is the general process of cleaning and preparing raw simulation trajectory files before performing detailed scientific analysis. This typically involves essential steps like removing the overall rotation and translation of a target molecule to keep it centered, and fixing any molecules that appear \"broken\" by the periodic boundary conditions. These routine procedures are necessary to create a clean trajectory that is suitable for correct visualization and accurate calculation of structural properties." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001768
 name: match list preparation
 def: "This is a setup step in some advanced simulation or analysis workflows where a list is created to define a correspondence between atoms in two different molecules or structures. This \"match list\" is essential for methods like alchemical free energy calculations, where it specifies which atom in one molecule transforms into which atom in another. The correct preparation of this list is a critical and often manual step that defines the mapping for the entire transformation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001769
 name: topology and coordinate file preparation
 def: "This is the fundamental setup process in preparing a molecular simulation, where two distinct but essential files are created. The first is the topology file, which defines the molecule's chemical identity, including its atoms, bonds, and force field parameters. The second is the coordinate file, which provides the initial three-dimensional positions of all the atoms, serving as the starting snapshot for the simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001770
@@ -14631,13 +14738,13 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001773
 name: LEaP preparation
 def: "LEaP preparation is the process of using the LEaP program from the AmberTools software suite to build a complete molecular system that is ready for simulation. This involves loading a molecular structure file, applying a specific force field to assign parameters, adding a box of solvent molecules, and introducing ions to neutralize the system's charge. This step is the standard and essential procedure for assembling all the necessary components into the final topology and coordinate files needed to run an AMBER simulation. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001774
 name: momentum removal
 def: "Momentum removal is a procedure applied periodically during a molecular dynamics simulation to prevent the entire system from drifting or spinning over time. It works by resetting the total linear and angular momentum of the system to zero at regular intervals, which can otherwise accumulate due to numerical inaccuracies in the integration algorithm. This is a standard housekeeping procedure that ensures the molecule of interest remains centered in the simulation box for easier analysis. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:001775
@@ -14679,7 +14786,7 @@ is_a: MOLSIM:001778 ! wavefunction model
 id: MOLSIM:001781
 name: secondary structure
 def: "Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein's overall architecture and how its shape changes during a simulation. (UNVERIFIED)" []
-is_a: MOLSIM:001333 ! structural property
+is_a: SO:0001078 ! polypeptide_secondary_structure
 
 [Term]
 id: MOLSIM:001782
@@ -14690,38 +14797,48 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001783
 name: parallel beta sheet
-def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)" []
+def: "A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001784
 name: anti-parallel beta sheet
-def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)" []
+def: "An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins." []
 is_a: MOLSIM:001782 ! beta sheet
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001785
-name: helix
-def: "A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)" []
-is_a: MOLSIM:001781 ! secondary structure
+name: obsolete helix
+def: "OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001114
 
 [Term]
 id: MOLSIM:001786
-name: 3-10 helix
-def: "The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete 3-10 helix
+def: "OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001119
 
 [Term]
 id: MOLSIM:001787
-name: alpha helix
-def: "The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete alpha helix
+def: "OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001117
 
 [Term]
 id: MOLSIM:001788
-name: pi helix
-def: "The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)" []
-is_a: MOLSIM:001785 ! helix
+name: obsolete pi helix
+def: "OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix." []
+comment: Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.
+is_obsolete: true
+replaced_by: SO:0001118
 
 [Term]
 id: MOLSIM:001789
@@ -14732,8 +14849,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001790
 name: bend
-def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein's compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)" []
+def: "A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001791
@@ -14744,8 +14862,9 @@ is_a: MOLSIM:001781 ! secondary structure
 [Term]
 id: MOLSIM:001792
 name: beta bridge
-def: "A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein's folded structure together. (UNVERIFIED)" []
+def: "A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets." []
 is_a: MOLSIM:001781 ! secondary structure
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001793
@@ -14764,8 +14883,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001795
 name: MDL solvent model format
-def: "The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent's bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)" []
+def: "The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions." []
 is_a: MOLSIM:001091 ! molecular topology format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001796
@@ -15114,13 +15234,14 @@ is_a: MOLSIM:001463 ! QM/MM model component
 id: MOLSIM:001849
 name: convergence analysis
 def: "Convergence analysis is the process of checking whether a simulation has been run for a sufficient amount of time to provide a stable and reliable result. This is typically done by monitoring a key property, such as the system's energy or a structural measurement, to see if its average value stops changing and remains steady over the later parts of the simulation. Performing this analysis is a critical step to ensure that the calculated properties are statistically meaningful and not just an artifact of a short, unrepresentative trajectory. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001850
 name: modeling and setup tool
-def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)" []
+def: "A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation." []
 is_a: MOLSIM:000158 ! simulation and modeling software
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001851
@@ -15176,7 +15297,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:001859
 name: network analysis
 def: "Network analysis is a method that represents a molecule as a graph of nodes (atoms or residues) connected by edges (interactions or correlations) to analyze how information is communicated through its structure. By applying graph theory, this approach can identify critical residues that act as communication hubs and map the pathways of correlated motion that connect distant parts of the molecule. This is a powerful tool for understanding allosteric regulation and the long-range effects of mutations. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001860
@@ -15188,7 +15309,7 @@ is_a: MOLSIM:000917 ! structural analysis
 id: MOLSIM:001861
 name: ligand analysis
 def: "Ligand analysis is a broad category of methods focused on characterizing the behavior of a small molecule, or ligand, during a simulation of its complex with a larger receptor. This includes analyzing the stability of its binding pose, its internal flexibility and conformational changes, and its specific interactions with the protein or nucleic acid. These analyses are fundamental to structure-based drug design for understanding the determinants of binding affinity and specificity. (UNVERIFIED)" []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 
 [Term]
 id: MOLSIM:001862
@@ -15220,21 +15341,22 @@ is_a: MOLSIM:001403 ! statistical property
 [Term]
 id: MOLSIM:001866
 name: backbone DH fluctuations
-def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)" []
+def: "Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein's backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein's flexibility and dynamics that is independent of its overall tumbling motion." []
 is_a: MOLSIM:001333 ! structural property
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001867
 name: membrane analysis
 def: "Membrane analysis is a category of analysis methods specifically focused on characterizing the properties of lipid bilayer simulations. These methods are used to quantify the structural and dynamic behavior of the membrane itself and its interactions with other molecules, like embedded proteins. This includes calculating key properties such as the area per lipid, membrane thickness, and lipid order parameters to validate the simulation and understand membrane function." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
 id: MOLSIM:001868
 name: area per lipid
 def: "The area per lipid is a fundamental biophysical metric representing the average cross-sectional surface area occupied by a single lipid molecule within a lipid bilayer. It is calculated by dividing the total area of the simulation box in the membrane plane by the number of lipids in one leaflet." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -15355,7 +15477,7 @@ is_a: MOLSIM:000342 ! correlation analysis
 id: MOLSIM:001885
 name: trajectory meta analysis
 def: "Trajectory meta-analysis refers to a higher level of analysis that involves comparing, contrasting, or combining the results from multiple, independent simulation trajectories. This can be used to improve statistical certainty, assess the convergence of a simulation, or identify the differences in dynamics between a wild-type protein and a mutant. This approach is essential for drawing robust conclusions that are not dependent on a single simulation run." []
-is_a: MOLSIM:000004 ! analysis
+is_a: MOLSIM:000004 ! simulation analysis
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -15381,8 +15503,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001889
 name: complex system
-def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)" []
+def: "A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together." []
 is_a: MOLSIM:001887 ! molecular simulation system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001890
@@ -15414,8 +15537,9 @@ is_a: MOLSIM:001890 ! ligand complex system
 [Term]
 id: MOLSIM:001894
 name: hybrid complex system
-def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)" []
+def: "A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair." []
 is_a: MOLSIM:001889 ! complex system
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001895
@@ -15576,7 +15700,7 @@ id: MOLSIM:001918
 name: MDAnalysis
 def: "MDAnalysis is an open-source Python library used for the analysis of molecular dynamics simulation trajectories. It provides a flexible and object-oriented framework that allows users to read, write, and manipulate atomic coordinate data from a wide variety of simulation packages. MDAnalysis is a powerful tool for writing custom, complex, and reproducible analysis scripts in a familiar Python environment." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
@@ -15584,41 +15708,44 @@ id: MOLSIM:001919
 name: MDTraj
 def: "MDTraj is a modern, open-source Python library designed for the fast and efficient analysis of molecular dynamics trajectories. It excels at reading and writing a very broad range of trajectory and topology file formats, making it highly interoperable. MDTraj provides a fast and powerful toolkit for performing common structural and time-series analyses on simulation data." []
 is_a: MOLSIM:000251 ! trajectory processing tool
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001920
 name: ProDy
 def: "ProDy is a free and open-source Python package for analyzing protein structural dynamics. It provides a comprehensive set of tools for tasks such as parsing structure files, analyzing conformational ensembles, and calculating collective modes of motion using methods like Normal Mode Analysis. For researchers studying protein function, ProDy offers a powerful environment for exploring the link between a protein's structure and its dynamic behavior. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:001921
 name: BioBB
 def: "BioBB, or BioExcel Building Blocks, is a library of Python wrappers that create a standardized interface for many common biomolecular simulation programs like GROMACS and AmberTools. Each building block performs a specific task, such as running an energy minimization or calculating an RMSD, using a consistent input and output format. For computational biologists, BioBB provides an interoperable toolkit for constructing complex, reproducible, and portable simulation workflows." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:001922
 name: 3DMol.js
-def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001923
 name: NGL
-def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+def: "NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids." []
+is_a: MOLSIM:001566 ! software library
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001924
 name: Open Babel
-def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)" []
+def: "Open Babel is a versatile software program and library, often called a \"chemical toolbox,\" for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files." []
 is_a: MOLSIM:000166 ! file conversion tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001925
@@ -15635,15 +15762,17 @@ is_a: MOLSIM:000251 ! trajectory processing tool
 [Term]
 id: MOLSIM:001927
 name: CHARMM-GUI
-def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)" []
+def: "CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations." []
 is_a: MOLSIM:000225 ! membrane packing tool
 is_a: MOLSIM:000714 ! tool web server
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001928
 name: Modeller
-def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)" []
+def: "Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein's structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation." []
 is_a: MOLSIM:001958 ! homology modeling tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001929
@@ -15667,15 +15796,17 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001932
 name: Jmol
-def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)" []
+def: "Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001933
 name: MolStar
-def: "MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)" []
+def: "MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies." []
 synonym: "Mol*" EXACT []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001934
@@ -15812,8 +15943,9 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:001955
 name: crystallographic build tool
-def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)" []
+def: "A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment." []
 is_a: MOLSIM:001556 ! system setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001956
@@ -15830,14 +15962,16 @@ is_a: MOLSIM:000490 ! structure preparation tool
 [Term]
 id: MOLSIM:001958
 name: homology modeling tool
-def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)" []
+def: "A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable." []
 is_a: MOLSIM:001850 ! modeling and setup tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001959
 name: AutoDock Vina
-def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)" []
+def: "AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001960
@@ -15873,14 +16007,16 @@ is_a: MOLSIM:001684 ! match analysis tool
 [Term]
 id: MOLSIM:001965
 name: DALI
-def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)" []
+def: "DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001966
 name: LS-align
-def: "LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)" []
+def: "LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm." []
 is_a: MOLSIM:001684 ! match analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001967
@@ -15898,8 +16034,9 @@ is_a: MOLSIM:001564 ! free energy analysis tool
 [Term]
 id: MOLSIM:001969
 name: free energy surface analysis tool
-def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)" []
+def: "A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates." []
 is_a: MOLSIM:001564 ! free energy analysis tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001970
@@ -15954,7 +16091,7 @@ is_a: MOLSIM:001531 ! united-atom force field
 id: MOLSIM:001978
 name: PLUMED
 def: "PLUMED is an open-source software library designed to analyze molecular dynamics simulations and perform enhanced sampling of free energy landscapes. It functions as middleware that interfaces with various simulation engines to calculate collective variables and apply biasing potentials in real-time." []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 property_value: IAO:0000117 orcid:0009-0007-1391-4986
 
 [Term]
@@ -16060,8 +16197,9 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:001995
 name: position restraints
-def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)" []
+def: "A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol." []
 is_a: MOLSIM:001552 ! restraint potential
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:001996
@@ -16157,7 +16295,7 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 id: MOLSIM:002010
 name: solvation
 def: "Solvation is the computational process of immersing a solute molecule, such as a protein, into a box containing solvent molecules, typically water. This step involves placing the solute coordinates into a pre-equilibrated solvent box, removing solvent molecules that overlap with the solute atoms, and updating the system topology. For experts, this process defines the simulation box dimensions, density, and total number of atoms, which are critical for the efficiency and validity of periodic boundary condition simulations. (UNVERIFIED)" []
-is_a: MOLSIM:000002 ! preparation
+is_a: MOLSIM:000002 ! simulation preparation
 
 [Term]
 id: MOLSIM:002011
@@ -16168,8 +16306,9 @@ is_a: MOLSIM:001333 ! structural property
 [Term]
 id: MOLSIM:002012
 name: continuation state
-def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the \"flying ice cube\" effect). (UNVERIFIED)" []
+def: "A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory." []
 is_a: MOLSIM:001164 ! simulation parameter
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002013
@@ -16335,28 +16474,32 @@ is_a: MOLSIM:000441 ! simulation state format
 [Term]
 id: MOLSIM:002039
 name: atom ID
-def: "An atom ID is usually a number, that uniquely defines a given atom in structure." []
+def: "An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system." []
 is_a: MOLSIM:000447 ! identifier
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 property_value: IAO:0000117 orcid:0000-0003-4177-3619
 
 [Term]
 id: MOLSIM:002040
 name: JSmol
-def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)" []
+def: "JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools." []
 is_a: MOLSIM:002041 ! molecular structure visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002041
 name: molecular structure visualization tool
-def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)" []
+def: "A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships." []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002042
 name: data plotting tool
-def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)" []
+def: "A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files." []
 synonym: "data visualization tool" EXACT []
 is_a: MOLSIM:000163 ! visualization tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002043
@@ -16387,33 +16530,36 @@ is_a: MOLSIM:001562 ! application programming interface
 id: MOLSIM:002047
 name: OpenMPI
 def: "Open MPI is an open-source, freely available implementation of the Message Passing Interface (MPI) standard. It is widely used in high-performance computing to facilitate communication between distributed processes. In biomolecular simulation, it is a standard library used to compile and run parallel simulation engines, such as GROMACS, LAMMPS, and NAMD, across multiple nodes of a computer cluster to ensure efficient scaling and data exchange. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002048
 name: MPICH
 def: "MPICH is a highly efficient, open-source implementation of the Message Passing Interface (MPI) standard. It serves as both a widely used standalone MPI library for high-performance computing and as the foundational framework for many other vendor-specific or derivative MPI implementations (such as Intel MPI and MVAPICH). For biomolecular simulations on distributed-memory supercomputers, MPICH provides the essential message-passing infrastructure required for large-scale parallelization. (UNVERIFIED)" []
-is_a: MOLSIM:001566 ! library
+is_a: MOLSIM:001566 ! software library
 
 [Term]
 id: MOLSIM:002049
 name: AutoDock
-def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)" []
+def: "AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function." []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002050
 name: GOLD
-def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)" []
+def: "GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement." []
 synonym: "Genetic Optimisation for Ligand Docking" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002051
 name: Glide
-def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)" []
+def: "Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations." []
 synonym: "Grid-based Ligand Docking with Energetics" EXACT []
 is_a: MOLSIM:000162 ! docking tool
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002052
@@ -16462,10 +16608,11 @@ property_value: IAO:0000117 orcid:0009-0007-1391-4986
 [Term]
 id: MOLSIM:002058
 name: PDBQT format
-def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)" []
+def: "The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges ('Q') and AutoDock-specific atom types ('T'), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms." []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
 disjoint_from: MOLSIM:002059 ! PROPKA output format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002059
@@ -16477,8 +16624,9 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002060
 name: docking log format
-def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)" []
+def: "A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files." []
 is_a: MOLSIM:000715 ! prediction data format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002061
@@ -16490,11 +16638,12 @@ is_a: MOLSIM:000715 ! prediction data format
 [Term]
 id: MOLSIM:002062
 name: Maestro format
-def: "The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)" []
+def: "The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties." []
 synonym: "mae format" EXACT []
 synonym: "maegz format" EXACT []
 is_a: MOLSIM:000715 ! prediction data format
 is_a: MOLSIM:001088 ! molecular structure format
+property_value: IAO:0000117 orcid:0000-0002-8291-8071
 
 [Term]
 id: MOLSIM:002063
@@ -16724,411 +16873,418 @@ property_value: IAO:0000117 orcid:0000-0002-2294-5393
 [Term]
 id: MOLSIM:002098
 name: restart simulation process
-def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)" []
-is_a: MOLSIM:000003 ! execution
+def: "An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)" []
+is_a: MOLSIM:000003 ! simulation execution
 
 [Term]
 id: MOLSIM:002099
 name: metadata extraction tool
-def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)" []
 is_a: MOLSIM:000165 ! data processing tool
 
 [Term]
 id: MOLSIM:002100
 name: PMEMD.cuda
-def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)" []
 is_a: MOLSIM:001669 ! PMEMD
 
 [Term]
 id: MOLSIM:002101
 name: metadata validation process
-def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002102
 name: coordinate wrapping process
-def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)" []
 is_a: MOLSIM:001767 ! trajectory post-processing
 
 [Term]
 id: MOLSIM:002103
 name: NMR restrained simulation
-def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)" []
 is_a: MOLSIM:000364 ! restrained simulation method
 
 [Term]
 id: MOLSIM:002104
 name: belly dynamics
-def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)" []
 is_a: MOLSIM:000335 ! restrained subset dynamics
 
 [Term]
 id: MOLSIM:002105
 name: replica exchange attempt frequency
-def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)" []
 is_a: MOLSIM:001219 ! enhanced sampling parameter
 
 [Term]
 id: MOLSIM:002106
 name: center of mass removal interval
-def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how frequently the net translational motion of the system's center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002107
 name: multi-timestep inner loop count
-def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:001165 ! integration parameter
 
 [Term]
 id: MOLSIM:002108
 name: output control parameter
-def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002109
 name: energy output interval
-def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002110
 name: restart output interval
-def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002111
 name: log output interval
-def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)" []
 is_a: MOLSIM:002108 ! output control parameter
 
 [Term]
 id: MOLSIM:002112
 name: simulation state time
-def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:001083 ! simulation state
 
 [Term]
 id: MOLSIM:002113
 name: final density
-def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002114
 name: computational performance metric
-def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)" []
 is_a: MOLSIM:001292 ! computed observable
 
 [Term]
 id: MOLSIM:002115
 name: total wallclock time
-def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 disjoint_from: MOLSIM:002116 ! total cpu time
 
 [Term]
 id: MOLSIM:002116
 name: total cpu time
-def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002117
 name: setup wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002118
 name: production wallclock time
-def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002119
 name: average integration step time
-def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002120
 name: simulation throughput
-def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)" []
 is_a: MOLSIM:002114 ! computational performance metric
 
 [Term]
 id: MOLSIM:002155
 name: simulation protocol
-def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002156
 name: simulation stage
-def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)" []
 is_a: MOLSIM:000000 ! molecular dynamics process
 
 [Term]
 id: MOLSIM:002157
 name: simulation parameter schedule
-def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)" []
 is_a: MOLSIM:001164 ! simulation parameter
 
 [Term]
 id: MOLSIM:002158
 name: simulation continuity check
-def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002159
 name: cross-source validation
-def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)" []
 is_a: MOLSIM:000353 ! validation analysis
 
 [Term]
 id: MOLSIM:002160
 name: file parsing error
-def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002161
 name: file format convention
-def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file's contents. (UNVERIFIED)" []
 is_a: MOLSIM:000436 ! data format
 
 [Term]
 id: MOLSIM:002162
 name: system classification label
-def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002163
 name: atom selection mask
-def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002164
 name: trajectory frame interval
-def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 disjoint_from: MOLSIM:002165 ! inter-stage time gap
 
 [Term]
 id: MOLSIM:002165
 name: inter-stage time gap
-def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)" []
 is_a: MOLSIM:002112 ! simulation state time
 
 [Term]
 id: MOLSIM:002166
 name: hydrogen detection strategy
-def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)" []
 is_a: MOLSIM:001696 ! analysis algorithm
 
 [Term]
 id: MOLSIM:002192
 name: initial density
-def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)" []
 is_a: MOLSIM:001293 ! thermodynamic property
 
 [Term]
 id: MOLSIM:002196
 name: atom count consistency check
-def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 disjoint_from: MOLSIM:002197 ! box consistency check
 
 [Term]
 id: MOLSIM:002197
 name: box consistency check
-def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002198
 name: timing consistency check
-def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002199
 name: sampling consistency check
-def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)" []
 is_a: MOLSIM:002159 ! cross-source validation
 
 [Term]
 id: MOLSIM:002203
 name: protein domain
-def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)" []
+def: "A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains." []
 is_a: SO:0000417 ! polypeptide_domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002204
 name: receptor-binding domain
-def: "A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)" []
+def: "A protein domain whose function is to attach to a matching partner molecule called a receptor." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002205
 name: catalytic domain
-def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)" []
+def: "A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme." []
 is_a: MOLSIM:002203 ! protein domain
 property_value: IAO:0000117 orcid:0000-0002-2294-5393
 
 [Term]
 id: MOLSIM:002206
 name: protein functional class label
-def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002207
 name: enzyme classification label
-def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002208
 name: transport protein classification label
-def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002209
 name: structural protein classification label
-def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002210
 name: regulatory protein classification label
-def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002211
 name: signaling protein classification label
-def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002212
 name: motor protein classification label
-def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002213
 name: immune protein classification label
-def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002214
 name: storage protein classification label
-def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)" []
 is_a: MOLSIM:002206 ! protein functional class label
 
 [Term]
 id: MOLSIM:002226
 name: periodic box angles
-def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)" []
 is_a: MOLSIM:001210 ! system setup parameter
 
 [Term]
 id: MOLSIM:002230
 name: SMILES code
-def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)" []
 is_a: MOLSIM:000447 ! identifier
 
 [Term]
 id: MOLSIM:002232
 name: compiler
-def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A software development and management tool that translates a program's source code into a runnable program. Which compiler was used can affect a simulation's speed and, occasionally, its numerical results. (UNVERIFIED)" []
 is_a: MOLSIM:000171 ! software development and management tool
 
 [Term]
 id: MOLSIM:002233
 name: atom index group
-def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)" []
 is_a: MOLSIM:000310 ! plan specification
 
 [Term]
 id: MOLSIM:002234
 name: classical molecular dynamics
-def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)" []
 is_a: MOLSIM:000843 ! molecular dynamics
 
 [Term]
 id: MOLSIM:002235
 name: source structure residue mapping
-def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)" []
 is_a: MOLSIM:001072 ! information content entity
 
 [Term]
 id: MOLSIM:002236
 name: oligomeric state
-def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)" []
 is_a: MOLSIM:001333 ! structural property
 
 [Term]
 id: MOLSIM:002237
 name: monomeric state
-def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 disjoint_from: MOLSIM:002238 ! dimeric state
 
 [Term]
 id: MOLSIM:002238
 name: dimeric state
-def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002239
 name: trimeric state
-def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002240
 name: tetrameric state
-def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002241
 name: higher-order oligomeric state
-def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)" []
 is_a: MOLSIM:002236 ! oligomeric state
 
 [Term]
 id: MOLSIM:002246
 name: spike opening conformational state
-def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)" []
 is_a: MOLSIM:000105 ! conformational state
 
 [Term]
 id: MOLSIM:002247
 name: biological strain classification label
-def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
 
 [Term]
 id: MOLSIM:002248
 name: histone variant classification label
-def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)" []
 is_a: MOLSIM:002162 ! system classification label
+
+[Term]
+id: MOLSIM:002249
+name: DSSR
+def: "A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)" []
+synonym: "Dissecting the Spatial Structure of RNA" EXACT []
+is_a: MOLSIM:001960 ! nucleic acid analysis tool
 
 [Term]
 id: MOLSIM:010001
@@ -17437,6 +17593,73 @@ synonym: "polypeptide structural region" EXACT []
 synonym: "structural_region" RELATED []
 is_a: MOLSIM:002090 ! molecular entity
 is_a: SO:0000839 ! polypeptide_region
+
+[Term]
+id: SO:0001078
+name: polypeptide_secondary_structure
+namespace: sequence
+alt_id: BS:00003
+def: "A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain." [EBIBS:GAR]
+comment: Biosapien term was secondary_structure.
+subset: biosapiens
+synonym: "2nary structure" RELATED BS []
+synonym: "polypeptide secondary structure" EXACT []
+synonym: "secondary structure" RELATED BS []
+synonym: "secondary structure region" RELATED BS []
+synonym: "secondary_structure" RELATED BS []
+xref: http://en.wikipedia.org/wiki/Secondary_structure "wiki"
+is_a: SO:0001070 ! polypeptide_structural_region
+
+[Term]
+id: SO:0001114
+name: peptide_helix
+namespace: sequence
+alt_id: BS:00152
+def: "A helix is a secondary_structure conformation where the peptide backbone forms a coil." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "helix" RELATED BS []
+is_a: MOLSIM:001781 ! secondary structure
+
+[Term]
+id: SO:0001117
+name: alpha_helix
+namespace: sequence
+alt_id: BS:00040
+def: "The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "a-helix" RELATED BS []
+synonym: "helix" RELATED BS [uniprot:feature_type]
+xref: http://en.wikipedia.org/wiki/Alpha_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
+
+[Term]
+id: SO:0001118
+name: pi_helix
+namespace: sequence
+alt_id: BS:00153
+def: "The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "pi helix" EXACT []
+xref: http://en.wikipedia.org/wiki/Pi_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
+
+[Term]
+id: SO:0001119
+name: three_ten_helix
+namespace: sequence
+alt_id: BS:0000340
+def: "The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier." [EBIBS:GAR]
+comment: Range.
+subset: biosapiens
+synonym: "3(10) helix" EXACT []
+synonym: "3-10 helix" EXACT []
+synonym: "310 helix" EXACT []
+synonym: "three ten helix" EXACT []
+xref: http://en.wikipedia.org/wiki/310_helix "wiki"
+is_a: SO:0001114 ! peptide_helix
 
 [Term]
 id: SO:0001236
@@ -18054,7 +18277,7 @@ range: MOLSIM:000001 ! software
 id: MOLSIM:000507
 name: alignment tool
 def: "In molecular dynamics, alignment tool provides spatial re-orientation of membrane proteins with respect to the hydrocarbon core of the lipid bilayer. It connects a structural alignment procedure or analysis step to the specific software program or tool used to perform the alignment of molecular structures. Structural alignment is used to superimpose molecular structures (e.g., proteins, nucleic acids) to compare their conformations or identify conserved regions. This property identifies the computational tool responsible for generating the alignment. (UNVERIFIED)" []
-domain: MOLSIM:000004 ! analysis
+domain: MOLSIM:000004 ! simulation analysis
 range: MOLSIM:000001 ! software
 
 [Typedef]
@@ -18095,14 +18318,14 @@ range: MOLSIM:001994 ! reaction coordinate
 [Typedef]
 id: MOLSIM:002167
 name: has simulation stage
-def: "A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)" []
-domain: MOLSIM:002155 ! simulation protocol
+def: "A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002156 ! simulation stage
 
 [Typedef]
 id: MOLSIM:002168
 name: has parameter schedule
-def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002157 ! simulation parameter schedule
 is_a: MOLSIM:002202 ! has simulation parameter
@@ -18110,44 +18333,51 @@ is_a: MOLSIM:002202 ! has simulation parameter
 [Typedef]
 id: MOLSIM:002169
 name: has continuity check
-def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002158 ! simulation continuity check
 
 [Typedef]
 id: MOLSIM:002170
 name: has parsing error
-def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)" []
 domain: MOLSIM:002156 ! simulation stage
 range: MOLSIM:002160 ! file parsing error
 
 [Typedef]
 id: MOLSIM:002171
 name: has system classification
-def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)" []
 domain: MOLSIM:001887 ! molecular simulation system
 range: MOLSIM:002162 ! system classification label
 
 [Typedef]
 id: MOLSIM:002172
 name: has format convention
-def: "A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)" []
 domain: MOLSIM:000436 ! data format
 range: MOLSIM:002161 ! file format convention
 
 [Typedef]
 id: MOLSIM:002173
 name: has restraint mask
-def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:002163 ! atom selection mask
 
 [Typedef]
 id: MOLSIM:002202
 name: has simulation parameter
-def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)" []
+def: "A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)" []
 domain: MOLSIM:000000 ! molecular dynamics process
 range: MOLSIM:001164 ! simulation parameter
+
+[Typedef]
+id: MOLSIM:002250
+name: follows protocol
+def: "A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)" []
+domain: MOLSIM:000000 ! molecular dynamics process
+range: MOLSIM:002155 ! simulation protocol
 
 [Typedef]
 id: OBI:0000299

--- a/molsim.owl
+++ b/molsim.owl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/molsim.owl#"
      xml:base="http://purl.obolibrary.org/obo/molsim.owl"
-     xmlns:dce="http://purl.org/dc/elements/1.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -17,9 +17,14 @@
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/molsim.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-07-29/molsim.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/molsim/releases/2026-08-07/molsim.owl"/>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-0476-9699"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <dcterms:contributor rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0001-8613-1447"/>
         <dcterms:creator rdf:resource="https://orcid.org/0000-0003-4846-8051"/>
@@ -30,7 +35,8 @@
         <oboInOwl:default-namespace xml:lang="en">molsim</oboInOwl:default-namespace>
         <rdfs:comment xml:lang="en">AI assistance disclosure: initial drafts of the term definitions in this ontology were produced with the assistance of large language models, primarily Google Gemini, with further drafting and curation support from Anthropic Claude; all drafts were then curated and reviewed by humans. Verification status is recorded per term and is machine-readable: a term carrying an IAO:0000117 (term editor) annotation has been checked by the named domain expert, whose ORCID is given; a definition whose text still ends with the marker (UNVERIFIED) has not yet been reviewed by a domain expert and should be treated as a draft. Terms marked owl:deprecated are retired and are exempt from verification.</rdfs:comment>
         <rdfs:comment xml:lang="en">Release-format note: the OWL and JSON products (molsim.owl, molsim.json and their -base/-full variants) are the complete and canonical releases. The OBO-format product (molsim.obo) is a CLASS-ONLY VIEW: OBO 1.2 cannot represent datatype properties, and named individuals are not carried through the conversion, so the data properties (per-species composition counts, boolean flags, serialised arrays) and the named individuals of this ontology are absent from it. The class hierarchy, definitions, synonyms and object properties in molsim.obo are complete and correct. Use the OWL or JSON release if you need the full content.</rdfs:comment>
-        <owl:versionInfo>2026-07-29</owl:versionInfo>
+        <rdfs:comment xml:lang="en">Scope note: MOLSIM&apos;s boundary is drawn by USE CASE, not by subject matter. The membership test for a new term is: would a complete record of a simulation dataset need to state it? That spans what was configured (timestep, thermostat, force field), what was computed (RMSD, potential of mean force, free energies), where the inputs came from (a PDB entry, a UniProt accession, a publication), and what it ran on (engine, version, hardware). Terms from neighbouring fields (quantum chemistry, computational materials science, structural biology) are admitted at most two levels below their attachment point: we record which QM engine ran and which basis set parameterised a force field, but not the internal machinery of quantum-chemical methods. This rule governs terms added from 2026-07-29 onward; earlier terms are retained. MOLSIM is the OBO-aligned ontology for biomolecular simulation metadata and is complementary to EMMO-based materials-modelling ontologies (EMMO, OSMO, VISO), with which it interoperates by SSSOM mapping rather than by adopting a shared upper ontology. Full statement: see the README.</rdfs:comment>
+        <owl:versionInfo>2026-08-07</owl:versionInfo>
         <foaf:homepage xml:lang="en">https://github.com/CPCLab/molsim-ontology</foaf:homepage>
     </owl:Ontology>
     
@@ -197,7 +203,9 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
+    </owl:AnnotationProperty>
     
 
 
@@ -240,12 +248,6 @@ We also have the outstanding issue of how to aim different definitions to differ
     <!-- http://purl.org/dc/elements/1.1/source -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/BibliographicResource -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/BibliographicResource"/>
     
 
 
@@ -692,9 +694,9 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002167">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation protocol to one of the discrete stages that make it up. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to one of the discrete stages that make it up. The stages belong to the run rather than to the protocol, because one protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation stage</rdfs:label>
     </owl:ObjectProperty>
     
@@ -706,7 +708,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002202"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002157"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a schedule defining how one of its parameters varies over simulated time or integration steps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parameter schedule</rdfs:label>
     </owl:ObjectProperty>
     
@@ -718,7 +720,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002158"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to a continuity check assessing its temporal join with an adjacent stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has continuity check</rdfs:label>
     </owl:ObjectProperty>
     
@@ -730,7 +732,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002160"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a simulation stage to an error encountered while loading or parsing one of its data files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has parsing error</rdfs:label>
     </owl:ObjectProperty>
     
@@ -742,7 +744,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular simulation system to a high-level classification label describing its composition. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has system classification</rdfs:label>
     </owl:ObjectProperty>
     
@@ -754,7 +756,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a data format to the specific convention or schema variant that a file follows. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has format convention</rdfs:label>
     </owl:ObjectProperty>
     
@@ -766,7 +768,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002163"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the atom selection mask defining which atoms are subject to restraints. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint mask</rdfs:label>
     </owl:ObjectProperty>
     
@@ -778,8 +780,20 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to a simulation parameter that governs how it is carried out, such as the integration timestep, the non-bonded cutoff, or an output write interval. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has simulation parameter</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002250 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002250">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
+        <obo:IAO_0000115 xml:lang="en">A relation that links a molecular dynamics process to the simulation protocol it was carried out according to. The protocol is the reusable plan and the process is one execution of it, so a single protocol may be followed by many runs. (UNVERIFIED)</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">follows protocol</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -1531,7 +1545,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002121">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the index of the first solvent molecule in its ordered list of molecules. In the Amber topology convention this pointer marks where solvent begins, separating solute from solvent. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">first solvent molecule index</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1542,7 +1556,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002122">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many solvent molecules it contains. It quantifies the amount of solvent used to solvate the solute. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of solvent molecules</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1553,7 +1567,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002123">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with the atom count recorded in each of its frames. It reflects the size of the coordinate set stored at every saved time point. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of atoms per frame</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1564,7 +1578,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002124">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a mapping from ion species to the count of ions of each species present. It records the ionic composition used, for example, to neutralize charge or set ionic strength. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">This property stores its value as text, not as a number. The text lists each kind of ion and how many of them there are, for example {&quot;Na+&quot;: 12, &quot;Cl-&quot;: 10}. That is how the simulation files themselves write it. The other count properties next to this one use plain numbers, because each of them counts a single thing. This one has to count several kinds of ion at the same time, and the ontology has no way yet to say which count belongs to which ion. We looked at two other ways of doing it: making a separate property for every kind of ion, or making a small object that holds one ion and its number. Both would add a lot of work for little gain right now, so we kept the text form. The text itself can be checked later with SHACL, a rule language for checking data files.</rdfs:comment>
         <rdfs:label xml:lang="en">ion counts dict</rdfs:label>
     </owl:DatatypeProperty>
@@ -1576,7 +1590,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002125">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many bond-angle terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total angles</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1587,7 +1601,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002126">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001131"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many dihedral, or torsion, terms are defined in its force-field topology. It helps describe the size and complexity of the bonded interaction set. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of total dihedrals</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1598,7 +1612,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002127">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001139"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with how many times a geometric constraint algorithm, such as SHAKE, failed to converge during the run. A nonzero value can signal instability in the integration. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of constraint failures</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1609,7 +1623,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002128">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation run with an indication of whether it finished normally or terminated abnormally. It supports quick screening of runs for successful completion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has completion status</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1620,7 +1634,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002129">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run was started as a continuation of a previous run rather than from initial conditions. It distinguishes restarted runs from fresh ones. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">continuation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1631,7 +1645,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002130">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the atomic coordinates in a trajectory have been translated back into the primary periodic unit cell. It records whether periodic-image wrapping was applied to the stored coordinates. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1642,7 +1656,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002131">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation uses a combined quantum-mechanics and molecular-mechanics treatment for part of the system. It records whether a region is described at the quantum level while the remainder uses a classical force field. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">QM/MM activation flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1653,7 +1667,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002132">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run employs self-guided Langevin dynamics, an enhanced sampling scheme that adds a guiding force to accelerate conformational exploration. It records the use of this sampling enhancement. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">self-guided Langevin dynamics flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1664,7 +1678,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002133">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a spherical solvent cap was applied around a region of interest instead of full periodic solvation. It records the use of a localized, non-periodic solvent boundary. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spherical cap flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1675,7 +1689,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002134">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether periodic box dimension information is present for a molecular system or trajectory. It records whether unit-cell size and shape data are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has box dimensions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1686,7 +1700,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002135">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether atomic velocity data are stored alongside coordinates in a file or trajectory. Velocities are needed to seamlessly restart a run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has velocities flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1697,7 +1711,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002136">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the kind of periodic box used for a molecular system, such as rectangular or truncated octahedral. It identifies the geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box type flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1707,7 +1721,7 @@ We also have the outstanding issue of how to aim different definitions to differ
 
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002137">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups descriptive properties characterizing a molecular dynamics trajectory as a whole, such as its length and coordinate encoding. It serves as an organizing parent for individual trajectory-level metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory metadata descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1718,7 +1732,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002138">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory with how many saved frames it contains. It reflects how many time points were recorded over the course of the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of frames</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1729,7 +1743,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002139">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002137"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a trajectory or coordinate file with an identifier of the file format used to store its coordinates. It records how the coordinate data are encoded, for example as NetCDF or formatted text. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate format specifier</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1740,7 +1754,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002140">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties whose values are arrays describing the size and geometry of a molecular system, such as periodic box vectors. It serves as an organizing parent for array-valued structural metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural and dimensional arrays</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1751,7 +1765,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002141">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the lengths and angles that define its periodic simulation box. It captures the full geometry of the periodic unit cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1762,7 +1776,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002142">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with an array giving the periodic box lengths and angles at the start of a run. It records the initial unit-cell geometry before any volume changes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial box dimensions array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1773,7 +1787,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002143">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording the names and labels assigned to components of a molecular system, such as residue and atom-type names. It serves as an organizing parent for naming-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system nomenclature descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1784,7 +1798,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002144">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the residue name used to identify its solvent in the topology, such as WAT for water. It records the label under which solvent is stored. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent residue name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1795,7 +1809,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002145">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the ordered list of residue names for its constituent residues. It records the per-residue naming as given in the system&apos;s topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue labels</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1806,7 +1820,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002146">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct residue names it contains. It summarizes the kinds of residues present without regard to how many times each occurs. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique residue names</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1817,7 +1831,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002147">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the set of distinct force-field atom types it uses. It summarizes the range of parameterized atom types present in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">unique atom types</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1828,7 +1842,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002148">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the identifier of the intrinsic radii set used in a generalized Born implicit-solvent calculation. It records which parameterization defines the atomic solvation radii. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">born radii set name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1839,7 +1853,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002149">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that groups properties recording diagnostic messages and validation outcomes produced while running or checking a simulation. It serves as an organizing parent for log- and validation-related metadata relations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log and validation descriptors</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1850,7 +1864,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002150">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with textual diagnostic output emitted when a fault occurred. It captures the message describing why a run failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has error message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1861,7 +1875,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002151">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation or processing step with a textual warning emitted during execution. Such warnings flag potential problems that did not necessarily stop the run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has warning message</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1872,7 +1886,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002152">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a non-fatal issue raised during a validation check. It flags a concern found while verifying correctness or consistency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation warning</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1883,7 +1897,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002153">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with a fault raised during a validation check that caused the check to fail. It records a validation failure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has validation error</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1894,7 +1908,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002154">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a dataset or run with the outcome of a check verifying that its data are mutually consistent. It records whether internal consistency tests passed or failed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">consistency check result</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1905,7 +1919,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002179">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains atomic coordinate data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has coordinates array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1916,7 +1930,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002180">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory or restart file contains per-atom force data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1927,7 +1941,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002181">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a trajectory file contains per-frame time-stamp data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has time array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1938,7 +1952,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002182">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a simulation applies NMR-derived restraints or dynamically varying conditions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has NMR restraints active</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1949,7 +1963,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002183">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether metadata extraction ran in a degraded mode because one or more input files were missing or unreadable. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is degraded extraction mode</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1960,7 +1974,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002184">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying target-temperature schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has temperature schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1971,7 +1985,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002185">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying positional-restraint weight schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has restraint schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1982,7 +1996,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002186">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether a run applies a time-varying non-bonded cutoff schedule. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has cutoff schedule</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -1993,7 +2007,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002187">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a descriptive feature or heuristic modification of its force field, such as CMAP support or CHAMBER conversion. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">force field feature</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2004,7 +2018,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002188">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a serialized mapping from each residue type to the number of residues of that type present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">residue composition map</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2015,7 +2029,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002189">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation with the complete, serialized set of key-value control parameters parsed from its input file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">raw control parameters</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2026,7 +2040,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002190">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002143"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a replica-exchange trajectory with the exchanged-coordinate variant detected, such as temperature replica exchange or multi-dimensional replica exchange. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">REMD variant type</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2037,7 +2051,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002191">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002149"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation stage with the file path or identifier of the restart file used to initiate it. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart file path</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2048,7 +2062,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002193">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether the total electrostatic charge of a molecular system is effectively zero, that is, whether the system is electrically neutral. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">is charge neutral</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2059,7 +2073,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002194">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with a short human-readable summary of the hydrogen masses observed, such as the mass range and the count of hydrogen atoms, used to describe hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen mass summary</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2071,7 +2085,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001941"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a graphics processing unit with the model name of the specific device used to run a simulation, such as the name reported by the CUDA runtime. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">gpu model name</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2082,7 +2096,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002200">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that indicates whether hydrogen mass repartitioning was inferred from the integration timestep, specifically a timestep of 3 femtoseconds or larger, rather than detected directly from the hydrogen masses in the topology. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">HMR inferred from timestep flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2094,7 +2108,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002155"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a simulation protocol with the total number of integration steps performed across all of its stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total simulation steps</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2105,7 +2119,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002215">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its proteins. Proteins are the large chain-like molecules built from amino acids; this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2116,7 +2130,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002216">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its nucleic acids (DNA and RNA); this reports how many atoms make up all of them together. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2127,7 +2141,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002217">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to its lipids. Lipids are the fatty molecules that form cell membranes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2138,7 +2152,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002218">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that are ions. Ions are individual charged atoms such as sodium or chloride, added to balance charge or set the salt level. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">ion atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2149,7 +2163,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002219">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms belonging to the solvent (usually water). It differs from number of solvent molecules (002122), which counts whole molecules rather than atoms. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">solvent atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2160,7 +2174,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002220">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of atoms that fall into none of the named categories (protein, nucleic acid, lipid, ion, solvent). It captures leftovers such as small-molecule ligands or cofactors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">other atom count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2171,7 +2185,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002221">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its proteins. A residue is one amino-acid building block of a protein chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2182,7 +2196,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002222">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of residues in its nucleic acids. Here a residue is one nucleotide building block of a DNA or RNA chain. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">nucleic acid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2193,7 +2207,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002223">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with the number of lipid residues it contains. Each lipid molecule is counted as one residue, so this effectively reports how many lipid molecules make up the membrane or other lipid assembly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">lipid residue count</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2204,7 +2218,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002224">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates a molecular system with how many nucleosomes it contains. A nucleosome is the basic repeating unit of chromatin, a stretch of DNA wound around a core of histone proteins. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleosomes</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2215,7 +2229,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002225">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001121"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that associates the system with the length of a DNA strand, measured as the number of nucleotide bases it contains. Because a system can contain several strands, this may be recorded once per strand. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">number of nucleotides per DNA strand</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2226,7 +2240,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002227">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002140"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the box angles as an ordered list of values (e.g. α, β, γ). It stores the raw angle data read from or written to a simulation file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box angles array</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2237,7 +2251,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002228">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the atomic positions (the 3-D coordinates of every atom over time). Positions are the most basic trajectory data and are almost always present. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has positions flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2248,7 +2262,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002229">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that states whether a saved trajectory includes the forces acting on each atom over time. Forces are optional extra data, useful for example when training machine-learning models. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">has forces flag</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2260,7 +2274,7 @@ We also have the outstanding issue of how to aim different definitions to differ
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topDataProperty"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records the version number of a piece of software, such as an MD engine (for example, version 2024.1). Recording the version makes a simulation reproducible, because software behaviour can change between versions. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">software version</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2271,7 +2285,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002242">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes an antibody, a Y-shaped immune protein that recognises and sticks to a specific target such as a virus. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains antibody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2282,7 +2296,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002243">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether a simulated system includes a nanobody, a very small, single-piece version of an antibody (originally from animals such as llamas) used as a compact binding tool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains nanobody</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2293,7 +2307,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002244">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the system includes a linker histone (such as histone H1), an extra histone that clamps the DNA where it enters and leaves the spool. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">contains linker histone</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -2304,7 +2318,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <owl:DatatypeProperty rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002245">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001156"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A relation that records whether the histone proteins still have their flexible tails, floppy ends that stick out from the spool and are often chemically marked to control gene activity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone tails present</rdfs:label>
     </owl:DatatypeProperty>
     
@@ -15943,7 +15957,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000000">
-        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation. Different types of processes address distinct phases or goals within the overall workflow. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A sequence of related actions or operations performed to achieve a specific outcome in a biomolecular simulation study. This encompasses all stages from initial system setup and simulation execution to final data analysis and interpretation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics process</rdfs:label>
     </owl:Class>
     
@@ -15961,9 +15976,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000002">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The initial stage of a biomolecular simulation process, focused on setting up the molecular system and simulation environment before running the main simulation. This typically involves obtaining structures, adding missing atoms or molecules (like solvent), assigning force field parameters, defining simulation conditions (box, ensemble), and performing initial minimization and equilibration. Proper preparation is crucial for the stability and validity of subsequent simulation steps. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">preparation</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">preparation</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation preparation</rdfs:label>
     </owl:Class>
     
 
@@ -15971,9 +15987,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000003">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">execution</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
+        <obo:IAO_0000115 xml:lang="en">The stage of a biomolecular simulation process where the main simulation runs are performed according to the prepared system and defined parameters to generate trajectory data. This phase involves propagating the system forward in time using algorithms like molecular dynamics or Monte Carlo, under specific ensemble conditions. The goal is typically to sample conformational space, observe dynamic events, or calculate specific properties like free energies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">execution</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation execution</rdfs:label>
     </owl:Class>
     
 
@@ -15981,9 +15999,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000004">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002156"/>
         <obo:IAO_0000115 xml:lang="en">The stage following simulation execution, where the generated trajectory data and energy files are processed and interpreted to extract meaningful scientific insights. This involves calculating various structural, dynamic, and thermodynamic properties, such as RMSD, RMSF, distances, angles, hydrogen bonds, interaction energies, free energies, diffusion coefficients, and clustering conformations. Appropriate analysis techniques are crucial for drawing valid conclusions from simulation results. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">analysis</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">analysis</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">simulation analysis</rdfs:label>
     </owl:Class>
     
 
@@ -16024,7 +16043,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000772"/>
         <obo:IAO_0000115 xml:lang="en">A force field specifically designed and parameterized for simulating lipid molecules and lipid bilayers, crucial components of cell membranes. It aims to accurately capture the unique properties of lipids, including their phase behavior and interactions with other molecules. Examples include LIPID14, LIPID17, and parameters within general force fields like CHARMM36m. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">lipid  force field</rdfs:label>
+        <rdfs:label xml:lang="en">lipid force field</rdfs:label>
     </owl:Class>
     
 
@@ -16146,7 +16165,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000008"/>
-        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It represents an update to Lipid14, incorporating refinements and potentially expanding the range of covered lipid types or improving accuracy for membrane simulations. It&apos;s designed for simulating lipid bilayers and membrane proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific lipid force field parameter set developed for the AMBER simulation package, released around 2017. It was built upon the modularity of LIPID14 and provided an extension of modular phospholipid residues to include anionic head groups and polyunsaturated tails.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">lipid17</rdfs:label>
     </owl:Class>
     
@@ -16729,6 +16749,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000074"/>
         <obo:IAO_0000115 xml:lang="en">A molecular similarity measure that compares two molecular structures by calculating their overlap while allowing asymmetric weighting through parameters α and β. The measure ranges from 0 (completely different) to 1 (identical), and can be adjusted to emphasize either the reference or query molecule in the comparison. It is particularly useful in molecular screening as it can identify both substructure and superstructure relationships between molecules. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">General form, for reference: T(A,B) = |A n B| / (alpha*|A - B| + beta*|B - A| + |A n B|), where A and B are the feature sets of the two molecules being compared. alpha weights features unique to A (the reference) and beta weights features unique to B (the query or fit molecule); alpha = beta = 1 reduces to the Tanimoto coefficient, and alpha = beta = 0.5 gives the Dice coefficient. The named variants below differ only in their fixed alpha/beta values, which each of their definitions states. Note this text is a plain-string note: no OWL consumer renders mathematical notation, so it is written to be readable as-is rather than as LaTeX. Requested in GitHub issue #1.</obo:IAO_0000116>
         <rdfs:label xml:lang="en">Tversky index algorithm</rdfs:label>
     </owl:Class>
     
@@ -16848,7 +16869,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000088">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000087"/>
-        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A greedy algorithm used to find a Minimum Spanning Tree (MST) for a connected, undirected graph with weighted edges. An MST connects all vertices together with the minimum possible total edge weight. Kruskal&apos;s algorithm iteratively adds the lowest-weight edge that does not form a cycle until all vertices are connected.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Kruskal&apos;s algorithm</rdfs:label>
     </owl:Class>
     
@@ -17128,7 +17150,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000245"/>
         <obo:IAO_0000115 xml:lang="en">HOLE is a computer program used to analyze the dimensions and shape of internal pathways or tunnels within a biomolecular structure. It operates by computationally squeezing a flexible sphere along a channel axis to determine the maximum pore radius at every point without overlapping the surrounding atoms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0009-0007-1391-4986"/>
-        <dcterms:BibliographicResource>https://doi.org/10.1016/S0263-7855(97)00009-X</dcterms:BibliographicResource>
+        <oboInOwl:hasDbXref>https://doi.org/10.1016/S0263-7855(97)00009-X</oboInOwl:hasDbXref>
         <rdfs:label xml:lang="en">HOLE</rdfs:label>
     </owl:Class>
     
@@ -17560,7 +17582,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS mdp format is the specific simulation parameter format used by the GROMACS software package. The file, which typically has a &quot;.mdp&quot; extension, contains a series of keyword-value pairs that control every aspect of the simulation run, from the integrator and time step to the thermostat and pressure coupling methods. For GROMACS users, creating and editing the mdp file is the primary way to define the simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS mdp format</rdfs:label>
     </owl:Class>
     
@@ -17603,7 +17626,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001851"/>
-        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Application programs specifically designed to perform molecular dynamics (MD) simulations, which calculate the motion of atoms and molecules over time based on classical mechanics and a chosen force field. These packages typically include capabilities for system preparation, simulation execution (often optimized for high-performance computing), and basic trajectory analysis. Examples include AMBER, GROMACS, NAMD, CHARMM, Desmond, and LAMMPS.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular dynamics engine</rdfs:label>
     </owl:Class>
     
@@ -17623,7 +17647,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool used to predict the preferred binding orientation and affinity (scoring) of one molecule (typically a small ligand) to another (usually a larger receptor like a protein or nucleic acid). Docking tools employ search algorithms to explore possible binding poses within a target site and use scoring functions to estimate the binding strength for each pose. Widely used in drug discovery and understanding molecular recognition, examples include AutoDock, Vina, Glide, GOLD, and DOCK.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking tool</rdfs:label>
     </owl:Class>
     
@@ -17643,7 +17668,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Software designed to process raw data generated from biomolecular simulations (like trajectories, energy files) to calculate specific quantitative properties and extract meaningful insights. Analysis tools implement algorithms for calculating metrics like RMSD, RMSF, radius of gyration, hydrogen bonds, interaction energies, principal components (PCA), free energy estimations (MM/PBSA), clustering, etc. Examples include cpptraj (AmberTools), GROMACS analysis utilities, MDAnalysis (Python library), and specialized scripts or programs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">analysis tool</rdfs:label>
     </owl:Class>
     
@@ -17653,7 +17679,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000001"/>
-        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files generated during a simulation workflow. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools. These tools handle the logistical aspects of managing simulation data. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A tool focused on manipulating, converting, filtering, or extracting information from data files. This can involve tasks like converting file formats, extracting specific columns or frames, merging datasets, calculating simple statistics, or preparing data for input into other analysis or visualization tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">data processing tool</rdfs:label>
     </owl:Class>
     
@@ -17663,7 +17690,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, GROMACS trajectory to AMBER format). File format compatibility is a common issue when using different software packages, making these tools essential for interoperability within a simulation workflow. Many simulation packages include their own conversion utilities, or general tools like Open Babel can be used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific type of data processing tool dedicated to converting molecular structure, trajectory, or data files from one format to another (e.g., PDB to MOL2, XTC to netcdf).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">file conversion tool</rdfs:label>
     </owl:Class>
     
@@ -18107,6 +18135,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
         <obo:IAO_0000115 xml:lang="en">A step within the preparation or equilibration phase where the system&apos;s temperature is gradually raised or adjusted to the desired target temperature for the production simulation. This is typically done by coupling the system to a thermostat while velocities are assigned or rescaled. Proper thermalization ensures the system reaches the correct kinetic energy distribution before equilibration or production runs. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">heating</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">thermalization</rdfs:label>
     </owl:Class>
     
@@ -18116,7 +18145,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000002"/>
-        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crucial phase in simulation preparation, following initial setup and minimization/thermalization, where the system is simulated under the target ensemble conditions (e.g., NVT or NPT) for a period to allow it to relax and reach a stable state. Key properties like temperature, pressure, density, potential energy, and RMSD are monitored to ensure the system is well-equilibrated before starting the production simulation intended for data collection. This phase allows the system to &apos;forget&apos; its initial, potentially artificial starting configuration.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">equilibration</rdfs:label>
     </owl:Class>
     
@@ -18242,7 +18272,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000221">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000223"/>
-        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A widely used software tool (available as a web server and standalone package) that automates many common tasks in preparing biomolecular structures (from PDB files) for continuum electrostatics calculations or simulations. Its core functions include adding missing heavy atoms, adding and optimizing hydrogen atom positions, assigning charges and radii from a chosen force field, and determining residue protonation states at a specified pH using the PROPKA algorithm internally. It outputs the structure in PQR format (PDB with Charge and Radius).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDB2PQR</rdfs:label>
     </owl:Class>
     
@@ -18252,7 +18283,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000222">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects. Tools like Epik (Schrödinger), Marvin (ChemAxon), or modules in Open Babel might address this specifically. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool specifically focused on determining the most likely ionization and tautomeric states of small molecule ligands, often in the context of drug discovery or protein-ligand binding studies. Predicting ligand protonation can be challenging due to diverse functional groups and potential binding site environmental effects.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ligand protonation tool</rdfs:label>
     </owl:Class>
     
@@ -18262,7 +18294,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000223">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000220"/>
-        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors or ions. PDB2PQR is a classic example of such a tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protonation tool designed for general use on biomolecular structures, typically proteins or nucleic acids obtained from sources like the PDB, to add hydrogens and determine appropriate protonation states for titratable residues at a given pH. These tools often focus on standard amino acids and sometimes common cofactors. PDB2PQR is a classic example of such a tool.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">generic protonation tool</rdfs:label>
     </owl:Class>
     
@@ -18302,7 +18335,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000227">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane. Examples include OPM, PPM, MemProtMD, and MemEmbed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool designed to predict or determine the likely orientation and transmembrane embedding depth of a protein structure within a lipid bilayer. Correctly positioning a membrane protein in the bilayer is a critical first step for setting up realistic membrane protein simulations. These tools often use algorithms based on hydrophobicity analysis, sequence features, or structural properties to find the most favorable position relative to the hydrophobic core and hydrophilic headgroup regions of the membrane.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">membrane protein orientation tool</rdfs:label>
     </owl:Class>
     
@@ -18312,7 +18346,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000228">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
-        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It typically works by optimizing the protein&apos;s position and orientation to minimize the calculated free energy of transferring the protein&apos;s amino acid side chains into the heterogeneous membrane environment (hydrophobic core vs interface vs aqueous phase), often using knowledge-based potentials or physical terms. The goal is to generate a realistic starting structure for membrane protein simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific computational tool or algorithm designed to predict the optimal orientation and insertion depth of a membrane protein within a lipid bilayer. It works from a knowledge-based statistical potential.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">memembed</rdfs:label>
     </owl:Class>
     
@@ -18439,7 +18474,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool specifically designed to predict the pKa values of ionizable groups (acidic or basic sites) within a molecule, typically amino acid residues in a protein or functional groups in a ligand. The pKa value indicates the pH at which a group is 50% protonated/deprotonated. These tools use various methods, ranging from simple empirical rules to sophisticated calculations involving continuum electrostatics (solving Poisson-Boltzmann equation) or QM methods, to estimate how the molecular environment shifts the intrinsic pKa of a group. PROPKA is a well-known example.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pKa tool</rdfs:label>
     </owl:Class>
     
@@ -18469,7 +18505,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000243">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties. FoldX is a prominent example. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational tool that allows researchers to simulate the effects of mutations (changing one amino acid residue to another) on the structure, stability, dynamics, or binding affinity of a protein. These tools typically take a protein structure, allow the user to specify mutations, and then use algorithms (often based on molecular mechanics energy functions, rotamer libraries, or machine learning) to model the structural changes and estimate the impact on stability (ddG) or other properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">in-silico mutagenesis tool</rdfs:label>
     </owl:Class>
     
@@ -19111,7 +19148,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000305">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000140"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to build a simplified representation or predict the structure of a molecule. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy. Common terms found in software and publications include &quot;molecular docking,&quot; &quot;homology modeling,&quot; &quot;scoring function,&quot; and &quot;binding pose prediction.&quot; (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling method is a computational technique used to to predict, refine, and simulate 3D molecular arrangements. As a type of computational method, it typically involves predicting a static structure or interaction pose without simulating its dynamic behavior over time, such as in protein-ligand docking. These methods often employ search algorithms and scoring functions to evaluate and rank potential conformations based on criteria like shape complementarity and interaction energy.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling method</rdfs:label>
     </owl:Class>
     
@@ -19162,8 +19200,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000310 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
         <obo:IAO_0000115 xml:lang="en">A plan specification is a document or set of rules that describes how a study or experiment should be designed and carried out. As a type of information content entity, it represents the formal design of a computational experiment, such as the ligand pairs selection criteria for a relative binding free energy study. This specification outlines the rationale and criteria for selecting systems and parameters before the simulation or analysis is performed, ensuring a systematic and reproducible approach. This concept is often described in publications in sections titled &quot;Experimental Design,&quot; &quot;Study Protocol,&quot; &quot;Selection Criteria,&quot; or &quot;Computational Strategy.&quot; (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">TODO: to be imported from http://purl.obolibrary.org/obo/IAO_0000104 (plan specification)</rdfs:comment>
+        <rdfs:comment xml:lang="en">Kept as a MOLSIM term rather than reusing IAO:0000104 plan specification, which is already present in the IAO import module but referenced nowhere. Reusing it would pull in two grouping levels MOLSIM has no use for, IAO:0000033 directive information entity and IAO:0000030 information content entity, and would place this branch under the BFO spine (BFO:0000031 generically dependent continuant and above), which MOLSIM defers. Revisit only if upper-ontology alignment is opened.</rdfs:comment>
         <rdfs:label xml:lang="en">plan specification</rdfs:label>
     </owl:Class>
     
@@ -19173,7 +19212,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000311">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">RMSD analysis is a calculation that measures how much a molecule&apos;s shape has changed over time compared to a reference shape, which is usually the starting shape or an average shape. As a type of structural analysis, this method quantifies the global structural deviation by calculating the root-mean-square deviation of atomic coordinates between trajectory frames and a reference structure after optimal superposition. It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and as a metric for clustering algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A calculation that measures how much a molecule&apos;s shape has changed compared to a reference structure by quantifying the root-mean-square deviation of atomic coordinates after optimal superposition. This can be performed against a single static starting structure over time (1D trajectory), or calculated for every pair of frames in a simulation to produce a frame-to-frame comparative matrix, often displayed as a 2D heat map (2D RMSD analysis). It is the most common procedure for assessing simulation stability, monitoring conformational transitions, and serving as a metric for clustering algorithms.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">RMSD analysis</rdfs:label>
     </owl:Class>
@@ -20610,10 +20649,10 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000448 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000448">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
-        <rdfs:label xml:lang="en">protein database ID</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A protein database ID is a unique alphanumeric code assigned to each entry in a public protein structure or sequence database, such as the Protein Data Bank (PDB ID, e.g., &apos;1TIM&apos;) or UniProt (accession number, e.g., &apos;P00761&apos;). These identifiers serve as the standard way to reference and retrieve specific protein structures or sequence information.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 on review by Daniel Beltran Anadon. Two objections, both accepted. First, the Protein Data Bank is not a protein database: it holds nucleic acids, protein-nucleic acid complexes and other assemblies, so the label and definition made a claim that is simply false. Second, a PDB entry identifies a deposited structure while a UniProt accession identifies a sequence record, so grouping them said less than it appeared to. Its two children, MOLSIM:000686 PDB ID and MOLSIM:000687 Uniprot ID, were re-parented to MOLSIM:000447 identifier alongside the other identifiers. No IAO:0100001 successor, because there is no single term that replaces it; this is the same shape as the other retired grouping terms whose children were re-parented instead. Note the term had been verified by orcid:0000-0003-4177-3619 before this review.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete protein database ID</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -20802,7 +20841,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000466">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000227"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OPM database (Orientations of Proteins in Membranes) is both a database and a web server/tool providing pre-calculated transmembrane orientations and positions for experimentally determined membrane protein structures found in the PDB. OPM uses a computational approach based on minimizing the calculated transfer free energy from water to the lipid bilayer to determine the most likely membrane boundaries and protein position relative to the bilayer center. It&apos;s a valuable resource for obtaining initial membrane protein placements for simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">OPM</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">orientations of proteins in membranes</rdfs:label>
     </owl:Class>
@@ -20835,7 +20875,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A text-based format containing control parameters for the Amber sander and pmemd programs, organized in Fortran namelists. It specifies simulation conditions like timestep, duration, and temperature/pressure coupling algorithms. This format dictates how the molecular dynamics simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER mdin format</rdfs:label>
     </owl:Class>
     
@@ -20857,7 +20898,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A format that stores the complete state of an Amber simulation, including atomic coordinates, velocities, and periodic box dimensions. It is used to save the simulation state at a specific point in time, allowing the run to be resumed exactly. The format can be either ASCII-based (.rst7) or binary NetCDF-based (.ncrst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AMBER restart format</rdfs:label>
     </owl:Class>
     
@@ -20940,7 +20982,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000478"/>
-        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent. For experts, the Connolly algorithm provides a smooth and mathematically well-defined surface that is essential for visualization and for continuum solvent models. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A Connolly surface calculation is a specific algorithm used to compute the solvent-accessible surface of a molecule, which is the surface traced out by the center of a probe sphere as it rolls over the molecule. It is a widely used method for defining the boundary between a molecule and the surrounding solvent.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Connolly surface analysis</rdfs:label>
     </owl:Class>
     
@@ -20959,10 +21002,11 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000481 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000481">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
-        <rdfs:label xml:lang="en">2D RMSD analysis</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A 2D RMSD analysis is a method where the Root-Mean-Square Deviation (RMSD) is calculated for multiple frames in a simulation trajectory with respect to a reference structure. The reference structure is usually the first frame in the trajectory or an average structure of the whole simulation. The results are typically visualized as a two-dimensional plot, where each point represents the RMSD between one frame and the reference structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000311"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with &apos;RMSD analysis&apos; (MOLSIM:000311), which shares the same parent and the same underlying principle. The 2D frame-to-frame form is now covered explicitly by that term&apos;s definition. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 2D RMSD analysis</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -22089,7 +22133,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000596">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000590"/>
-        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format for representing data that is distributed over a three-dimensional grid. Originating from the XPLOR-NIH software, it is used to store volumetric data like electron density or potential maps. This format is used in structural biology to visualize grid-based properties around a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">.grid</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">grid format</rdfs:label>
     </owl:Class>
@@ -22867,7 +22912,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000670">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000917"/>
-        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization. For experts, this is a routine part of trajectory post-processing to remove the overall translational motion of the system. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Coordinate centering is a structural analysis method, often performed as a pre-processing step, that translates the coordinates of a molecular system so that its center of mass is at the origin of the coordinate system. This is a standard procedure to ensure that the molecule remains in the center of the simulation box for easier analysis and visualization.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate centering analysis</rdfs:label>
     </owl:Class>
     
@@ -22958,6 +23004,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000679">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Image bond fixing is a post-processing step applied to simulation trajectories to correct the visual representation of molecules in a periodic system. When a molecule crosses a periodic boundary, it can appear &quot;broken&quot; in the raw output, with parts of it on opposite sides of the simulation box. This procedure identifies such cases and translates the atomic coordinates to make the molecule appear whole, which is essential for correct visualization and many types of analysis.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000659"/>
+        <rdfs:comment xml:lang="en">Retired as redundant with its former parent &apos;periodic boundary imaging&apos; (MOLSIM:000659), of which it was the only child. Bond fixing is an implicit outcome of imaging, and that term&apos;s definition now states so. Reported and approved by the term verifier in GitHub issue #45.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete image bond fixing analysis</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -23030,7 +23078,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000686 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000686">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A PDB ID is the unique four-character alphanumeric code assigned to each experimentally determined biomolecular structure deposited in the Protein Data Bank (PDB). This identifier (e.g., &apos;1TIM&apos;, &apos;6M0J&apos;) serves as the standard way to reference and retrieve specific 3D structural data for proteins, nucleic acids, and their complexes. It allows researchers globally to unambiguously access the same structural entry. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PDB ID</rdfs:label>
     </owl:Class>
@@ -23040,7 +23088,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
     <!-- http://purl.obolibrary.org/obo/MOLSIM_000687 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000687">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000448"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">A UniProt ID, more formally known as a UniProt Accession Number (e.g., &apos;P00761&apos;, &apos;Q8WZ42&apos;), is the stable and unique identifier assigned to a protein sequence record in the UniProt Knowledgebase (UniProtKB). This ID provides access to comprehensive information about a protein, including its sequence, function, annotations, and cross-references to other databases. It serves as a primary key for protein sequence and functional data. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Uniprot ID</rdfs:label>
     </owl:Class>
@@ -23243,7 +23291,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000706">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000703"/>
-        <obo:IAO_0000115 xml:lang="en">A secondary database that curates and represents information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Databases that curate and represent information about biological pathways, such as metabolic, signaling, or regulatory networks, detailing the interactions between molecules. These resources help understand complex biological processes and the roles of individual components. KEGG and Reactome are widely used examples.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">pathway database</rdfs:label>
     </owl:Class>
     
@@ -23487,7 +23536,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000741">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A specific protein force field parameter set from the AMBER family, representing one of the earlier polarizable force fields. Unlike fixed-charge force fields (like ff99SB), ff02 includes electronic polarizability explicitly, aiming for a more accurate description of electrostatics but at a higher computational cost. Its adoption was less widespread than fixed-charge counterparts.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff02</rdfs:label>
     </owl:Class>
     
@@ -23598,7 +23648,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000752">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models. It is less commonly used today for high-resolution studies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An earlier force field parameter set from the CHARMM family, notable for being a &apos;united-atom&apos; force field for proteins. In this representation, nonpolar hydrogen atoms (e.g., on CH, CH2, CH3 groups) are implicitly included in the heavy atoms they are attached to, reducing the number of particles and computational cost compared to all-atom models.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM 19</rdfs:label>
     </owl:Class>
     
@@ -23818,7 +23869,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000774">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001664"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics engine is the specific executable program responsible for numerically integrating the equations of motion to simulate atomic movements over time. It performs the computationally intensive task of calculating forces and updating atomic positions at every time step to generate a trajectory. For experts, this term distinguishes the core computational solver, such as pmemd or namd2, from the overarching software suite that includes tools for setup and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Abalone (Abalone II) is a general purpose molecular dynamics and molecular graphics program for simulations of bio-molecules in a periodic boundary conditions in explicit or implicit water models. Mainly designed to simulate the protein folding and DNA-ligand complexes in AMBER force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Abalone</rdfs:label>
     </owl:Class>
     
@@ -23848,7 +23900,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000777">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A high-performance software package specifically designed for classical molecular dynamics simulations of biological systems, developed by D. E. Shaw Research (DESRES). Desmond is known for its exceptional speed, particularly on GPUs, and its integration with the Schrödinger Materials Science Suite. It supports standard force fields (like CHARMM, AMBER, OPLS) and offers features for system building, simulation execution (including free energy calculations), and analysis, primarily targeting drug discovery and biomolecular research.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Desmond</rdfs:label>
     </owl:Class>
     
@@ -23938,7 +23991,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000786">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000160"/>
-        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A highly scalable, parallel molecular dynamics simulation software package developed at the University of Illinois Urbana-Champaign, designed specifically for simulating large biomolecular systems on high-performance computers (NAnoscale Molecular Dynamics). NAMD works particularly well with the CHARMM force field (and others like AMBER) and is often used in conjunction with the VMD visualization program for setup and analysis. It is known for its excellent performance on parallel architectures, including GPUs.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD</rdfs:label>
     </owl:Class>
     
@@ -24515,7 +24569,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000843">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000308"/>
-        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Molecular dynamics (MD) is a computer simulation technique used to study the physical movement of atoms and molecules over time. It calculates the forces between particles using an empirical potential energy function (force field) and then integrates Newton&apos;s equations of motion numerically to simulate how the positions and velocities evolve in small time steps. MD simulations provide detailed information about the dynamic behavior, conformational changes, and thermodynamics of molecular systems.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">MD</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">molecular dynamics</rdfs:label>
     </owl:Class>
@@ -24778,7 +24833,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000867">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000438"/>
-        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results. The script provides flexibility for complex simulation protocols. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A CHARMM input file is a script containing a sequence of commands written in the CHARMM scripting language, which directs the CHARMM program to perform various tasks. These tasks can range from reading topology and coordinate files, setting up system parameters, running energy minimizations or molecular dynamics simulations, to analyzing results.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM input format</rdfs:label>
     </owl:Class>
     
@@ -24820,8 +24876,9 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000871">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">GROMACS input  format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">In GROMACS, the primary molecular dynamics input file usually has an .mdp extension and contains keyword-value pairs defining the simulation parameters. Processed by the grompp tool, it controls aspects like the integration algorithm, timestep, simulation length, temperature and pressure coupling methods, and cutoff schemes. This file dictates how the MD simulation engine (mdrun) will execute the run.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">GROMACS input format</rdfs:label>
     </owl:Class>
     
 
@@ -24870,7 +24927,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000876">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002065"/>
-        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A NAMD configuration file, typically ending in .namd, contains parameters and commands that control a molecular dynamics simulation run using the NAMD software. It uses a keyword-value pair format, often leveraging Tcl scripting capabilities, to specify input files (structure, coordinates, parameters), simulation conditions (temperature, pressure, duration), and algorithms. This file dictates the entire simulation protocol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAMD configuration format</rdfs:label>
     </owl:Class>
     
@@ -24880,7 +24938,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000877">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000437"/>
-        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It specifies the molecular geometry, basis sets, theoretical methods (ranging from quantum mechanics like DFT or MP2 to molecular mechanics), and the desired task (e.g., TASK SCF, TASK MD). The flexible block structure allows for setting up complex, multi-step calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An NWChem input file (.nw) uses directives and nested blocks to instruct the NWChem software package on performing computational chemistry tasks. It is composed of commands, called directives, which define data (such as basis sets, geometries, and filenames) and the actions to be performed on that data. Directives are processed in the order presented in the input file, with the exception of certain start-up directives (see Input File Structure) which provide critical job control information, and are processed before all other input. Most directives are specific to a particular module and define data that is used by that module only. A few directives (see Top-level Directives) potentially affect all modules, for instance by specifying the total electric charge on the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem input format</rdfs:label>
     </owl:Class>
     
@@ -24922,7 +24981,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000881">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The CHARMM output file is the main text log generated during a CHARMM run, typically containing an echo of the input script commands interspersed with the results produced by those commands. This includes detailed energy breakdowns, progress information during dynamics or minimization (like step number, time, temperature, pressure, energies), and outputs from analysis routines. It serves as the primary record of the CHARMM job execution.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM output format</rdfs:label>
     </owl:Class>
     
@@ -24962,7 +25022,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000885">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The GROMACS MD output typically refers to the primary text log file (.log) generated by the mdrun simulation engine. It contains summary information about the simulation setup, detailed performance data (like PME load balancing and timings), step-by-step progress updates (if configured in the .mdp file), and final run statistics including energy averages and runtime. This file is crucial for monitoring performance and verifying run completion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GROMACS output format</rdfs:label>
     </owl:Class>
     
@@ -25042,7 +25103,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000893">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000441"/>
-        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific molecular dynamics restart files (.rst) containing coordinates and velocities. Input directives like RESTART or TASK MD RESTART instruct NWChem to utilize these files to continue the computation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Restarting an NWChem calculation involves using various files generated during a previous run, depending on the calculation type. This may include the run database (.db), molecular orbital vector files (.movecs), geometry files, or specific QM/MM restart files (.rst).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NWChem restart format</rdfs:label>
     </owl:Class>
     
@@ -25095,7 +25157,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000898">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A GROMACS include topology file (.itp) contains the topology definition for a specific type of molecule (like a protein, lipid, or solvent). It typically includes sections like [ moleculetype ], [ atoms ], [ bonds ], etc., and is designed to be reusable. These .itp files are incorporated into the main system topology (.top) file using the #include directive.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS include topology format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">GROMACS itp format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">itp format</rdfs:label>
@@ -25140,7 +25203,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000902">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001090"/>
-        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability. It typically stores coordinates in single precision. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DCD (.dcd) trajectory format is a widely used binary file format for storing atomic coordinates from molecular dynamics simulations, optionally including periodic box information. Originally developed for CHARMM, it is now supported by many simulation packages (like NAMD, LAMMPS) and analysis tools (like VMD) due to its efficiency and portability.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dcd format</rdfs:label>
     </owl:Class>
     
@@ -25171,6 +25235,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000905">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. Small molecule structure formats are designed primarily for representing organic and drug-like molecules, often emphasizing chemical details like bond orders, formal charges, and stereochemistry. These formats are widely used in cheminformatics, drug discovery databases, and as input for various modeling tasks. Common examples include SDF, Mol2, and SMILES strings.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete small molecule structure</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -25319,7 +25384,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000921">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A generic name for a text-based file format that stores the Cartesian (x, y, z) coordinates of atoms in a molecular system. The specific layout can vary, as multiple simulation packages like CHARMM and Amber have their own distinct versions of a &quot;.crd&quot; file. Due to its ambiguity, it is often necessary to specify which software&apos;s CRD format is being used.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crd format</rdfs:label>
     </owl:Class>
     
@@ -25445,7 +25511,8 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_000941">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000305"/>
-        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure. For experts, this is a fundamental operation used in structural alignment, docking algorithms, and for setting up systems in a specific orientation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A coordinate rotation method is a structure modification method that applies a mathematical rotation to the coordinates of a molecule or a group of atoms. This procedure changes the orientation of the selected atoms in three-dimensional space without altering their internal structure.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">coordinate rotation modeling</rdfs:label>
     </owl:Class>
     
@@ -25614,15 +25681,7 @@ interpreted by or directly executed by a processing unit.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER inpcrd format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmcrd format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format.
-
-The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. 
-
-Users can interact with it using file-based commands:
-
-Loading:  users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command.
-
-Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
+        <rdfs:comment xml:lang="en">Amber&apos;s standard ASCII coordinate trajectory file format. The &quot;Coordinates Data Set&quot; or &quot;COORDS&quot; in Amber is not a file format, but rather a specialized, in-memory data structure used by the cpptraj analysis program. It is designed to efficiently hold and manipulate sets of coordinate frames (i.e., structures) loaded from trajectory files during an analysis session. Since the COORDS data set is an internal, in-memory representation, it does not have a file extension. Users can interact with it using file-based commands: Loading: users populate a COORDS data set by loading data from standard Amber file formats, such as restart files (.rst7), PDB files, or trajectory files (.nc, .mdcrd), using the loadcrd command. Saving: users write the contents of a COORDS data set to a file using the crdout command. The output will be in a standard coordinate or trajectory format (e.g., Amber restart, PDB, etc.), not a special &quot;COORDS format.&quot;</rdfs:comment>
         <rdfs:label xml:lang="en">AMBER crd format</rdfs:label>
     </owl:Class>
     
@@ -26009,13 +26068,7 @@ Saving: users write the contents of a COORDS data set to a file using the crdout
         <obo:IAO_0000115 xml:lang="en">The .trj format is an ASCII (text-based) trajectory file format used by the Amber molecular dynamics software suite and other analysis programs. Its fundamental purpose is to store a time-series of atomic coordinates, capturing the dynamic motion of a system during a simulation. The file contains sequential &quot;frames&quot; where each frame is a complete set of X, Y, and Z coordinates for every atom in the system at a specific point in time. It can also store periodic box dimensions, although this capability is sometimes limited.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER trj format</oboInOwl:hasExactSynonym>
-        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives:
-
-vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software.
-
-vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict.
-
-vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
+        <rdfs:comment xml:lang="en">The .trj format belongs to a family of older Amber text-based trajectory formats. Its role is best understood in comparison to its relatives: vs. .mdcrd: The .trj and .mdcrd formats are functionally identical. Both are safe, relatively unambiguous choices for storing Amber ASCII trajectories. A file with one extension can often be renamed to the other without causing issues in analysis software. vs. .crd: The .crd extension is highly ambiguous and problematic. It is the native format for the CHARMM simulation package and is interpreted as such by default in many tools. Using .trj avoids this critical format conflict. vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended format for Amber trajectories. Compared to .trj, NetCDF (.nc) files are smaller, faster to read/write, and store data with higher precision. The .trj format is considered a legacy option.</rdfs:comment>
         <rdfs:label xml:lang="en">trj format</rdfs:label>
     </owl:Class>
     
@@ -26025,14 +26078,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010020"/>
-        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule. There is no single, standardized file extension for a distance matrix file. The format is often dependent on the analysis program that generates it or is saved in a general-purpose data format. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">Common examples include:
-
-- General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs.
-
-- Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format.
-
-- Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">A distance matrix in molecular simulation is a 2D data set that stores the pairwise distances between a selection of particles, such as atoms or residues, calculated from a simulation trajectory. It is a common form of analysis used to study conformational changes, structural stability, and the relative movement of different parts of a molecule.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:comment xml:lang="en">Common examples include: - General Text Formats: Often saved as plain text (.txt), comma-separated values (.csv), or a generic data (.dat) file for easy parsing and use in other programs. - Program-Specific Formats: Some simulation packages output the matrix in their own specific formats. For example, GROMACS can generate a distance matrix as an .xpm file, which is a portable pixmap image format. - Binary Formats: For efficiency, especially with large matrices, they may be saved in binary formats like NumPy&apos;s .npy format, which is common in Python-based analysis workflows.</rdfs:comment>
         <rdfs:label xml:lang="en">distance matrix format</rdfs:label>
     </owl:Class>
     
@@ -26044,8 +26092,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001040"/>
         <obo:IAO_0000115 xml:lang="en">The GROMACS XPM file is an ASCII text file format used by the GROMACS molecular dynamics suite to store two-dimensional matrix data. It is a specialized application of the general XPixMap (.xpm) format, adapted to represent scientific data such as distance matrices, root-mean-square deviation (RMSD) matrices, or hydrogen bond patterns. The format is human-readable and designed for easy visualization. It encodes numerical data as a color-coded image defined by characters, making it viewable with standard XPM viewers and convertible into graphical formats like PostScript using GROMACS utilities such as gmx xpm2ps. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.xpm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">xpm  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">GROMACS xpm format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">xpm format</rdfs:label>
     </owl:Class>
     
 
@@ -26055,8 +26103,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
         <obo:IAO_0000115 xml:lang="en">The AMBER prmtop format is a text file that acts as a blueprint for a molecule, defining all its chemical properties for a simulation. It contains a complete description of the atoms, their connectivity through bonds, the force field parameters governing their interactions, and their partial charges. This file, used in conjunction with a coordinate file, provides all the static information the AMBER simulation engine needs to calculate the forces on the system. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parmtop format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER prmtop format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">parm7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">prmtop format</rdfs:label>
     </owl:Class>
     
@@ -26065,11 +26116,13 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001043">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000472"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format from the Amber simulation software that describes the structure and force field parameters of a molecule. This is the traditional, ASCII-based version of the Amber parameter/topology file, containing all information needed to calculate forces on the system. It is often used interchangeably with the prmtop format.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001042"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER PARM7 format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER parm7 format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">parm7 format</rdfs:label>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001042 prmtop format. ParmEd writes one Amber topology format under two extensions, .prmtop and .parm7, so these were never two formats. Both terms also carried skos:exactMatch to the same EDAM term, EDAM:format_3881 AMBER top, which is what surfaced the duplication. prmtop survives because it is the name that actually occurs in practice: 19 occurrences against 0 for parm7 in the AMBER keyword corpus this ontology was extracted from. Its names are kept as exact synonyms on MOLSIM:001042.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete parm7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26139,7 +26192,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation, allowing it to be continued later. This is a general term for Amber restart files, which can be either text-based or binary. It contains the atomic coordinates, velocities, and simulation box dimensions at a specific point in time. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A file format from the Amber software that saves the state of a simulation in plain text, allowing the run to be continued later. It contains the atomic coordinates, velocities, and periodic box dimensions at a specific point in time, in a human-readable form. The same ASCII format is written under several extensions, including .rst, .rst7 and .restrt. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">restrt format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">rst7 format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">rst format</rdfs:label>
     </owl:Class>
     
@@ -26148,9 +26203,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001050 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001050">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000471"/>
-        <obo:IAO_0000115 xml:lang="en">A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">rst7 format</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A text-based file format from the Amber software that saves the state of a simulation. It is the ASCII version of the Amber restart file, containing coordinates, velocities, and box information in a human-readable format. This format is often used for its portability and ease of inspection.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001049"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-07 as an internal duplicate of MOLSIM:001049 rst format. ParmEd writes one Amber ASCII coordinate format under several extensions, .rst7, .restrt and .inpcrd, so .rst and .rst7 were never two formats; the real division in this family is ASCII against the binary NetCDF MOLSIM:001051 ncrst format. Both terms also carried skos:closeMatch to the same EDAM term, EDAM:format_3886 RST, which is the pattern that surfaced the duplication. The curator chose rst as the surviving label; note that ParmEd itself does not write a .rst extension, so rst7 format and restrt format are kept as exact synonyms on MOLSIM:001049.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete rst7 format</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -26251,8 +26308,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
         <obo:IAO_0000115 xml:lang="en">The LMOD conflib format is a conformational library file used by the Low-Mode (LMOD) conformational search program in AmberTools. This file stores a pre-calculated or user-defined collection of different 3D structures for a single molecule. The LMOD program reads this library as input to guide its search, allowing it to more efficiently sample, cluster, or select representative conformations for further analysis. (UNVERIFIED)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>.conflib</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib  format</oboInOwl:hasExactSynonym>
-        <rdfs:label xml:lang="en">conflib  format</rdfs:label>
+        <oboInOwl:hasExactSynonym xml:lang="en">LMOD conflib format</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">conflib format</rdfs:label>
     </owl:Class>
     
 
@@ -26284,7 +26341,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PQR format is a modification of the standard Protein Data Bank (PDB) format used in computational biology to store atomic coordinate data along with atomic partial charges (Q) and radii (R). The name itself is a mnemonic, representing PDB + Q (charge) + R (radius). Its primary advantage is that it bundles the necessary structural and electrostatic parameters into a single, PDB-like file that is easily parsed by both analysis software and molecular visualization programs. These files are most commonly generated by the PDB2PQR software, which processes a standard PDB file, adds missing hydrogen atoms, and assigns atomic charges and radii based on a chosen force field.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym>.pqr</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">pqr format</rdfs:label>
     </owl:Class>
@@ -26296,7 +26354,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001063">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000490"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Molecular Operating Environment (MOE) is a comprehensive, commercial software system for drug discovery, molecular modeling, and computational chemistry developed by the Chemical Computing Group. It integrates visualization with a vast array of tools for structure preparation, docking, pharmacophore modeling, and molecular dynamics setup within a single unified interface.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Molecular Operating Environment</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MOE</rdfs:label>
     </owl:Class>
@@ -26394,8 +26453,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001072 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001072">
-        <obo:IAO_0000115>An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
-        <dcterms:BibliographicResource></dcterms:BibliographicResource>
+        <obo:IAO_0000115 xml:lang="en">An information content entity is an abstract concept representing any piece of data, information, or knowledge that can be identified and described. In the context of simulations, it refers to the abstract data itself, such as the concept of a molecular structure or a simulation parameter set, separate from the specific file format used to store it. This distinction helps in organizing and standardizing the description of simulation data and metadata. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">information content entity</rdfs:label>
     </owl:Class>
     
@@ -26405,7 +26463,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001073">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular system specification is the complete abstract description of all the molecules and their properties that constitute a simulation. It includes the identity and 3D arrangement of all atoms (the structure) and the rules governing their interactions (the topology and force field). This specification is the complete informational blueprint of the system before any simulation is performed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular system specification defines the physical and chemical properties of a molecule required for computational chemistry and quantum mechanical simulations. This specification is the complete informational blueprint of the system before any simulation is performed.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular system specification</rdfs:label>
     </owl:Class>
     
@@ -26555,6 +26614,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001087">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A file format specifically designed to describe the complex, three-dimensional structures of large biological molecules like proteins and DNA. These formats accommodate hierarchical descriptions, such as chains and residues, in addition to atomic coordinates. Examples include the widely used PDB and mmCIF formats.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the file-format flattening. Classifying structure formats by molecule size was an artificial distinction: a small molecule can be stored in a PDB file and a macromolecule in a mol2 file. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Reported in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete macromolecular structure format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -26576,6 +26636,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001089">
         <obo:IAO_0000115 xml:lang="en">OBSOLETE. A coordinate file primarily stores the three-dimensional positions (X, Y, Z coordinates) of atoms in a molecular system. It may also contain atom names, residue information, and potentially periodic box dimensions, but typically lacks detailed bonding (topology) or force field parameter information. Common examples include PDB, GRO, and XYZ formats, used for initial structures or snapshots from simulations.</obo:IAO_0000115>
+        <rdfs:comment xml:lang="en">Retired in the same file-format flattening. Grouping coordinate formats by the software that writes them proved unhelpful, since formats are not owned by one program. Its former children are now direct children of &apos;molecular structure format&apos; (MOLSIM:001088). Related discussion in GitHub issue #20.</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete software-specific coordinate format</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
@@ -26681,7 +26742,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002066"/>
         <obo:IAO_0000115 xml:lang="en">The DFTB parameter format is a set of files, known as Slater-Koster files, that contain the parameters for a Density Functional Tight Binding (DFTB) calculation. These files define the pre-calculated electronic and repulsive properties between pairs of atom types, which are derived from more expensive quantum mechanical calculations. This parameterization is what allows the DFTB method to achieve its high computational speed while retaining a quantum mechanical description of the system. (UNVERIFIED)</obo:IAO_0000115>
-        <oboInOwl:hasExactSynonym xml:lang="en">skf  format</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">skf format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">DFTB parameter format</rdfs:label>
     </owl:Class>
     
@@ -26875,7 +26936,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000439"/>
-        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The mdinfo format is a text file generated by the Amber simulation software that provides a concise, real-time summary of a running simulation. It contains the most recently calculated energy terms and thermodynamic properties, such as temperature and pressure, formatted for easy monitoring. This file is continuously updated during a run, making it useful for checking the immediate status and stability of a simulation without having to parse the much larger main output file.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">AMBER mdinfo format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">mdinfo format</rdfs:label>
     </owl:Class>
@@ -26886,7 +26948,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001671"/>
-        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured biological or chemical repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system. In the context of biomolecular simulation, these servers are the primary means of accessing essential resources such as experimental protein structures, force field libraries, or archived simulation trajectories. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A database web server is an online application that provides a graphical interface for searching, visualizing, and retrieving data from a structured repository. It acts as an accessible gateway, allowing researchers to query complex datasets and download specific entries without needing direct interaction with the underlying database management system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">database web server</rdfs:label>
     </owl:Class>
     
@@ -27299,7 +27362,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data. These are often set with keywords like ntc or restraint_wt. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of simulation parameter that controls the application of geometric constraints or restraints to the system. Constraints are used to fix certain degrees of freedom, while restraints are used to guide the system towards a particular conformation. These constraint and restraint parameter settings are used to control the flexibility of the system or to apply experimental data.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">constraint and restraint parameter</rdfs:label>
     </owl:Class>
     
@@ -27444,7 +27508,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001215">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies whether the simulation involves an alchemical transformation for a free energy calculation. This parameter indicates that some atoms/residues in the system have their properties changed over the course of the simulation. The alchemical transformation state is a key descriptor for identifying free energy calculations. This is often controlled by a perturbation flag (lambda, λ).</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">alchemical transformation state</rdfs:label>
     </owl:Class>
     
@@ -27454,7 +27519,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001216">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design. This is often specified in the simulation submission script. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation process parameter that specifies the number of independent simulation runs performed from the same or similar initial conditions. Running number of replicates helps to assess the statistical robustness and convergence of simulation results. This is a key parameter of the overall simulation experimental design.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">number of replicates</rdfs:label>
     </owl:Class>
     
@@ -28707,7 +28773,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000328"/>
-        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Hydrogen mass repartitioning is a system setup method where a portion of the mass of a heavy atom is transferred to its bonded hydrogen atoms. This makes the hydrogens heavier, which slows down their bond vibrations and allows a larger time step to be used in a molecular dynamics simulation. For experts, this technique, often abbreviated HMR, is a common strategy to increase computational efficiency without significantly altering the system&apos;s dynamics.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hydrogen mass repartitioning analysis</rdfs:label>
     </owl:Class>
     
@@ -28737,7 +28804,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001340">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of structural property representing the torsion angle defined by four sequentially bonded atoms, which describes the rotation around the central bond. The dihedral angle is the most important descriptor for characterizing the overall conformation of a flexible molecule. Its value is a primary output of many structural analysis tools. This value is commonly referred to as dihedral or torsion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">dihedral angle</rdfs:label>
     </owl:Class>
     
@@ -29031,7 +29099,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001358"/>
-        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A type of nucleic acid parameter that describes the relative geometry and orientation between two successive base pairs in a helix. These parameters define the local helical structure. They are essential for characterizing the sequence-dependent variations in DNA and RNA structure. These parameters include shift, slide, rise, tilt, roll, and twist.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">base pair step parameter</rdfs:label>
     </owl:Class>
     
@@ -29730,7 +29799,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000860"/>
-        <obo:IAO_0000115 xml:lang="en">The adaptive string method is an improvement on the standard string method for finding transition pathways. It adaptively adjusts the distribution of the images along the string, concentrating them in regions where the path has high curvature or where the free energy is changing rapidly. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Adaptive String Method (ASM) is a numerical technique used in computational chemistry and physics to find minimum free energy paths (MFEPs) or reaction pathways in complex, high-dimensional systems such as chemical reactions, conformational changes in biomolecules, or phase transitions. It is an improvement over the original string method because it adapts the distribution of points (&quot;images&quot;) along the path to better capture regions of high curvature or complexity. For experts, this adaptive placement of images leads to a more efficient and accurate determination of the minimum free energy path.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">adaptive string method</rdfs:label>
     </owl:Class>
     
@@ -29833,7 +29903,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a set of rules, or a force field, used in computer simulations to describe how the atoms in a protein move and interact. The AMBER ff03 protein force field was a significant redevelopment that derived its partial atomic charges from quantum mechanical calculations in a continuum solvent, aiming for a more physically realistic electrostatic model. While influential, its different charge model required consistent use of its specifically paired water model, and it was eventually succeeded by other force fields in mainstream use. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Amber ff03 is a modified version of the ff99 AMBER force field. The main changes are that charges are now derived from quantum calculations that use a continuum dielectric to mimic solvent polarization, and that the φ and ψ backbone torsions for proteins are modified, with the effect of decreasing the preference for helical configurations. The changes are just for proteins; nucleic acid parameters are the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03</rdfs:label>
     </owl:Class>
     
@@ -29843,7 +29914,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where some hydrogen atoms are computationally merged with their neighboring carbon atoms. The AMBER ff03ua is a united-atom variant of the ff03 force field, where non-polar hydrogen atoms are not explicitly represented but are incorporated into the heavy atoms they are attached to. This model is useful for studying large-scale protein dynamics or for simulations where the highest atomistic detail is not required and computational speed is a priority. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">This is a simplified version of the amber ff03 force field where the aliphatic hydrogen atoms on all amino acid side-chains are united to their corresponding carbon atoms. The aliphatic hydrogen atoms on all alpha carbon atoms are still represented explicitly to minimize the impact of the united-atom approximation on protein backbone conformations. In addition, aromatic hydrogens are also explicitly represented. Nucleic acid parameters are still in all atom and kept the same as in ff99.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber ff03ua</rdfs:label>
     </owl:Class>
     
@@ -30363,7 +30435,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000006"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid. For structural biologists, these components are essential for interpreting X-ray diffraction data and building a complete model of the crystal lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic model component is a fundamental concept used to describe the structure of a crystal. It represents one of the key pieces of information, such as the repeating unit or the symmetry rules, that define how molecules are arranged in a crystalline solid.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic model component</rdfs:label>
     </owl:Class>
     
@@ -30727,7 +30800,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000009"/>
-        <obo:IAO_0000115 xml:lang="en">Amber fb15 is a specific &quot;recipe&quot; or force field used in computer simulations to model the behavior of proteins with improved accuracy for certain structural features. The AMBER ff15 (force-balanced 15) protein force field is a refinement that rebalances the dihedral angle potentials to better reproduce the conformational ensembles of both folded and disordered proteins. This force field is particularly useful for studying intrinsically disordered proteins or for simulations where capturing the subtle balance between different secondary structures is critical. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The AMBER FB15 (force-balanced 15) protein force field is a refinement of the AMBER94 ff with a systematic and thorough optimization of the intramolecular terms. The key difference in the optimized result is a significant lowering of the potential in regions away from the energy minima, which is expected to yield greater flexibility in finite temperature simulations. This force field is particularly useful for simulations of proteins, particularly when fluctuations away from equilibrium, conformational changes, and/or temperature dependence are expected to play important roles.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">amber fb15</rdfs:label>
     </owl:Class>
     
@@ -31001,7 +31075,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001558">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An electrostatics analysis tool is a type of software designed to calculate and visualize the electrostatic properties of a molecule. These tools typically take a molecular structure with assigned atomic charges and compute quantities like the electrostatic potential on the molecule&apos;s surface or the total electrostatic energy of solvation. They are essential for understanding how a molecule will interact with other charged molecules and its polar solvent environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">electrostatics analysis tool</rdfs:label>
     </owl:Class>
     
@@ -31081,8 +31156,10 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001566">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000170"/>
-        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">A software library is a collection of pre-written code and subroutines that provide specific functionalities to be used by other programs. Libraries are not executed directly by end-users but are imported or linked by developers to perform specialized tasks, such as mathematical computations or file parsing.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">library</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">software library</rdfs:label>
     </owl:Class>
     
 
@@ -31141,7 +31218,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001572">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001969"/>
-        <obo:IAO_0000115 xml:lang="en">ndfes is a software package designed for the calculation and analysis of N-dimensional free energy surfaces from molecular simulation data. It includes a collection of scripts for analyzing enhanced sampling simulations, such as those using umbrella sampling or metadynamics. This toolkit allows researchers to reconstruct and visualize complex free energy landscapes defined by multiple collective variables. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ndfes software, included in the FE-ToolKit package, is used to analyze biased umbrella sampling to estimate free energy surfaces in an arbitrary number of reaction coordinate dimensions using either the variational free energy profile (vFEP), multistate Bennett acceptance ratio method (MBAR), or the highly-related weighted thermodynamic perturbation and generalized weighted thermodynamic perturbation methods.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ndfes</rdfs:label>
     </owl:Class>
     
@@ -31151,7 +31229,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001573">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats. For advanced users and developers, ParmEd provides a powerful tool for complex simulation setup, analysis, and force field development tasks. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">ParmEd is a software package and Python library designed for manipulating and converting molecular topology and parameter files from various simulation packages, with a primary focus on the AMBER force field format. It allows users to programmatically modify force field parameters, change molecular connectivity, and convert between different file formats.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ParmEd</rdfs:label>
     </owl:Class>
     
@@ -31294,8 +31373,9 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001587">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The Intel Math Kernel Library (MKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against MKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">Intel Math Kernel Library</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">The Intel oneAPI Math Kernel Library (oneMKL) is a collection of highly optimized mathematical functions for science, engineering, and financial applications, specifically tuned for Intel processors. It provides high-performance implementations of routines for linear algebra (BLAS, LAPACK, ScaLAPACK), Fast Fourier Transforms (FFT), and other core mathematical operations. For biomolecular simulation software, linking against oneMKL can significantly boost performance by accelerating the fundamental mathematical computations underlying the simulation algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
+        <rdfs:label xml:lang="en">Intel oneAPI Math Kernel Library</rdfs:label>
     </owl:Class>
     
 
@@ -31304,7 +31384,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001588">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A package manager is a tool that automates the process of installing, upgrading, configuring, and removing software packages and their dependencies. It simplifies the management of the complex web of software required for scientific computing by handling the details of where to find packages and which versions are compatible. For simulation scientists, package managers like Conda are crucial for creating stable and reproducible software environments.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">package manager</rdfs:label>
     </owl:Class>
     
@@ -31314,7 +31395,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001589">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001588"/>
-        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Miniconda is a minimal, bootstrap installer for the Conda package manager, which is widely used in the scientific computing community. It includes only the Conda package manager and Python, allowing users to create customized software environments by installing only the packages they need. For researchers, Miniconda provides a lightweight way to set up isolated and reproducible environments for their simulation and analysis software.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Miniconda</rdfs:label>
     </owl:Class>
     
@@ -31510,7 +31592,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001608">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001970"/>
-        <obo:IAO_0000115 xml:lang="en">an interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An interactive utility included in the AmberTools software package for deriving force field parameters. It assists users in calculating new parameters for bond lengths and angles based on a set of built-in empirical rules. This tool is particularly useful when parameterizing a new molecule for which no existing force field parameters are available. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parmcal</rdfs:label>
     </owl:Class>
     
@@ -31745,7 +31827,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001631">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format. This conversion is essential for visualizing simulation snapshots or using the structures in other programs that do not read AMBER formats directly. For AMBER users, ambpdb is a fundamental tool for exporting their simulation data for analysis and visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ambpdb utility is a command-line tool in the AmberTools suite that converts AMBER&apos;s native topology (.prmtop) and coordinate (.inpcrd or .rst7) files into the standard Protein Data Bank (PDB) format.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ambpdb</rdfs:label>
     </owl:Class>
     
@@ -31955,7 +32038,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001652">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines. For researchers wishing to use CHARMM force fields within the AMBER ecosystem, chamber is an essential interoperability tool. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The chamber script is a utility within the AmberTools suite that facilitates the conversion of CHARMM-formatted force field files into a format that can be used by AMBER. It processes CHARMM topology (PSF) and parameter (PAR) files, allowing users to run simulations with CHARMM force fields using the AMBER simulation engines.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">chamber</rdfs:label>
     </owl:Class>
     
@@ -31965,7 +32049,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001653">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001569"/>
-        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite used as a quality control step in simulation setup. It functions by comparing two molecular structure files to ensure that their atom names and connectivity are identical. This check is crucial for preventing errors when processing large sets of conformations where atom ordering might have been inadvertently changed. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">match_atomname is a utility program within the AmberTools suite that takes an input file and a reference file in pdb, ac, prepi, prepc and mol2 format and it automatically detects the corresponding atom name in the reference for each atom name in the input. An output file in the same format as that of the input is generated using the matched atom names. Designed to recover atom-name information lost after running Gaussian calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match_atomname</rdfs:label>
     </owl:Class>
     
@@ -32035,7 +32120,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001660">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001659"/>
-        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language distributed with the AmberTools software suite. It is designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NAB, or Nucleic Acid Builder, is a specialized programming language designed specifically for the purpose of constructing and manipulating three-dimensional models of nucleic acids and proteins. For experts, NAB provides a powerful and scriptable way to build complex or non-standard biomolecular structures that would be difficult to create with standard graphical tools. Originally distributed with the AmberTools software suite, it is now only available from an independent GitHub repository.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NAB</rdfs:label>
     </owl:Class>
     
@@ -32045,7 +32131,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001661">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a software library or collection of tools designed to facilitate the setup, execution, and analysis of free energy calculations. It likely provides functions and scripts to automate complex workflows, such as alchemical transformations or umbrella sampling analysis. For researchers, such a toolkit aims to simplify the technically demanding process of calculating binding free energies or potentials of mean force. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The FE-ToolKit is a collection of tools designed to facilitate the setup, execution, and analysis of alchemical free energy simulations and umbrella sampling.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">FE-ToolKit</rdfs:label>
     </owl:Class>
     
@@ -32155,7 +32242,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001672">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages. For scientists studying glycobiology, GLYCAM-Web provides an essential resource for preparing complex carbohydrate structures for molecular simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GLYCAM-Web is a collection of online tools and web servers that assist researchers in building three-dimensional models of carbohydrates and glycoproteins. It uses the GLYCAM force field to generate realistic structures and provides tools for tasks like predicting the conformation of glycosidic linkages.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">GLYCAM-Web</rdfs:label>
     </owl:Class>
     
@@ -32165,7 +32253,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001673">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001119"/>
-        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Glycoprotein Builder is a web-based tool that automates the process of constructing three-dimensional models of glycoproteins. It allows users to start with a protein structure and graphically attach various glycan (sugar chain) structures to specific amino acid residues. For researchers, this tool greatly simplifies the otherwise complex and tedious task of building a complete, simulation-ready model of a glycosylated protein.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Glycoprotein Builder</rdfs:label>
     </owl:Class>
     
@@ -32237,7 +32326,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001680">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
-        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DL-Find is a software library that provides a collection of robust algorithms for geometry optimization tasks. It contains routines for efficiently finding energy minima (stable structures) and first-order saddle points (transition states) on a potential energy surface. This library acts as an optimization engine that can be incorporated into other simulation or quantum chemistry programs to perform complex structural searches and reaction path calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DL-Find</rdfs:label>
     </owl:Class>
     
@@ -32260,6 +32350,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <obo:IAO_0000115 xml:lang="en">x3DNA is a comprehensive software package for the analysis, rebuilding, and visualization of three-dimensional nucleic acid structures. It takes a DNA or RNA structure file as input and calculates a wide range of standard helical and base pair parameters that are used to describe the detailed geometry of the helix. It is a cornerstone tool in the field of nucleic acid structural biology for characterizing and comparing experimental or simulated structures.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-4303-9349"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-7544-0938"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">x3DNA</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">3DNA</rdfs:label>
     </owl:Class>
     
@@ -32279,7 +32370,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001684">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000164"/>
-        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound. These tools are fundamental for comparing simulation results to experimental structures or for virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A match analysis tool is a program that compares two or more molecular structures or datasets to find and quantify their similarities. This can involve superimposing two protein structures to calculate their RMSD or searching a database of small molecules to find ones that have a similar shape or chemical features to a query compound.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">match analysis tool</rdfs:label>
     </owl:Class>
     
@@ -32882,7 +32974,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001743">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001715"/>
-        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The ICOSA algorithm is a computational method used to rapidly calculate the solvent-accessible surface area (SASA) of a molecule. It works by placing a sphere of dots, arranged in a pattern based on an icosahedron, around each atom and then counting how many of these dots are not covered by neighboring atoms. This numerical approach provides a fast and efficient way to estimate the molecular surface area, a property that is crucial for implicit solvent models and for analyzing a molecule&apos;s exposure to its environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">ICOSA algorithm</rdfs:label>
     </owl:Class>
     
@@ -32913,7 +33006,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001746">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_010012"/>
-        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The DSSP (Define Secondary Structure of Proteins) algorithm is the most widely used and standard algorithm for assigning secondary structure to the residues of a protein. It works by identifying the characteristic hydrogen-bonding patterns between the backbone amide and carbonyl groups that define alpha-helices and beta-sheets. The detailed, per-residue output of the DSSP algorithm is a standard tool for protein structure analysis and validation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DSSP algorithm</rdfs:label>
     </owl:Class>
     
@@ -33006,6 +33100,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001755">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
         <obo:IAO_0000115 xml:lang="en">An atom name is a unique label given to an atom within a specific residue to distinguish it from other atoms of the same element. For example, in an amino acid, the names &apos;CA&apos; and &apos;CB&apos; are used to differentiate the alpha-carbon from the beta-carbon.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom name</rdfs:label>
     </owl:Class>
@@ -33272,7 +33367,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001781 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001781">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
         <obo:IAO_0000115 xml:lang="en">Secondary structure refers to the regular, repeating local shapes, like spirals and zig-zags, that a protein or nucleic acid chain folds into. In proteins, this refers to common motifs such as alpha-helices and beta-sheets, which are stabilized by a regular pattern of hydrogen bonds between backbone atoms. Identifying and tracking the secondary structure is a fundamental analysis for understanding a protein&apos;s overall architecture and how its shape changes during a simulation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">secondary structure</rdfs:label>
     </owl:Class>
@@ -33293,7 +33388,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001783">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A parallel beta sheet is a type of beta sheet where the adjacent protein chains all run in the same direction, like lanes on a one-way highway. In this arrangement, the neighboring beta-strands are all aligned in the same N-terminus to C-terminus direction, which results in a pattern of angled, evenly spaced hydrogen bonds between the strands. This arrangement is typically found buried in the core of a protein and often requires long loop connections between the strands.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -33303,7 +33399,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001784">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001782"/>
-        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein chains run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An anti-parallel beta sheet is a type of beta sheet where the adjacent protein strands run in opposite directions, like traffic on a two-way street. In this arrangement, the neighboring beta-strands are aligned in opposite N-terminus to C-terminus directions, resulting in a pattern of straight, perpendicular hydrogen bonds between the strands. This arrangement is generally more stable than the parallel form and is a very common structural motif found in many proteins.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">anti-parallel beta sheet</rdfs:label>
     </owl:Class>
     
@@ -33312,9 +33409,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001785 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001785">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. A helix is a common shape in proteins and DNA where the molecular chain is twisted into a spiral or corkscrew. It is a secondary structure motif characterized by a repeating pattern of backbone dihedral angles that causes the polymer chain to follow a helical path, which is stabilized by a regular pattern of internal hydrogen bonds. The alpha-helix in proteins and the double helix of DNA are two of the most fundamental and recognizable structures in biology.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33322,9 +33421,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001786 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001786">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">3-10 helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The 3-10 helix is a type of spiral shape found in proteins that is tighter and more narrow than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue three positions down the chain (i → i+3). While less common than the alpha-helix, short segments of 3-10 helix are often found at the ends of alpha-helices, acting as a cap to the structure.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete 3-10 helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33332,9 +33433,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001787 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001787">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">alpha helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The alpha-helix is the most common spiral shape found in proteins, resembling a coiled ribbon. It is a right-handed secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue four positions down the chain (i → i+4). This highly stable and common structure forms a fundamental building block for the architecture of most proteins.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete alpha helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33342,9 +33445,11 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <!-- http://purl.obolibrary.org/obo/MOLSIM_001788 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001788">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001785"/>
-        <obo:IAO_0000115 xml:lang="en">The pi-helix is a rare and wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is very rare and is usually found only as a short, single-turn insertion within other helical structures. (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">pi helix</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">OBSOLETE. The pi-helix is a wide spiral shape found in proteins that is less stable than the common alpha-helix. It is a secondary structure motif characterized by a repeating hydrogen bond between the backbone carbonyl of a residue and the backbone amide of the residue five positions down the chain (i → i+5). Because its internal packing is less favorable, the pi-helix is usually found only as a short, single-turn insertion within other helical structures. Once thought to be rare, short π-helices are found in 15% of known protein structures and are believed to be an evolutionary adaptation derived by the insertion of a single amino acid into an α-helix.</obo:IAO_0000115>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <rdfs:comment xml:lang="en">Retired 2026-08-05 in favour of the Sequence Ontology term, which covers the same concept in the ontology whose scope owns protein secondary structure. The MOLSIM hierarchy position is preserved: the SO class is asserted under MOLSIM:001781 secondary structure so the DSSP category set stays in one place.</rdfs:comment>
+        <rdfs:label xml:lang="en">obsolete pi helix</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -33363,7 +33468,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001790">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain. Bends are crucial for creating a protein&apos;s compact, globular shape by connecting other secondary structure elements like helices and sheets. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A bend is a region in a protein chain that creates a sharp turn, changing the direction of the polypeptide. It is a short structural motif, typically involving a few amino acid residues, that is characterized by a specific pattern of backbone dihedral angles that reverses the direction of the chain.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">bend</rdfs:label>
     </owl:Class>
     
@@ -33383,7 +33489,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001792">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
-        <obo:IAO_0000115 xml:lang="en">A beta bridge is a single hydrogen bond that links two distant parts of a protein chain together, forming a small zig-zag. It is a simple secondary structure element consisting of a single pair of hydrogen bonds between the backbone atoms of two residues that are not adjacent in the sequence. While a beta sheet is formed by many such hydrogen bonds, an isolated beta bridge can act as a key stabilizing interaction that helps to hold a protein&apos;s folded structure together. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A beta bridge is an isolated, localized hydrogen bond between two amino acid residues from different segments of a protein, mimicking the interactions found in β-sheets.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">beta bridge</rdfs:label>
     </owl:Class>
     
@@ -33415,7 +33522,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001091"/>
-        <obo:IAO_0000115 xml:lang="en">The MDL solvent model format is a file that defines the properties of a solvent for use in certain implicit solvent calculations. It contains parameters that describe the solvent&apos;s bulk properties, such as its density and viscosity, which are needed by the simulation program. This format is used by specific, less common simulation methods to incorporate the effects of a solvent without explicitly representing every solvent molecule. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Solvent MoDeL (MDL) file is an explicit molecular model input used for 1D-RISM and 3D-RISM (Reference Interaction Site Model) calculations in software like Amber. It supplies atomic coordinates, partial charges, and Lennard-Jones parameters for solvent molecules or ions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">MDL solvent model format</rdfs:label>
     </owl:Class>
     
@@ -33990,7 +34098,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001850">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000158"/>
-        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A modeling and setup tool is a type of software used to construct and prepare a molecular system before a simulation is run. This involves tasks like building a molecule from scratch, repairing a structure from an experimental database, or surrounding a protein with water molecules to mimic its natural environment. For an expert, these tools are essential for creating a chemically correct and physically stable starting point, which is a prerequisite for any meaningful simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">modeling and setup tool</rdfs:label>
     </owl:Class>
     
@@ -34154,7 +34263,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001866">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Backbone DH fluctuations are a measure of how much the backbone of a protein wiggles and changes shape during a simulation. It specifically quantifies the fluctuations in the dihedral angles (DH) of the protein&apos;s backbone, which describe the rotations around the chemical bonds that connect the amino acids. Analyzing these fluctuations provides a detailed picture of the protein&apos;s flexibility and dynamics that is independent of its overall tumbling motion.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">backbone DH fluctuations</rdfs:label>
     </owl:Class>
     
@@ -34407,7 +34517,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001889">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001887"/>
-        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together. For experts, this category encompasses the vast majority of simulations aimed at understanding molecular recognition. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A complex system in this context refers to a molecular simulation system that contains two or more interacting macromolecules, or a macromolecule interacting with a smaller molecule like a drug. The primary focus of simulating such a system is to study the interactions, binding, and functional consequences of the molecules coming together.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">complex system</rdfs:label>
     </owl:Class>
     
@@ -34460,7 +34571,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001894">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001889"/>
-        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A hybrid complex system is a type of complex system composed of macromolecules from different biological classes. This most commonly refers to a complex formed between a protein and a nucleic acid, such as a transcription factor bound to DNA. Simulating these systems is essential for understanding many fundamental biological processes like gene regulation and DNA repair.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">hybrid complex system</rdfs:label>
     </owl:Class>
     
@@ -34761,7 +34873,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001922">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">3Dmol.js is a JavaScript library used for creating interactive, 3D visualizations of molecular structures directly within a web browser. It allows web developers to embed high-quality molecular viewers into websites and web applications without requiring any plugins. For creators of online scientific resources, 3Dmol.js provides a lightweight and versatile tool for displaying and interacting with molecular data on the web.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">3DMol.js</rdfs:label>
     </owl:Class>
     
@@ -34772,7 +34885,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001923">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001566"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids. For developers of web-based bioinformatics tools, NGL provides a powerful and scalable component for molecular graphics and data visualization. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">NGL Viewer is a WebGL-based JavaScript library for the fast and high-quality visualization of large molecular complexes and trajectories in the web browser. It is designed for high-performance rendering, enabling smooth, interactive exploration of even very large structures like ribosomes or viral capsids.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">NGL</rdfs:label>
     </owl:Class>
     
@@ -34782,7 +34896,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001924">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000166"/>
-        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Open Babel is a versatile software program and library, often called a &quot;chemical toolbox,&quot; for reading, writing, and converting between over 100 different chemical file formats. It allows users to easily interconvert between the various file types used by different simulation, modeling, and visualization programs. Its powerful interoperability makes it an essential utility in many simulation and modeling workflows for preparing and manipulating molecular structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Open Babel</rdfs:label>
     </owl:Class>
     
@@ -34813,7 +34928,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001927">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000225"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000714"/>
-        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations. For simulation experts and novices alike, CHARMM-GUI is an invaluable resource that greatly simplifies the preparation of systems for use with simulation packages like CHARMM, NAMD, GROMACS, and AMBER. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">CHARMM-GUI is a powerful and widely used web server that provides a graphical interface for generating input files for a wide variety of complex biomolecular simulations. It automates many difficult and error-prone setup tasks, such as building lipid membranes, solvating proteins, and preparing systems for free energy calculations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">CHARMM-GUI</rdfs:label>
     </owl:Class>
     
@@ -34823,7 +34939,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001928">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001958"/>
-        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Modeller is a widely used computer program for generating three-dimensional models of proteins through homology or comparative modeling. It predicts a protein&apos;s structure by using the known structure of a related protein as a template and satisfying spatial restraints. For researchers, Modeller is a powerful tool to create high-quality structural hypotheses for proteins whose experimental structures have not yet been determined, providing a starting point for further simulation.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Modeller</rdfs:label>
     </owl:Class>
     
@@ -34864,7 +34981,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001932">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and is often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provides a versatile and accessible tool for basic molecular visualization and analysis. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Jmol is a free, open-source molecular viewer for 3D chemical structures, written in the Java programming language. Because it is Java-based, it can run on a wide variety of operating systems and was often used as a tool for displaying molecules on websites. For researchers and educators, Jmol provided a versatile and accessible tool for basic molecular visualization and analysis. Nowadays replaced by JavaScript and openGL tools such as JSMol, NGL or Mol*.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">Jmol</rdfs:label>
     </owl:Class>
     
@@ -34874,7 +34992,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001933">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">MolStar is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">MolStar (Mol*) is a modern, web-based toolkit for visualizing and analyzing large-scale molecular data. It is designed for high-performance rendering of extremely large structures, such as those from cryo-electron microscopy, directly in a web browser. For the structural biology community, Mol* is the state-of-the-art viewer integrated into databases like the PDB for exploring complex biological assemblies.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Mol*</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">MolStar</rdfs:label>
     </owl:Class>
@@ -35094,7 +35213,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001955">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001556"/>
-        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment. For experts, this is a necessary step when preparing crystal simulations to ensure the simulation box dimensions and contents match the physical lattice. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A crystallographic build tool is a software utility used to reconstruct a full crystal lattice or supercell from the asymmetric unit provided in a structure file. It applies the specific symmetry operations defined by the space group to generate the complete crystallographic packing environment.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">crystallographic build tool</rdfs:label>
     </owl:Class>
     
@@ -35124,7 +35244,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001958">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001850"/>
-        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are the standard solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A homology modeling tool is a software program designed to predict the three-dimensional structure of a protein based on its amino acid sequence and experimentally determined template structures. It constructs a model by mapping the target sequence onto the backbone of a homologous protein and computationally refining the loops and side chains to resolve steric conflicts. For experts, these tools are a solution for generating starting structural models when high-resolution crystallography or NMR data for the specific target is unavailable.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">homology modeling tool</rdfs:label>
     </owl:Class>
     
@@ -35134,7 +35255,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001959">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand. For experts, Vina provides a substantial improvement in speed and accuracy over previous generations, making it a standard engine for high-throughput virtual screening in drug discovery. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock Vina is an open-source software tool for molecular docking that predicts the preferred orientation and binding affinity of a small molecule to a protein receptor. It utilizes a sophisticated iterated local search global optimizer combined with an empirical scoring function to efficiently explore the conformational space of the ligand.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock Vina</rdfs:label>
     </owl:Class>
     
@@ -35195,7 +35317,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001965">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. It breaks the structures into hexapeptide fragments and reassembles alignments to find similarities in the pattern of residue-residue contacts. This approach allows experts to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">DALI (Distance Alignment) is a software method that compares protein structures by analyzing their internal distance matrices rather than their rigid-body superposition. This approach allows to detect distant evolutionary relationships and structural similarities even when the proteins have undergone significant conformational changes or distortions.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">DALI</rdfs:label>
     </owl:Class>
     
@@ -35205,7 +35328,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001966">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001684"/>
-        <obo:IAO_0000115 xml:lang="en">LS-align is a computational tool designed for the flexible structural alignment of small molecule ligands. It employs a heuristic iterative search algorithm to optimize the superposition of atoms based on both their spatial proximity and chemical mass. For cheminformatics, this tool is valuable for virtual screening and pharmacophore discovery by identifying molecules that share a similar 3D shape and chemical features despite having different bonding topologies. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">LS-align is an algorithm designed for atom-level structural comparison of ligand molecules. The target function of LS-align is a combination of inter-atom distance, atom mass, and chemical bond connections; while the final atom-to-atom alignment is generated by maximizing such target function through an enhanced-greedy based, iterative heuristic search algorithm.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">LS-align</rdfs:label>
     </owl:Class>
     
@@ -35236,7 +35360,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001969">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001564"/>
-        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. For experts, these tools enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A free energy surface analysis tool is a software utility used to reconstruct the multidimensional free energy landscape of a system from enhanced sampling simulation data. It processes the history of visited states or applied biases, such as those from metadynamics or umbrella sampling, to generate a potential of mean force (PMF) map. Enable the visualization of low-energy basins and transition barriers along specific collective variables or reaction coordinates.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">free energy surface analysis tool</rdfs:label>
     </owl:Class>
     
@@ -35501,7 +35626,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001995">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001552"/>
-        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol⋅nm^2). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational technique used to anchor atoms to specific locations in 3D space during a simulation. It applies an artificial harmonic energy penalty proportional to the square of the displacement of an atom from a reference coordinate. For experts, these are heavily used during system equilibration (to relax solvent around a fixed solute) or in free energy calculations to prevent ligand drift, typically defined with a force constant k in units of kJ/(mol*nm^2) or kcal/mol.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">position restraints</rdfs:label>
     </owl:Class>
     
@@ -35677,7 +35803,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory. For experts, exact binary continuation is essential for preserving the ensemble distribution and avoiding artifacts associated with regenerating velocities (the &quot;flying ice cube&quot; effect). (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A configuration setting that instructs a molecular dynamics engine to resume a simulation exactly from where a previous run finished. It requires reading the full state of the system—including atomic positions, velocities, and sometimes forces—from a checkpoint or restart file to ensure a seamless trajectory.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">continuation state</rdfs:label>
     </owl:Class>
     
@@ -35951,7 +36078,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002039">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in structure.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An atom ID is usually a number, that uniquely defines a given atom in a molecular structure. It is typically used in molecular topology descriptions to uniquely identify an atom from the set of atoms defining the system.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0003-4177-3619"/>
         <rdfs:label xml:lang="en">atom ID</rdfs:label>
     </owl:Class>
@@ -35962,7 +36090,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002040">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002041"/>
-        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">JSmol is an open-source, HTML5/JavaScript-based molecular viewer that allows for the interactive 3D visualization of chemical structures within web browsers without requiring Java or other plugins. It is the modern, JavaScript implementation of the popular Jmol applet, widely used in chemical education, databases, and web-based cheminformatics tools.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">JSmol</rdfs:label>
     </owl:Class>
     
@@ -35972,7 +36101,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed specifically to render and interactively display three-dimensional models of molecular structures, complexes, and dynamic simulation trajectories. These tools are used to visually inspect atomic coordinates, molecular surfaces, and spatial relationships.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">molecular structure visualization tool</rdfs:label>
     </owl:Class>
     
@@ -35982,7 +36112,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002042">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000163"/>
-        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files. In simulation workflows, these are used to plot time-series data (like RMSD or energy over time), histograms, and statistical analyses. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A visualization tool designed to generate 2D or 3D graphs, charts, and plots from numerical data files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">data visualization tool</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">data plotting tool</rdfs:label>
     </owl:Class>
@@ -36054,7 +36185,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002049">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. Older than Vina, classic AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function. It remains widely used for generating starting poses for molecular dynamics simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">AutoDock is a suite of automated docking tools designed to predict how small molecules bind to a receptor of known 3D structure. AutoDock (e.g., AutoDock 4) utilizes a Lamarckian genetic algorithm and a grid-based empirical scoring function.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">AutoDock</rdfs:label>
     </owl:Class>
     
@@ -36064,7 +36196,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002050">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">GOLD (Genetic Optimisation for Ligand Docking) is a highly regarded commercial docking program developed by the Cambridge Crystallographic Data Centre (CCDC). It uses a genetic algorithm to explore ligand conformational space and offers multiple scoring functions. It is frequently used in pharmaceutical pipelines to generate highly accurate protein-ligand complex structures for subsequent MD refinement.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Genetic Optimisation for Ligand Docking</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">GOLD</rdfs:label>
     </owl:Class>
@@ -36075,7 +36208,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000162"/>
-        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function (e.g., SP, XP). It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Glide (Grid-based Ligand Docking with Energetics) is a commercial molecular docking program within the Schrödinger software suite. It uses a systematic, hierarchical search of positional, orientational, and conformational space followed by evaluation with an empirical scoring function. It is heavily utilized in industry for virtual screening and preparing complexes for Desmond MD simulations.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">Grid-based Ligand Docking with Energetics</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Glide</rdfs:label>
     </owl:Class>
@@ -36155,7 +36289,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The PDBQT format is an extension of the standard PDB format specifically designed for use with the AutoDock and AutoDock Vina molecular docking suites. In addition to atomic coordinates, it stores calculated partial charges (&apos;Q&apos;) and AutoDock-specific atom types (&apos;T&apos;), making it a structural format that intrinsically carries the predictive interaction parameters required for, and generated by, docking algorithms.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">PDBQT format</rdfs:label>
     </owl:Class>
     
@@ -36176,7 +36311,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
-        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A docking log format is a text-based or tabular file generated by molecular docking software (such as AutoDock Vina, Glide, or GOLD) to record the numerical results of a virtual screening or pose prediction run. It typically contains ranked lists of predicted binding poses, estimated binding affinities or docking scores, and clustering metrics like RMSD, serving as the primary predictive output for analyzing binding without needing to parse the 3D structure files.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <rdfs:label xml:lang="en">docking log format</rdfs:label>
     </owl:Class>
     
@@ -36198,7 +36334,8 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000715"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001088"/>
-        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, hierarchical file format of the Schrödinger software suite, used to store molecular structures along with extensive property data. As a prediction data format, it is frequently used to encapsulate the output of predictive modeling workflows like Glide docking, embedding algorithmic metadata such as docking scores, physical descriptors, and predicted interaction energies directly alongside the atomic coordinates. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Maestro format (typically .mae or .maegz) is the native, proprietary text-based format developed by Schrödinger software suite, used to store molecular structures along with associated properties.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-8291-8071"/>
         <oboInOwl:hasExactSynonym xml:lang="en">mae format</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">maegz format</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">Maestro format</rdfs:label>
@@ -36575,7 +36712,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002098">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000003"/>
-        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An execution that resumes a previously interrupted or completed molecular dynamics run by reading saved coordinates, velocities, and simulation state from a restart file. It allows a long simulation to be continued across multiple sessions without loss of continuity. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart simulation process</rdfs:label>
     </owl:Class>
     
@@ -36585,7 +36722,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000165"/>
-        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data processing tool that reads simulation input, output, or trajectory files and extracts descriptive metadata such as system composition, run settings, and provenance information. It supports cataloguing and FAIR annotation of simulation datasets. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata extraction tool</rdfs:label>
     </owl:Class>
     
@@ -36595,7 +36732,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001669"/>
-        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A PMEMD build that runs molecular dynamics calculations on NVIDIA graphics processing units using the CUDA programming model. It accelerates simulations by offloading the compute-intensive force evaluation and integration steps to the GPU. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">PMEMD.cuda</rdfs:label>
     </owl:Class>
     
@@ -36605,7 +36742,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks recorded or extracted metadata for completeness, correctness, and internal consistency against expected schemas or physical constraints. It helps ensure that a simulation dataset is reliably described before it is shared or archived. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">metadata validation process</rdfs:label>
     </owl:Class>
     
@@ -36615,7 +36752,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002102">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001767"/>
-        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A trajectory post-processing that translates atomic coordinates back into the primary periodic unit cell so that molecules which crossed periodic boundaries appear whole. It produces trajectories that are easier to visualize and analyze without altering the underlying physics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">coordinate wrapping process</rdfs:label>
     </owl:Class>
     
@@ -36625,7 +36762,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002103">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000364"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained simulation method that biases the dynamics using experimental nuclear magnetic resonance observables, such as interatomic distance restraints from nuclear Overhauser effects or torsion-angle restraints from scalar couplings. It guides the simulated structure toward conformations consistent with the measurements. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">NMR restrained simulation</rdfs:label>
     </owl:Class>
     
@@ -36635,7 +36772,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000335"/>
-        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A restrained subset dynamics in which only a selected group of atoms is allowed to move while the remaining atoms are held fixed throughout the run. It reduces computational cost and focuses sampling on a region of interest, taking its name from the Amber convention of designating a mobile region. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">belly dynamics</rdfs:label>
     </owl:Class>
     
@@ -36645,7 +36782,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001219"/>
-        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An enhanced sampling parameter that specifies how often exchanges between neighboring replicas are attempted during a replica exchange simulation. It controls the rate at which configurations are swapped between conditions such as different temperatures. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">replica exchange attempt frequency</rdfs:label>
     </owl:Class>
     
@@ -36655,7 +36792,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002106">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how frequently the net translational motion of the system&apos;s center of mass is removed during a run. Periodic removal prevents the gradual accumulation of spurious overall drift of the simulated system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">center of mass removal interval</rdfs:label>
     </owl:Class>
     
@@ -36665,7 +36802,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002107">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001165"/>
-        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An integration parameter that specifies how many short inner integration steps are taken per long outer step in a multiple-timestep integration scheme. It sets how often fast-varying forces are evaluated relative to slow-varying forces to improve computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">multi-timestep inner loop count</rdfs:label>
     </owl:Class>
     
@@ -36675,7 +36812,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002108">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that governs how frequently and in what form simulation data are written to output files during a run. It determines the temporal resolution and volume of the recorded energies, coordinates, and diagnostic information. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">output control parameter</rdfs:label>
     </owl:Class>
     
@@ -36685,7 +36822,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often energy and related thermodynamic quantities are written to the output or log during a run. Smaller intervals give finer-grained monitoring at the cost of larger output files. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">energy output interval</rdfs:label>
     </owl:Class>
     
@@ -36695,7 +36832,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often a restart file containing the current coordinates, velocities, and state is written during a run. It determines how much progress can be recovered if the run is interrupted. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">restart output interval</rdfs:label>
     </owl:Class>
     
@@ -36705,7 +36842,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002111">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002108"/>
-        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An output control parameter that specifies how often diagnostic and status information is written to the simulation log during a run. It controls the verbosity and temporal resolution of the recorded run history. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">log output interval</rdfs:label>
     </owl:Class>
     
@@ -36715,7 +36852,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002112">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001083"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state that represents the elapsed model time reached by the system at a given point in a molecular dynamics run. It records how far the simulation has advanced along the physical time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation state time</rdfs:label>
     </owl:Class>
     
@@ -36725,7 +36862,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002113">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the end of a run or equilibration stage. It is commonly compared against experimental density to assess whether the system has equilibrated correctly. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">final density</rdfs:label>
     </owl:Class>
     
@@ -36735,7 +36872,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002114">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001292"/>
-        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computed observable that quantifies the computational cost or efficiency of a simulation run rather than a physical property of the system. Examples include elapsed real time and the amount of simulated time produced per unit of computing time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">computational performance metric</rdfs:label>
     </owl:Class>
     
@@ -36745,7 +36882,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002115">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the total real-world elapsed time taken to complete a run from start to finish. It reflects the actual time a user waits, including all computation and input or output. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36755,7 +36892,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002116">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the cumulative processor time consumed by a run, summed across all active compute cores. It reflects total computational effort rather than elapsed real time. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">total cpu time</rdfs:label>
     </owl:Class>
     
@@ -36765,7 +36902,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent preparing a run before the production phase begins, such as reading inputs and building data structures. It isolates initialization overhead from the main computation. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">setup wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36775,7 +36912,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that measures the real-world elapsed time spent in the production phase of a run, during which the trajectory of interest is generated. It excludes setup and finalization overhead. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">production wallclock time</rdfs:label>
     </owl:Class>
     
@@ -36785,7 +36922,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that represents the mean real-world time required to advance the simulation by one integration step. It is a convenient measure of per-step computational efficiency. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">average integration step time</rdfs:label>
     </owl:Class>
     
@@ -36795,7 +36932,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002114"/>
-        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A computational performance metric that expresses how much simulated model time is produced per unit of real-world computing time, commonly reported as nanoseconds per day. It is a standard measure for comparing the practical speed of simulations. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation throughput</rdfs:label>
     </owl:Class>
     
@@ -36805,7 +36942,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002155">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that describes a sequential, multi-stage computational workflow, such as minimization, heating, equilibration, and production, applied to a molecular system. It organizes the individual stages and their ordering into a single reproducible procedure. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation protocol</rdfs:label>
     </owl:Class>
     
@@ -36815,7 +36952,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000000"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation protocol, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics process that constitutes one discrete, chronological phase within a larger simulation run, characterized by its own role and its own input and output files. Examples include a heating stage or a production stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation stage</rdfs:label>
     </owl:Class>
     
@@ -36825,7 +36962,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002157">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001164"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation parameter that specifies how another parameter, such as target temperature, restraint force constant, or non-bonded cutoff, changes over the course of a run, whether across simulated time or across integration steps. It captures ramping and stepwise schedules applied during a stage. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation parameter schedule</rdfs:label>
     </owl:Class>
     
@@ -36835,7 +36972,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002158">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that evaluates whether two consecutive simulation stages join without an unexpected break, by comparing the end time of one stage with the start time of the next. It flags gaps that may indicate missing segments or unit errors. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">simulation continuity check</rdfs:label>
     </owl:Class>
     
@@ -36845,7 +36982,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002159">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000353"/>
-        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A validation analysis that checks whether metadata extracted from several distinct files describing the same stage, such as topology, input, output, and trajectory files, agree with one another. It surfaces inconsistencies such as mismatched atom counts or timesteps. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">cross-source validation</rdfs:label>
     </owl:Class>
     
@@ -36855,7 +36992,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002160">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records a failure, exception, or warning encountered while reading or extracting metadata from a simulation data file. It preserves the reason a file could not be fully processed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file parsing error</rdfs:label>
     </owl:Class>
     
@@ -36865,7 +37002,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002161">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000436"/>
-        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A data format that designates a specific standardized schema variant that a file adheres to within a broader container format, such as the AMBER conventions used inside a NetCDF file. It identifies the precise rules for interpreting the file&apos;s contents. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">file format convention</rdfs:label>
     </owl:Class>
     
@@ -36875,7 +37012,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002162">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that assigns a high-level descriptive category to a molecular system based on its overall composition, such as a protein-ligand complex in explicit water. It provides a concise, human-readable summary of what is being simulated. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">system classification label</rdfs:label>
     </owl:Class>
     
@@ -36885,7 +37022,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002163">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a specific subset of atoms within a molecular system using a formal string or logical expression, for the purpose of applying restraints, constraints, or targeted analysis. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom selection mask</rdfs:label>
     </owl:Class>
     
@@ -36896,7 +37033,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002164">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002165"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the average amount of simulated time elapsed between consecutive saved frames of a trajectory. It reflects how finely the trajectory samples the simulated time coordinate. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trajectory frame interval</rdfs:label>
     </owl:Class>
     
@@ -36906,7 +37043,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002165">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002112"/>
-        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A simulation state time that represents the difference between the end time of one simulation stage and the start time of the next. A nonzero gap indicates a break in the continuous simulated-time coordinate across stages. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">inter-stage time gap</rdfs:label>
     </owl:Class>
     
@@ -36916,7 +37053,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001696"/>
-        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An analysis algorithm that identifies which atoms in a molecular system are hydrogens, for the purpose of applying or detecting hydrogen mass repartitioning. Different strategies rely on different atomic attributes, such as atomic number or atom name. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">hydrogen detection strategy</rdfs:label>
     </owl:Class>
     
@@ -36926,7 +37063,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002192">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001293"/>
-        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A thermodynamic property that represents the mass density of the simulated system at the start of a run, computed from the topology mass and the initial periodic box volume. It provides a baseline for comparison against the equilibrated density reached during a constant-pressure run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">initial density</rdfs:label>
     </owl:Class>
     
@@ -36936,7 +37073,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002196">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the atom count agrees across all files describing a stage, such as topology, coordinate, output, and trajectory files. A mismatch indicates the files do not describe the same system. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom count consistency check</rdfs:label>
     </owl:Class>
     
@@ -36946,7 +37083,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002197">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether periodic box information is consistently present or absent across the files describing a stage. It flags cases where, for example, a topology declares a box but a coordinate file does not. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">box consistency check</rdfs:label>
     </owl:Class>
     
@@ -36956,7 +37093,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002198">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether step counts, timesteps, and total durations agree across the input, output, and trajectory files of a stage. It verifies that the recorded trajectory length matches the configured number of steps times the timestep. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">timing consistency check</rdfs:label>
     </owl:Class>
     
@@ -36966,7 +37103,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002199">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002159"/>
-        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A cross-source validation that checks whether the coordinate write frequency configured in the input matches the frequency reflected in the output and trajectory. It confirms that sampling settings were applied as specified. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">sampling consistency check</rdfs:label>
     </owl:Class>
     
@@ -36976,7 +37113,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000417"/>
-        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A polypeptide domain that occurs in a protein. It is a distinct, self-contained part of a protein that folds up on its own and usually carries out a particular job. Large proteins are often built from several domains.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">protein domain</rdfs:label>
     </owl:Class>
@@ -36987,7 +37124,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain whose function is to attach to a matching partner molecule called a receptor.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">receptor-binding domain</rdfs:label>
     </owl:Class>
@@ -36998,7 +37135,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002205">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002203"/>
-        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme. (NEWLY_ADDED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein domain that contains the active site, the pocket where an enzyme carries out its chemical reaction. It is the working part of an enzyme.</obo:IAO_0000115>
         <obo:IAO_0000117 rdf:resource="https://orcid.org/0000-0002-2294-5393"/>
         <rdfs:label xml:lang="en">catalytic domain</rdfs:label>
     </owl:Class>
@@ -37009,7 +37146,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002206">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label that records the biological job of the main protein in a simulated system. Proteins do most of the work in living cells, and this label groups simulations by the kind of job their protein does. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">protein functional class label</rdfs:label>
     </owl:Class>
     
@@ -37019,7 +37156,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002207">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an enzyme, a protein that speeds up a chemical reaction in the cell without being used up itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">enzyme classification label</rdfs:label>
     </owl:Class>
     
@@ -37029,7 +37166,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a transport protein, one that moves ions or molecules from place to place, for example carrying them across a cell membrane. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">transport protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37039,7 +37176,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a structural protein, one that gives shape, stiffness, or mechanical support to cells and tissues, like a scaffold. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">structural protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37049,7 +37186,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002210">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a regulatory protein, one that switches biological processes on or off, or tunes how fast they run. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">regulatory protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37059,7 +37196,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002211">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a signaling protein, one that passes messages within a cell or between cells so the cell can respond to its surroundings. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">signaling protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37069,7 +37206,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002212">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a motor protein, one that turns chemical energy into movement, walking along tracks inside the cell to carry cargo or generate force. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">motor protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37079,7 +37216,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002213">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is an immune protein, one that helps recognise or fight off germs and foreign material; antibodies are a familiar example. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">immune protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37089,7 +37226,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002214">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002206"/>
-        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A protein functional class label for a system whose main protein is a storage protein, one that holds onto useful substances such as iron or amino acids until they are needed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">storage protein classification label</rdfs:label>
     </owl:Class>
     
@@ -37099,7 +37236,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002226">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001210"/>
-        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system setup parameter that gives the three angles (commonly α, β, γ) between the edges of the simulation box. These are needed to describe boxes that are not simple rectangular blocks, for example triclinic or truncated-octahedral boxes. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">periodic box angles</rdfs:label>
     </owl:Class>
     
@@ -37109,7 +37246,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002230">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000447"/>
-        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An identifier that encodes the structure of a molecule as a short line of text, using the SMILES notation (Simplified Molecular-Input Line-Entry System). It lets a small molecule be written, searched, and shared as plain text, and complements the InChI code. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">SMILES code</rdfs:label>
     </owl:Class>
     
@@ -37119,7 +37256,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002232">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000171"/>
-        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A software development and management tool that translates a program&apos;s source code into a runnable program. Which compiler was used can affect a simulation&apos;s speed and, occasionally, its numerical results. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">compiler</rdfs:label>
     </owl:Class>
     
@@ -37129,7 +37266,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002233">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000310"/>
-        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that defines a named group of atoms selected from the system, so the group can be referred to by name during setup or analysis. It is the concept behind a Gromacs index (.ndx) file, where groups such as Protein or Water are listed. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom index group</rdfs:label>
     </owl:Class>
     
@@ -37139,7 +37276,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002234">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000843"/>
-        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A molecular dynamics method in which the forces between atoms come from a classical (empirical) force field rather than from quantum-mechanical calculations. It is the most common and computationally affordable form of molecular dynamics. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">classical molecular dynamics</rdfs:label>
     </owl:Class>
     
@@ -37149,7 +37286,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002235">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001072"/>
-        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An information content entity that records how the atoms or residues in a simulation correspond to an experimental source structure (such as a PDB entry), including any changes made, for example point mutations or modelled-in missing residues. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">source structure residue mapping</rdfs:label>
     </owl:Class>
     
@@ -37159,7 +37296,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002236">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001333"/>
-        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A structural property that describes how many copies of a protein chain join together to form a working unit. Many proteins function only when several copies assemble into one complex. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -37169,7 +37306,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002237">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which the protein works on its own as a single chain, not joined to copies of itself. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">monomeric state</rdfs:label>
     </owl:Class>
     
@@ -37179,7 +37316,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002238">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which two copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">dimeric state</rdfs:label>
     </owl:Class>
     
@@ -37189,7 +37326,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which three copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">trimeric state</rdfs:label>
     </owl:Class>
     
@@ -37199,7 +37336,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which four copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">tetrameric state</rdfs:label>
     </owl:Class>
     
@@ -37209,7 +37346,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002241">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002236"/>
-        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An oligomeric state in which five or more copies of a protein chain join together to form the working unit. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">higher-order oligomeric state</rdfs:label>
     </owl:Class>
     
@@ -37219,7 +37356,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002246">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_000105"/>
-        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A conformational state of a coronavirus spike protein describing how many of its receptor-binding domains are raised into the open position, ready to engage a host cell. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spike opening conformational state</rdfs:label>
     </owl:Class>
     
@@ -37229,7 +37366,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002247">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming the specific strain or sequence variant of the organism or virus that the simulated molecule comes from, for example a particular variant of the COVID-19 virus. It groups simulations by biological origin. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">biological strain classification label</rdfs:label>
     </owl:Class>
     
@@ -37239,8 +37376,19 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002248">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A system classification label naming a non-standard version of a histone protein present in the structure (for example H2A.Z). Different histone versions can change how DNA is packaged and read. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">histone variant classification label</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/MOLSIM_002249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002249">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001960"/>
+        <obo:IAO_0000115 xml:lang="en">A nucleic acid analysis tool that characterises RNA secondary structure and higher-order motifs directly from three-dimensional coordinates. Built on the 3DNA suite, it annotates base pairs, helices, stems, hairpin loops and multi-branch junctions, and produces schematic representations of the result. It is widely used for RNA structural bioinformatics and is integrated into viewers such as Jmol and PyMOL. (UNVERIFIED)</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym xml:lang="en">Dissecting the Spatial Structure of RNA</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">DSSR</rdfs:label>
     </owl:Class>
     
 
@@ -37357,7 +37505,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001717"/>
-        <obo:IAO_0000115>The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The Kabsch algorithm, is a method for calculating the optimal rotation matrix that minimizes the RMSD between two paired sets of points. The algorithm only computes the rotation matrix, but it also requires the computation of a translation vector. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Kabsch RMSD algorithm</rdfs:label>
     </owl:Class>
     
@@ -37367,7 +37515,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001745"/>
-        <obo:IAO_0000115>In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">In protein structure, STRIDE (Structural identification) is an algorithm for the assignment of protein secondary structure elements given the atomic coordinates of the protein. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">STRIDE algorithm</rdfs:label>
     </owl:Class>
     
@@ -37387,7 +37535,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which fit a known distribution to the data using maximum likelihood or Bayesian methods. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">parametric distribution fitting algorithm</rdfs:label>
     </owl:Class>
     
@@ -37397,7 +37545,7 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MOLSIM_010015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001751"/>
-        <obo:IAO_0000115>Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Statistical algorithm which uses smooth piecewise polynomials to fit the densitiy. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">spline-based estimation algorithm</rdfs:label>
     </owl:Class>
     
@@ -37805,6 +37953,195 @@ vs. .nc (NetCDF): The NetCDF format is the modern, binary, and recommended forma
         <owl:annotatedTarget>Region of polypeptide with a given structural property.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref>SO:cb</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001078">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001070"/>
+        <obo:IAO_0000115>A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00003</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Secondary_structure</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>polypeptide secondary structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>2nary structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary structure region</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>secondary_structure</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001078</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Biosapien term was secondary_structure.</rdfs:comment>
+        <rdfs:label>polypeptide_secondary_structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A region of peptide with secondary structure has hydrogen bonding along the peptide chain that causes a defined conformation of the chain.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Secondary_structure</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>2nary structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary structure region</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>secondary_structure</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001781"/>
+        <obo:IAO_0000115>A helix is a secondary_structure conformation where the peptide backbone forms a coil.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00152</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001114</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>peptide_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A helix is a secondary_structure conformation where the peptide backbone forms a coil.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>helix</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00040</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Alpha_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym>a-helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>helix</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id>SO:0001117</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>alpha_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The helix has 3.6 residues per turn which corresponds to a translation of 1.5 angstroms (= 0.15 nm) along the helical axis. Every backbone N-H group donates a hydrogen bond to the backbone C=O group of the amino acid four residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Alpha_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>a-helix</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget>helix</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>uniprot:feature_type</oboInOwl:hasDbXref>
+        <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/so#BS"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:00153</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/Pi_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>pi helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001118</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>pi_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The pi helix has 4.1 residues per turn and a translation of 1.15 (=0.115 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid five residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001118"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/Pi_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SO_0001119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001114"/>
+        <obo:IAO_0000115>The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.</obo:IAO_0000115>
+        <oboInOwl:hasAlternativeId>BS:0000340</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref>http://en.wikipedia.org/wiki/310_helix</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym>3(10) helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>3-10 helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>310 helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>three ten helix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace>sequence</oboInOwl:hasOBONamespace>
+        <oboInOwl:id>SO:0001119</oboInOwl:id>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/so#biosapiens"/>
+        <rdfs:comment>Range.</rdfs:comment>
+        <rdfs:label>three_ten_helix</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>The 3-10 helix has 3 residues per turn with a translation of 2.0 angstroms (=0.2 nm) along the helical axis. The N-H group of an amino acid forms a hydrogen bond with the C=O group of the amino acid three residues earlier.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>EBIBS:GAR</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/SO_0001119"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>http://en.wikipedia.org/wiki/310_helix</owl:annotatedTarget>
+        <rdfs:label>wiki</rdfs:label>
     </owl:Axiom>
     
 
@@ -39787,8 +40124,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_001532">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_001522"/>
-        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
-        <rdfs:comment xml:lang="en">The Cambridge Structural Database (CSD) is the world&apos;s primary repository for the three-dimensional crystal structures of small organic and metal-organic molecules. It contains hundreds of thousands of experimentally determined structures, providing a vast resource for chemical and biological research. This database is essential for validating force field parameters and for obtaining high-quality starting geometries for computational studies. (UNVERIFIED)</rdfs:comment>
+        <obo:IAO_0000115 xml:lang="en">The small molecule structural database that serves as the primary repository for experimentally determined three-dimensional crystal structures of small organic and metal-organic molecules. It provides high-quality reference geometries used for validating force fields and for obtaining starting structures in computational studies. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Cambridge Structural Database</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39810,7 +40146,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002174">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBERRESTART in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER restart or state file. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBERRESTART NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39820,7 +40156,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002175">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002161"/>
-        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The file format convention denoted by the string AMBER in a NetCDF file&apos;s global Conventions attribute, designating the file as an AMBER coordinate trajectory. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">AMBER trajectory NetCDF convention</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39830,7 +40166,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002176">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002162"/>
-        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The system classification label assigned to a molecular system composed of a protein receptor, a small-molecule ligand, and explicit water molecules. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Protein / Ligand in Explicit Water</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39840,7 +40176,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002177">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s atomic number is exactly one, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atomic number HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     
@@ -39850,7 +40186,7 @@ Within the Bayesian framework, use the posterior predictive p-value.</obo:IAO_00
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/MOLSIM_002178">
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/MOLSIM_002166"/>
-        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (NEWLY_ADDED) (UNVERIFIED)</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">The hydrogen detection strategy that identifies hydrogen atoms by testing whether an atom&apos;s name begins with the letter H, used when applying or detecting hydrogen mass repartitioning. (UNVERIFIED)</obo:IAO_0000115>
         <rdfs:label xml:lang="en">atom name HMR detection strategy</rdfs:label>
     </owl:NamedIndividual>
     


### PR DESCRIPTION
Regenerate all nine release artefacts from molsim-edit.owl at 2b9efe1. Version stamp moves from 2026-07-29 to 2026-08-07, covering 37 commits on main since the last build.

Update the README size row to 2,046 live classes, 113 data properties, 17 object properties, 70 live named individuals, 2,269 declared and 23 retired.
